### PR TITLE
automatically push testing release to npm repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npx lerna bootstrap
       - run: npx lerna run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,21 @@
-# name: main
+name: Main Workflow
+on:
+  push: {}
 
-# on:
-#   push:
-#     branches:
-#     - '*'
-#   pull_request:
-#     branches:
-#     - master
-#     - dev
-
-# jobs:
-#   lints:
-#     name: Run Lints
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - uses: actions/checkout@v2
-#     - uses: actions/setup-node@v2
-#       with:
-#         node-version: '14'
-#     - run: npm ci
-#     - run: npm run bootstrap
-#     - run: npm run lint
-#     - run: npm run build
-#     - run: npm run test-all
-
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - run: npm ci
+      - run: npx lerna bootstrap
+      - run: npx lerna run build
+      - run: npx lerna run test
+      - run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --npm-tag dev --skip-git -y
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: echo "npm pushed to 0.0.0-$(git rev-parse --short HEAD)"

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent"
+  "version": "fixed"
 }

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -10,7 +10,7 @@
 		"build"
 	],
 	"scripts": {
-		"build": "npm run build-browser && npm run build-node",
+		"build": "npm run codegen && npm run build-browser && npm run build-node",
 		"build-node": "../../node_modules/.bin/tsc -p tsconfig.node.json",
 		"build-browser": "../../node_modules/.bin/webpack --mode=production --max-old-space-size=4096",
 		"examples:node": "ts-node --project tsconfig.node.json ./examples/node-example.js",


### PR DESCRIPTION
this will allow for easier testing of monorepo changes with existing repos.
It will be p ushed using a npm `tag` to prevent confusing of accidentally
using development releases