### PR TITLE
fixes for wei not exporting the `wei` function

### DIFF
--- a/packages/contracts-interface/package-lock.json
+++ b/packages/contracts-interface/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/contracts-interface",
-			"version": "2.47.0-ovm.0",
+			"version": "2.47.2-ovm.0",
 			"license": "MIT",
 			"dependencies": {
 				"ethers": "5.4.1",

--- a/packages/data/package-lock.json
+++ b/packages/data/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/data",
-			"version": "2.46.1-ovm.0",
+			"version": "2.46.3-ovm.0",
 			"license": "MIT",
 			"dependencies": {
 				"bignumber.js": "9.0.1",

--- a/packages/optimism-networks/package-lock.json
+++ b/packages/optimism-networks/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/optimism-networks",
-			"version": "2.46.1-0",
+			"version": "2.46.2",
 			"license": "MIT",
 			"dependencies": {
 				"@eth-optimism/watcher": "^0.0.1-alpha.9"

--- a/packages/providers/package-lock.json
+++ b/packages/providers/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/providers",
-			"version": "2.46.1-0",
+			"version": "2.46.3-alpha.0",
 			"license": "MIT",
 			"dependencies": {
 				"@eth-optimism/provider": "0.0.1-alpha.14",

--- a/packages/queries/package-lock.json
+++ b/packages/queries/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/queries",
-			"version": "2.47.0-ovm.0",
+			"version": "2.47.2-ovm.0",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "0.21.1",

--- a/packages/transaction-notifier/package-lock.json
+++ b/packages/transaction-notifier/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/transaction-notifier",
-			"version": "2.46.1",
+			"version": "2.46.2",
 			"license": "MIT",
 			"dependencies": {
 				"ethers": "5.4.1",

--- a/packages/wei/package-lock.json
+++ b/packages/wei/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/wei",
-			"version": "2.46.1",
+			"version": "2.46.2",
 			"license": "MIT",
 			"dependencies": {
 				"big.js": "6.1.1",

--- a/packages/wei/package.json
+++ b/packages/wei/package.json
@@ -2,10 +2,10 @@
 	"name": "@synthetixio/wei",
 	"version": "2.46.2",
 	"description": "Convenient BigNumber library for web3",
-	"main": "build/node/wei.js",
+	"main": "build/node/index.js",
 	"browser": "./build/index.js",
 	"source": "./src/index.ts",
-	"types": "./build/node/wei.d.ts",
+	"types": "./build/node/index.d.ts",
 	"scripts": {
 		"build": "npm run build-browser && npm run build-node",
 		"build-node": "../../node_modules/.bin/tsc -p tsconfig.node.json",

--- a/packages/wei/src/index.ts
+++ b/packages/wei/src/index.ts
@@ -1,3 +1,4 @@
 import Wei from './wei';
 
 export default Wei;
+export { wei } from './wei';


### PR DESCRIPTION
this causes an error on recent releases because we are now building the `webpack` version of the module as well, which fails to export due to the `package.json` specification.