### PR TITLE
fix queries browser deps

### DIFF
--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -4,6 +4,7 @@
 	"description": "react-query for pulling synthetix data in react interfaces",
 	"source": "./src/index.ts",
 	"main": "./build/node/index.js",
+	"module": "./build/node/index.js",
 	"browser": "./build/index.js",
 	"types": "./build/node/index.d.ts",
 	"files": [

--- a/packages/queries/webpack.config.js
+++ b/packages/queries/webpack.config.js
@@ -30,4 +30,8 @@ module.exports = {
 		extensions: ['.ts', '.js'],
 	},
 	plugins: [],
+	externals: {
+		'react': 'React',
+		'react-dom': 'ReactDOM'
+	}
 };


### PR DESCRIPTION
webpack has an "externals" option to mark certain npm modules as resolved from browser

in addition, specify the "module" option for webpack projects which can import without
the need for the browser version