### PR TITLE
feat(data): Add L2 kovan rates to rateUpdates

### DIFF
--- a/packages/data/__tests__/queries.test.ts
+++ b/packages/data/__tests__/queries.test.ts
@@ -244,6 +244,16 @@ describe('@synthetixio/data tests', () => {
 			expect(l2RateUpdatesInfo![0].synth).toEqual('SNX');
 			expect(l2RateUpdatesInfo!.length).toBeGreaterThan(0);
 		});
+
+		test('should return rateUpdates data from l2 kovan', async () => {
+			const l2RateUpdatesInfo = await snxDataKovanOvm.rateUpdates({
+				max: 5,
+				synth: 'SNX',
+				minTimestamp: oneMonthTimestamp,
+			});
+			expect(l2RateUpdatesInfo![0].synth).toEqual('SNX');
+			expect(l2RateUpdatesInfo!.length).toBeGreaterThan(0);
+		});
 	});
 
 	describe('debtSnapshots query', () => {

--- a/packages/data/queries/rateUpdates/parse.ts
+++ b/packages/data/queries/rateUpdates/parse.ts
@@ -1,19 +1,21 @@
 import { ethers } from 'ethers';
 import { RateUpdate } from '../../generated/graphql';
 import { formatTimestamp } from '../../src/utils';
+import { NetworkId } from '@synthetixio/contracts-interface';
 
-export const parseRates = ({
-	block,
-	currencyKey,
-	id,
-	rate,
-	synth,
-	timestamp,
-}: RateUpdate): RateUpdate => ({
-	block: Number(block),
-	currencyKey,
-	id,
-	rate: ethers.utils.formatEther(rate),
-	synth,
-	timestamp: formatTimestamp(timestamp),
-});
+export const parseRates = (rate: RateUpdate, networkId?: number): RateUpdate => {
+	const { block, currencyKey, id, rate: rateValue, synth, timestamp } = rate;
+	const parsedRate =
+		networkId && networkId === NetworkId['Kovan-Ovm']
+			? rateValue
+			: ethers.utils.formatEther(rateValue);
+
+	return {
+		block: Number(block),
+		currencyKey,
+		id,
+		rate: parsedRate,
+		synth,
+		timestamp: formatTimestamp(timestamp),
+	};
+};

--- a/packages/data/src/constants.ts
+++ b/packages/data/src/constants.ts
@@ -17,6 +17,7 @@ export const l1Endpoints = {
 export const l2Endpoints = {
 	snx: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-ovm',
 	snxKovan: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-kovan-ovm',
+	snxKovanRates: 'https://api.thegraph.com/subgraphs/name/killerbyte/optimism-kovan-exchanges',
 };
 
 export const timeSeriesEntityMap = { '1d': 'dailySNXPrices', '15m': 'fifteenMinuteSNXPrices' };

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -192,9 +192,14 @@ const synthetixData = ({ networkId }: { networkId: NetworkId }): SynthetixData =
 			params,
 			queryMethod: createRateUpdatesQuery,
 			networkId,
-			endpoints: { [NetworkId.Mainnet]: l1Endpoints.rates },
+			endpoints: {
+				[NetworkId.Mainnet]: l1Endpoints.rates,
+				[NetworkId['Kovan-Ovm']]: l2Endpoints.snxKovanRates,
+			},
 		});
-		return response != null ? response.rateUpdates.map(parseRates) : null;
+		return response != null
+			? response.rateUpdates.map((rate: RateUpdate) => parseRates(rate, networkId))
+			: null;
 	},
 	debtSnapshots: async (params?: DebtSnapshotParams): Promise<DebtSnapshot[] | null> => {
 		const response = await getData({


### PR DESCRIPTION
- Adding the endpoint for L2 Kovan rate updates
- This will allow Kwenta to render the rates chart for rates on L2 Kovan 