### PR TITLE
add wei package

### DIFF
--- a/packages/wei/__tests__/wei.ts
+++ b/packages/wei/__tests__/wei.ts
@@ -1,0 +1,221 @@
+import Wei, { wei } from '../src/wei';
+import { BigNumber } from 'ethers';
+import Big from 'big.js';
+
+describe('Wei numeric type', () => {
+	describe('Constructor', () => {
+		it('denies null construction', () => {
+			expect(Wei).toThrow();
+		});
+
+		it('constructs from a number', () => {
+			const a = new Wei(14.3);
+			expect(a.toBN()).toEqual(BigNumber.from('14300000000000000000'));
+			const b = new Wei(14, 18, true);
+			expect(b.toBN()).toEqual(BigNumber.from('14'));
+		});
+
+		it('constructs from a number', () => {
+			const a = new Wei('14.3');
+			expect(a.toBN()).toEqual(BigNumber.from('14300000000000000000'));
+			const b = new Wei('14', 18, true);
+			expect(b.toBN()).toEqual(BigNumber.from('14'));
+		});
+
+		it('constructs from a Big', () => {
+			const a = new Wei(new Big('14.3'));
+			expect(a.toBN()).toEqual(BigNumber.from('14300000000000000000'));
+			const b = new Wei(new Big('14'), 18, true);
+			expect(b.toBN()).toEqual(BigNumber.from('14'));
+		});
+
+		it('constructs from a BN', () => {
+			const a = new Wei(BigNumber.from('14'));
+			expect(a.toBN()).toEqual(BigNumber.from('14'));
+		});
+
+		it('copy constructs', () => {
+			const a = new Wei('1', 18, true);
+			const b = new Wei(a);
+			expect(a != b);
+			expect(a.eq(b));
+		});
+	});
+
+	describe('Conversion operators', () => {
+		let v: Wei;
+
+		beforeEach(() => {
+			v = new Wei('923.46');
+		});
+
+		it('converts to a string', () => {
+			expect(v.toString()).toEqual('923.460000000000000000');
+			expect(v.str).toEqual('923.460000000000000000');
+			expect(v.toString(2)).toEqual('923.46');
+			expect(v.toString(0, true)).toEqual('923460000000000000000');
+		});
+
+		it('converts to a BN', () => {
+			expect(v.toBN()).toEqual(BigNumber.from('923460000000000000000'));
+			expect(v.bn).toEqual(BigNumber.from('923460000000000000000'));
+		});
+
+		it('converts to a Big', () => {
+			expect(v.toBig()).toEqual(new Big('923.46'));
+			expect(v.toBig(true)).toEqual(new Big('923460000000000000000'));
+		});
+
+		it('converts to a number', () => {
+			let t = v.toNumber();
+			expect(Math.abs(t - 923.46) < 1e-12); // toNumber as a non-wei value; ${t}
+			t = v.num;
+			expect(Math.abs(t - 923.46) < 1e-12); // num as a non-wei value; ${t}
+			t = v.toNumber(true);
+			expect(Math.abs(t - 923.46 * 1e18) < 1e-12); // toNumber as a wei value; ${t}
+		});
+
+		it('converts sortable', () => {
+			expect(v.toSortable()).toEqual(
+				'0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003078333230663934663934633961336130303030'
+			);
+		});
+	});
+
+	describe('math operators', () => {
+		let a: Wei, b: Wei, c: Wei;
+
+		beforeEach(() => {
+			a = new Wei('932.46', 15);
+			b = new Wei('23.29467', 16);
+			c = new Wei('-123.325');
+		});
+
+		it('scales', () => {
+			expect(a.scale(15)).toEqual(a);
+			expect(a.scale(18).toBN()).toEqual(BigNumber.from('932460000000000000000'));
+		});
+
+		it('abs', () => {
+			expect(a.abs().eq(a)); // abs(a)
+			expect(b.abs().eq(b)); // abs(b)
+			expect(c.abs().eq(c.toBig().abs())); // abs(c)
+		});
+
+		it('neg', () => {
+			expect(a.neg().eq('-932.46')); // neg(a)
+			expect(b.neg().eq('-23.29467')); // neg(b)
+			expect(c.neg().eq('123.325')); // neg(c)
+		});
+
+		it('div', () => {
+			expect(a.div(a).feq(1, 1e-12)); // a / a
+			expect(a.div(b).feq(a.toBig().div(b.toBig()), 1e-12)); // a / b
+			expect(b.div(a).feq(b.toBig().div(a.toBig()), 1e-12)); // b / a
+			expect(a.div(c).feq(a.toBig().div(c.toBig()), 1e-12)); // a / c
+		});
+
+		it('sub', () => {
+			expect(a.sub(a).feq(0, 1e-12)); // a - a
+			expect(a.sub(b).feq(a.toBig().sub(b.toBig()), 1e-12)); // a - b
+			expect(b.sub(a).feq(b.toBig().sub(a.toBig()), 1e-12)); // b - a
+			expect(a.sub(c).feq(a.toBig().sub(c.toBig()), 1e-12)); // a - c
+		});
+
+		it('add', () => {
+			expect(a.add(b).feq(a.toBig().add(b.toBig()), 1e-12)); // a + b
+			expect(b.add(a).feq(b.toBig().add(a.toBig()), 1e-12)); // b + a
+			expect(a.add(c).feq(a.toBig().add(c.toBig()), 1e-12)); // a + c
+		});
+
+		it('mul', () => {
+			expect(a.mul(b).feq(a.toBig().mul(b.toBig()), 1e-12)); // a * b
+			expect(b.mul(a).feq(b.toBig().mul(a.toBig()), 1e-12)); // b * a
+			expect(a.mul(c).feq(a.toBig().mul(c.toBig()), 1e-12)); // a * c
+		});
+
+		it('pow', () => {
+			for (let i = 1; i < 6; ++i) {
+				expect(a.pow(i).feq(a.toBig().pow(i), 1e-12)); // a^${i}
+				expect(b.pow(i).feq(b.toBig().pow(i), 1e-12)); // b^${i}
+				expect(c.pow(i).feq(c.toBig().pow(i), 1e-12)); // c^${i}
+			}
+		});
+
+		it('inv', () => {
+			expect(a.inv().feq(a.toBig().pow(-1), 1e-12)); // 1 / a
+			expect(b.inv().feq(b.toBig().pow(-1), 1e-12)); // 1 / b
+			expect(c.inv().feq(c.toBig().pow(-1), 1e-12)); // 1 / c
+		});
+	});
+
+	describe('comparison operators', () => {
+		const v = new Wei('3.14159');
+
+		it('cmp', () => {
+			expect(v.cmp(3) == 1);
+			expect(v.cmp(4) == -1);
+			expect(v.cmp(3.14159) == 0);
+			expect(v.cmp(v.scale(15)) == 0);
+		});
+
+		it('eq', () => {
+			expect(!v.eq(3.1));
+			expect(v.eq(3.14159));
+			expect(v.eq(v.scale(15)));
+		});
+
+		it('feq', () => {
+			expect(!v.feq(4, 1e-2));
+			expect(v.feq(4, 1));
+			expect(v.feq(3.14159, 1e-10));
+			expect(v.feq(v.scale(15), 1e-10));
+		});
+
+		it('gt', () => {
+			expect(v.gt(2));
+			expect(!v.gt(4));
+			expect(!v.gt(3.14159));
+		});
+
+		it('gte', () => {
+			expect(v.gte(2));
+			expect(!v.gte(4));
+			expect(v.gte(3.14159));
+		});
+
+		it('lt', () => {
+			expect(v.lt(5));
+			expect(!v.lt(2));
+			expect(!v.lt(3.14159));
+		});
+
+		it('lte', () => {
+			expect(v.lte(5));
+			expect(!v.lte(2));
+			expect(v.lte(3.14159));
+		});
+	});
+
+	describe('static operators', () => {
+		it('min', () => {
+			expect(Wei.min(wei(1), wei(2), wei(3)).eq(1));
+			expect(Wei.min(wei(2), wei(3), wei(1)).eq(1));
+			expect(Wei.min(wei(2), wei(-3)).eq(-3));
+			expect(Wei.min(wei(1)).eq(1));
+		});
+
+		it('max', () => {
+			expect(Wei.max(wei(1), wei(2), wei(3)).eq(3));
+			expect(Wei.max(wei(3), wei(2), wei(1)).eq(3));
+			expect(Wei.max(wei(2), wei(-3)).eq(2));
+			expect(Wei.max(wei(1)).eq(1));
+		});
+
+		it('avg', () => {
+			expect(Wei.avg(wei(1)).eq(1));
+			expect(Wei.avg(wei(2), wei(2)).eq(2));
+			expect(Wei.avg(wei(5), wei(2), wei(8)).eq(5));
+		});
+	});
+});

--- a/packages/wei/babel.config.json
+++ b/packages/wei/babel.config.json
@@ -1,0 +1,4 @@
+{
+	"presets": ["@babel/preset-env", "@babel/preset-typescript"],
+	"plugins": ["@babel/transform-runtime"]
+}

--- a/packages/wei/package-lock.json
+++ b/packages/wei/package-lock.json
@@ -1,0 +1,1343 @@
+{
+	"name": "@synthetixio/wei",
+	"version": "1.0.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@synthetixio/wei",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"big.js": "6.1.1",
+				"ethers": "5.0.32"
+			},
+			"devDependencies": {
+				"@types/big.js": "6.0.2"
+			}
+		},
+		"node_modules/@ethersproject/abi": {
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.13.tgz",
+			"integrity": "sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/abstract-provider": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz",
+			"integrity": "sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/networks": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/web": "^5.0.12"
+			}
+		},
+		"node_modules/@ethersproject/abstract-signer": {
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz",
+			"integrity": "sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"node_modules/@ethersproject/address": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+			"integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/rlp": "^5.0.7"
+			}
+		},
+		"node_modules/@ethersproject/base64": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.9.tgz",
+			"integrity": "sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9"
+			}
+		},
+		"node_modules/@ethersproject/basex": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.9.tgz",
+			"integrity": "sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"node_modules/@ethersproject/bignumber": {
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+			"integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"bn.js": "^4.4.0"
+			}
+		},
+		"node_modules/@ethersproject/bytes": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+			"integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/constants": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+			"integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13"
+			}
+		},
+		"node_modules/@ethersproject/contracts": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.12.tgz",
+			"integrity": "sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abi": "^5.0.10",
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"node_modules/@ethersproject/hash": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.12.tgz",
+			"integrity": "sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/hdnode": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.10.tgz",
+			"integrity": "sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/basex": "^5.0.7",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/pbkdf2": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/wordlists": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/json-wallets": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz",
+			"integrity": "sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hdnode": "^5.0.8",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/pbkdf2": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"aes-js": "3.0.0",
+				"scrypt-js": "3.0.1"
+			}
+		},
+		"node_modules/@ethersproject/keccak256": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+			"integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"js-sha3": "0.5.7"
+			}
+		},
+		"node_modules/@ethersproject/logger": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+			"integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			]
+		},
+		"node_modules/@ethersproject/networks": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.9.tgz",
+			"integrity": "sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/pbkdf2": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz",
+			"integrity": "sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/sha2": "^5.0.7"
+			}
+		},
+		"node_modules/@ethersproject/properties": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+			"integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/providers": {
+			"version": "5.0.24",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.24.tgz",
+			"integrity": "sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/basex": "^5.0.7",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/networks": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/rlp": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/web": "^5.0.12",
+				"bech32": "1.1.4",
+				"ws": "7.2.3"
+			}
+		},
+		"node_modules/@ethersproject/random": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.9.tgz",
+			"integrity": "sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/rlp": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+			"integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/sha2": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.9.tgz",
+			"integrity": "sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"hash.js": "1.1.3"
+			}
+		},
+		"node_modules/@ethersproject/signing-key": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.11.tgz",
+			"integrity": "sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"elliptic": "6.5.4"
+			}
+		},
+		"node_modules/@ethersproject/solidity": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.10.tgz",
+			"integrity": "sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/strings": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
+			"integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/transactions": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.11.tgz",
+			"integrity": "sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/rlp": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/units": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.11.tgz",
+			"integrity": "sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/wallet": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.12.tgz",
+			"integrity": "sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/hdnode": "^5.0.8",
+				"@ethersproject/json-wallets": "^5.0.10",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/wordlists": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/web": {
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.14.tgz",
+			"integrity": "sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/base64": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@ethersproject/wordlists": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.10.tgz",
+			"integrity": "sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@types/big.js": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-6.0.2.tgz",
+			"integrity": "sha512-7NdmOT3zjtghMofDwP1nAJCJWVjc/96V5msXRAZ4lPrvpGlajA95VQec7OXwA2wQaVmhjt+F5ko8pjvQU1tTFA==",
+			"dev": true
+		},
+		"node_modules/aes-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+		},
+		"node_modules/bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+		},
+		"node_modules/big.js": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
+			"integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+		},
+		"node_modules/brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"node_modules/elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"dependencies": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/ethers": {
+			"version": "5.0.32",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.32.tgz",
+			"integrity": "sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abi": "5.0.13",
+				"@ethersproject/abstract-provider": "5.0.10",
+				"@ethersproject/abstract-signer": "5.0.14",
+				"@ethersproject/address": "5.0.11",
+				"@ethersproject/base64": "5.0.9",
+				"@ethersproject/basex": "5.0.9",
+				"@ethersproject/bignumber": "5.0.15",
+				"@ethersproject/bytes": "5.0.11",
+				"@ethersproject/constants": "5.0.10",
+				"@ethersproject/contracts": "5.0.12",
+				"@ethersproject/hash": "5.0.12",
+				"@ethersproject/hdnode": "5.0.10",
+				"@ethersproject/json-wallets": "5.0.12",
+				"@ethersproject/keccak256": "5.0.9",
+				"@ethersproject/logger": "5.0.10",
+				"@ethersproject/networks": "5.0.9",
+				"@ethersproject/pbkdf2": "5.0.9",
+				"@ethersproject/properties": "5.0.9",
+				"@ethersproject/providers": "5.0.24",
+				"@ethersproject/random": "5.0.9",
+				"@ethersproject/rlp": "5.0.9",
+				"@ethersproject/sha2": "5.0.9",
+				"@ethersproject/signing-key": "5.0.11",
+				"@ethersproject/solidity": "5.0.10",
+				"@ethersproject/strings": "5.0.10",
+				"@ethersproject/transactions": "5.0.11",
+				"@ethersproject/units": "5.0.11",
+				"@ethersproject/wallet": "5.0.12",
+				"@ethersproject/web": "5.0.14",
+				"@ethersproject/wordlists": "5.0.10"
+			}
+		},
+		"node_modules/hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"node_modules/hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dependencies": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/js-sha3": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+		},
+		"node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"node_modules/minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
+		"node_modules/scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+		},
+		"node_modules/ws": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		}
+	},
+	"dependencies": {
+		"@ethersproject/abi": {
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.13.tgz",
+			"integrity": "sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==",
+			"requires": {
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"@ethersproject/abstract-provider": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz",
+			"integrity": "sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/networks": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/web": "^5.0.12"
+			}
+		},
+		"@ethersproject/abstract-signer": {
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz",
+			"integrity": "sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==",
+			"requires": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"@ethersproject/address": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+			"integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/rlp": "^5.0.7"
+			}
+		},
+		"@ethersproject/base64": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.9.tgz",
+			"integrity": "sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9"
+			}
+		},
+		"@ethersproject/basex": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.9.tgz",
+			"integrity": "sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"@ethersproject/bignumber": {
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+			"integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"bn.js": "^4.4.0"
+			}
+		},
+		"@ethersproject/bytes": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+			"integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+			"requires": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/constants": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+			"integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.0.13"
+			}
+		},
+		"@ethersproject/contracts": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.12.tgz",
+			"integrity": "sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==",
+			"requires": {
+				"@ethersproject/abi": "^5.0.10",
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"@ethersproject/hash": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.12.tgz",
+			"integrity": "sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==",
+			"requires": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"@ethersproject/hdnode": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.10.tgz",
+			"integrity": "sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==",
+			"requires": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/basex": "^5.0.7",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/pbkdf2": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/wordlists": "^5.0.8"
+			}
+		},
+		"@ethersproject/json-wallets": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz",
+			"integrity": "sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==",
+			"requires": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hdnode": "^5.0.8",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/pbkdf2": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"aes-js": "3.0.0",
+				"scrypt-js": "3.0.1"
+			}
+		},
+		"@ethersproject/keccak256": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+			"integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"js-sha3": "0.5.7"
+			}
+		},
+		"@ethersproject/logger": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+			"integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+		},
+		"@ethersproject/networks": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.9.tgz",
+			"integrity": "sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==",
+			"requires": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/pbkdf2": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz",
+			"integrity": "sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/sha2": "^5.0.7"
+			}
+		},
+		"@ethersproject/properties": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+			"integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+			"requires": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/providers": {
+			"version": "5.0.24",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.24.tgz",
+			"integrity": "sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==",
+			"requires": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/basex": "^5.0.7",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/networks": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/rlp": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/web": "^5.0.12",
+				"bech32": "1.1.4",
+				"ws": "7.2.3"
+			}
+		},
+		"@ethersproject/random": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.9.tgz",
+			"integrity": "sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/rlp": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+			"integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/sha2": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.9.tgz",
+			"integrity": "sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"hash.js": "1.1.3"
+			}
+		},
+		"@ethersproject/signing-key": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.11.tgz",
+			"integrity": "sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"elliptic": "6.5.4"
+			}
+		},
+		"@ethersproject/solidity": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.10.tgz",
+			"integrity": "sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"@ethersproject/strings": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
+			"integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/transactions": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.11.tgz",
+			"integrity": "sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==",
+			"requires": {
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/rlp": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8"
+			}
+		},
+		"@ethersproject/units": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.11.tgz",
+			"integrity": "sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"@ethersproject/wallet": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.12.tgz",
+			"integrity": "sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==",
+			"requires": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/hdnode": "^5.0.8",
+				"@ethersproject/json-wallets": "^5.0.10",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/wordlists": "^5.0.8"
+			}
+		},
+		"@ethersproject/web": {
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.14.tgz",
+			"integrity": "sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==",
+			"requires": {
+				"@ethersproject/base64": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"@ethersproject/wordlists": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.10.tgz",
+			"integrity": "sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==",
+			"requires": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"@types/big.js": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-6.0.2.tgz",
+			"integrity": "sha512-7NdmOT3zjtghMofDwP1nAJCJWVjc/96V5msXRAZ4lPrvpGlajA95VQec7OXwA2wQaVmhjt+F5ko8pjvQU1tTFA==",
+			"dev": true
+		},
+		"aes-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+		},
+		"bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+		},
+		"big.js": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
+			"integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg=="
+		},
+		"bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"ethers": {
+			"version": "5.0.32",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.32.tgz",
+			"integrity": "sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==",
+			"requires": {
+				"@ethersproject/abi": "5.0.13",
+				"@ethersproject/abstract-provider": "5.0.10",
+				"@ethersproject/abstract-signer": "5.0.14",
+				"@ethersproject/address": "5.0.11",
+				"@ethersproject/base64": "5.0.9",
+				"@ethersproject/basex": "5.0.9",
+				"@ethersproject/bignumber": "5.0.15",
+				"@ethersproject/bytes": "5.0.11",
+				"@ethersproject/constants": "5.0.10",
+				"@ethersproject/contracts": "5.0.12",
+				"@ethersproject/hash": "5.0.12",
+				"@ethersproject/hdnode": "5.0.10",
+				"@ethersproject/json-wallets": "5.0.12",
+				"@ethersproject/keccak256": "5.0.9",
+				"@ethersproject/logger": "5.0.10",
+				"@ethersproject/networks": "5.0.9",
+				"@ethersproject/pbkdf2": "5.0.9",
+				"@ethersproject/properties": "5.0.9",
+				"@ethersproject/providers": "5.0.24",
+				"@ethersproject/random": "5.0.9",
+				"@ethersproject/rlp": "5.0.9",
+				"@ethersproject/sha2": "5.0.9",
+				"@ethersproject/signing-key": "5.0.11",
+				"@ethersproject/solidity": "5.0.10",
+				"@ethersproject/strings": "5.0.10",
+				"@ethersproject/transactions": "5.0.11",
+				"@ethersproject/units": "5.0.11",
+				"@ethersproject/wallet": "5.0.12",
+				"@ethersproject/web": "5.0.14",
+				"@ethersproject/wordlists": "5.0.10"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"js-sha3": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+		},
+		"ws": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"requires": {}
+		}
+	}
+}

--- a/packages/wei/package.json
+++ b/packages/wei/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@synthetixio/wei",
+	"version": "1.0.0",
+	"description": "Convenient BigNumber library for web3",
+	"main": "build/node/wei.js",
+	"browser": "./build/index.js",
+	"source": "./src/index.ts",
+	"types": "./build/node/wei.d.ts",
+	"scripts": {
+		"build": "npm run build-browser && npm run build-node",
+		"build-node": "tsc -p tsconfig.node.json",
+		"build-browser": "webpack --mode=production",
+		"examples:node": "ts-node --project tsconfig.node.json ./examples/node-example.js",
+		"examples:browser": "npm run build-browser && http-server -o ./examples/browser-example.html -c-1",
+		"lint": "eslint './src/**/*.{js,ts,tsx}' && tsc",
+		"lint:fix": "eslint --fix './src/**/*.{js,ts,tsx}'",
+		"test": "node --experimental-vm-modules ../../node_modules/.bin/jest --coverage --no-cache",
+		"tsc": "tsc --noemit",
+		"codegen": "graphql-codegen --config codegen.yml"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Synthetixio/js-monorepo.git"
+	},
+	"author": "Matthew Conover <git@mconover.dev>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/Synthetixio/js-monorepo/issues"
+	},
+	"homepage": "https://github.com/Synthetixio/js-monorepo#readme",
+	"dependencies": {
+		"big.js": "6.1.1",
+		"ethers": "5.0.32"
+	},
+	"devDependencies": {
+		"@types/big.js": "6.0.2"
+	}
+}

--- a/packages/wei/src/index.ts
+++ b/packages/wei/src/index.ts
@@ -1,0 +1,3 @@
+import Wei from './wei';
+
+export default Wei;

--- a/packages/wei/src/wei.ts
+++ b/packages/wei/src/wei.ts
@@ -1,0 +1,286 @@
+// https://en.wikipedia.org/wiki/Scale_factor_(computer_science)
+
+// TODO: create a BN extension which works as a replacement for big using scaled integers
+import { BigNumber, ethers } from 'ethers';
+import Big from 'big.js';
+
+export const WEI_PRECISION = 18;
+Big.DP = WEI_PRECISION;
+
+export type WeiSource = Wei | number | string | BigNumber | Big;
+
+/**
+ * A numeric value in Wei. This enables arithmetic to be performed on Wei types without needing
+ * to convert them to a decimal value in-between.
+ *
+ * @warning ALL Arithmetic and Comparison operations assume non-Wei values if they are passed any
+ * source material which is not an instance of `Wei`. If you have a Number/string/BN/Big which is
+ * already in Wei and you would like to operate with it correctly, you must first construct a new
+ * Wei value from it using `new Wei(numberinwei, true)` which is NOT the default behavior,
+ * even for BN types.
+ */
+export default class Wei {
+	static is(w: unknown): w is Wei {
+		return w instanceof Wei;
+	}
+
+	static min(a: Wei, ...args: Wei[]): Wei {
+		let best = a;
+		for (const i of args) {
+			best = best.lt(i) ? best : i;
+		}
+		return new Wei(best);
+	}
+
+	static max(a: Wei, ...args: Wei[]): Wei {
+		let best = a;
+		for (const i of args) {
+			best = best.gt(i) ? best : i;
+		}
+		return new Wei(best);
+	}
+
+	static avg(a: Wei, ...args: Wei[]): Wei {
+		let sum = new Wei(a);
+		args.forEach((i) => (sum = sum.add(i)));
+		return sum.div(1 + args.length);
+	}
+
+	/** Value */
+	private readonly v: BigNumber;
+
+	/** Decimals (usually WEI_PRECISION) */
+	private readonly p: number;
+
+	get z() {
+		return BigNumber.from(10).pow(BigNumber.from(this.p));
+	}
+
+	/**
+	 * Create a (lazy as possible) clone of the source. For some types this means no memory copy will
+	 * need to happen while for others it will. This should only be used for converting RHS parameters
+	 * which are needed in a known form. Should probably only be used by the `Wei.from` function.
+	 *
+	 * @param n Source material
+	 * @param p The number of decimal places to scale by. If you are working with Ether or Synth, leave this as default
+	 * @param isWei if false or unspecfiied, automatically scale any value to `p` places. If n is a BigNumber, this is ignored.
+	 */
+	constructor(n: WeiSource, p?: number, isWei?: boolean);
+
+	constructor(n: WeiSource, p = 18, isWei = false) {
+		this.p = p;
+
+		if (n === undefined || n === null) throw new Error('Cannot parse undefined/null as a number.');
+		if (Wei.is(n)) {
+			this.v = n.scale(p).v;
+		} else if ((n as BigNumber)._isBigNumber) {
+			this.v = n as BigNumber;
+		} else if (isWei) {
+			// already wei, don't scale again
+			if (n instanceof Big) {
+				this.v = BigNumber.from(n.abs().toFixed(0));
+			} else {
+				this.v = BigNumber.from(n);
+			}
+		} else {
+			// not wei, scale it
+			// TODO: avoid use of Big.js, but this is a really easy way to do the conversion for now
+			this.v = BigNumber.from(new Big(n as any).mul(new Big(10).pow(this.p)).toFixed(0));
+		}
+	}
+
+	///////////////////////////
+	// Conversion functions //
+	/////////////////////////
+
+	/**
+	 * Creates a new version of the Wei object with a new precision
+	 * Note: if p is less than the current p, precision may be lost.
+	 * @param p new decimal places precision
+	 * @returns new Wei value with specified decimal places
+	 */
+	scale(p: number): Wei {
+		if (p == this.p) {
+			return this;
+		}
+
+		return wei(wei(1, p).v.mul(this.v).div(this.z));
+	}
+
+	/**
+	 * Write the value as a string.
+	 *
+	 * @param asWei If true, then returns the scaled integer value, otherwise converts to a floating point value
+	 * @param dp Decimal places to use when not printing as Wei
+	 * @returns The value as a string
+	 * @memberof Wei
+	 */
+	toString(dp = this.p, asWei = false): string {
+		if (asWei) dp = 0;
+		return this.toBig(asWei).toFixed(dp);
+	}
+
+	/** The unscaled value as a string. */
+	get str(): string {
+		return this.toString();
+	}
+
+	/**
+	 * Write the value in Wei as a padded string which can be used for sorting.
+	 * Will convert it to base64 to reduce the string length and make comparisons less costly.
+	 *
+	 * @returns Resulting string which can be used to sort multiple wei numbers.
+	 * @memberof Wei
+	 */
+	toSortable(): string {
+		// TODO: handle sign?
+		return ethers.utils.hexZeroPad(Buffer.from(this.v.toHexString()), 64);
+	}
+
+	/**
+	 * Convert the value of this to a BN type. This will always return the value as a scaled Wei
+	 * integer. If you wish to convert it, simply take the result and divide by `Z`
+	 *
+	 * @returns The value (in Wei) as a BigNumber
+	 * @memberof Wei
+	 */
+	toBN(): BigNumber {
+		return BigNumber.from(this.v);
+	}
+
+	/** The scaled value as a BN */
+	get bn(): BigNumber {
+		return this.toBN();
+	}
+
+	/**
+	 * Convert the value of this to a Big type.
+	 *
+	 * @param asWei If true, then returns the scaled integer value, otherwise converts to a floating point value.
+	 * @returns The value as a Big type (either in Wei or not)
+	 * @memberof Wei
+	 */
+	toBig(asWei = false): Big {
+		const big = new Big(this.v.toString());
+		return asWei ? big : big.div(new Big(10).pow(this.p));
+	}
+
+	/** The unscaled value as a Big */
+	get big(): Big {
+		return this.toBig();
+	}
+
+	/**
+	 * Convert the value to a JS number type.
+	 *
+	 * @param {boolean} [asWei=false] By default will convert to a floating point which should preserve accuracy of the most significant digits. Otherwise try to represent as an integer Wei value.
+	 * @returns {number} The value as a number type (or as close as it can represent).
+	 * @memberof Wei
+	 */
+	toNumber(asWei = false): number {
+		// JS number has 52 bit mantissa, `ceil(log10(2^52)) = 16`
+		const str = this.toBig(asWei).toPrecision(16);
+		return Number.parseFloat(str);
+	}
+
+	/** The unscaled value as a number */
+	get num(): number {
+		return this.toNumber();
+	}
+
+	////////////////////
+	// Math operators //
+	////////////////////
+
+	neg(): Wei {
+		return new Wei(this.v.mul(-1), this.p, true);
+	}
+
+	abs(): Wei {
+		return new Wei(this.v.abs(), this.p, true);
+	}
+
+	div(other: WeiSource): Wei {
+		other = parseNum(other, this.p);
+		return new Wei(this.v.mul(this.z).div(other.v), this.p, true);
+	}
+
+	sub(other: WeiSource): Wei {
+		other = parseNum(other, this.p);
+		return new Wei(this.v.sub(other.v), this.p, true);
+	}
+
+	add(other: WeiSource): Wei {
+		other = parseNum(other, this.p);
+		return new Wei(this.v.add(other.v), this.p, true);
+	}
+
+	mul(other: WeiSource): Wei {
+		other = parseNum(other, this.p);
+		return new Wei(this.v.mul(other.v).div(this.z), this.p, true);
+	}
+
+	pow(p: number): Wei {
+		return new Wei(this.big.pow(p), this.p);
+	}
+
+	inv(): Wei {
+		return new Wei(this.z.pow(2).div(this.v), this.p, true);
+	}
+
+	///////////////////////////
+	// Comparison operators //
+	/////////////////////////
+
+	cmp(other: WeiSource): number {
+		other = parseNum(other, this.p);
+		if (this.v.gt(other.v)) return 1;
+		else if (this.v.lt(other.v)) return -1;
+		else return 0;
+	}
+
+	eq(other: WeiSource): boolean {
+		other = parseNum(other, this.p);
+		return this.v.eq(other.v);
+	}
+
+	/**
+	 * Fuzzy equality comparison. If passing a number, assumes it is not in Wei, so 1e-18 == 1 wei.
+	 *
+	 * @param other Value to compare against
+	 * @param fuzz Tolerance for equality
+	 * @returns True if other is within `fuzz` tolerance of this value.
+	 * @memberof Wei
+	 */
+	feq(other: WeiSource, fuzz: WeiSource): boolean {
+		const o = parseNum(other, this.p);
+		const f = parseNum(fuzz, this.p);
+		return this.v.sub(o.v).abs().lt(f.v);
+	}
+
+	gt(other: WeiSource): boolean {
+		return this.cmp(other) > 0;
+	}
+
+	gte(other: WeiSource): boolean {
+		return this.cmp(other) >= 0;
+	}
+
+	lt(other: WeiSource): boolean {
+		return this.cmp(other) < 0;
+	}
+
+	lte(other: WeiSource): boolean {
+		return this.cmp(other) <= 0;
+	}
+}
+
+/** convenience function for not writing `new Wei(s)` every time. */
+export function wei(s: WeiSource, p = WEI_PRECISION, isWei = false): Wei {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return new Wei(s as any, p, isWei);
+}
+
+function parseNum(v: WeiSource | Wei, p: number): Wei {
+	return Wei.is(v) ? v.scale(p) : new Wei(v, p);
+}

--- a/packages/wei/tsconfig.json
+++ b/packages/wei/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"module": "commonjs",
+		"declarationDir": "./build"
+	}
+}

--- a/packages/wei/tsconfig.node.json
+++ b/packages/wei/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"module": "commonjs",
+		"outDir": "./build/node"
+	},
+	"include": ["src"]
+}


### PR DESCRIPTION
`Wei` is a simple wrapper around the ethers `BigNumber` which provides features for conversion,
decimal scaling, and math, normally expected in a regular BigNumber library. The math is
intended to mimic as closely as possible the same operations which actually occur within
the EVM, and to be lightweight as well.

For more advanced math operations, Wei uses `Big.js` under the hood. This can be changed.

Quick samples:

Making a new `Wei` instance:

```
import { wei } from '@synthetixio/wei';

// constructing "42100000000000000000"
const numba = wei(42.1);
const strig = wei('42.1');
const plainbn = wei(new ethers.BigNumber('42100000000000000000'));

// numba == strig == plainbn

// using other than default `Wei` units
const satoshis = wei(1, 8);

```

Math:

```
const a = wei(1.2);
const b = wei(3.4);
const c = a.add(b); // = wei(4.6)
const d = a.mul(b); // = wei(4.08)
```

Simple formatting:
```
a.toString(2) // = '1.20'
```

Notice how `mul` is scaled correctly despite internal representation being higher.

All tests have been implemented for 100% coverage. This lib should be easy to maintain, and it
works best if integrated everywhere.