### PR TITLE
Revert "feat: point L2 mainnet rates queries to L1 subgraphs (#51)"

### DIFF
--- a/packages/data/__tests__/queries.test.ts
+++ b/packages/data/__tests__/queries.test.ts
@@ -235,7 +235,7 @@ describe('@synthetixio/data tests', () => {
 			expect(l1RateUpdatesAnnualInfo!.length).toBeGreaterThan(1000);
 		});
 
-		test.skip('should return rateUpdates data from l2', async () => {
+		test('should return rateUpdates data from l2', async () => {
 			const l2RateUpdatesInfo = await snxDataOvm.rateUpdates({
 				max: 5,
 				synth: 'SNX',

--- a/packages/data/queries/rateUpdates/parse.ts
+++ b/packages/data/queries/rateUpdates/parse.ts
@@ -6,7 +6,7 @@ import { NetworkId } from '@synthetixio/contracts-interface';
 export const parseRates = (rate: RateUpdate, networkId?: number): RateUpdate => {
 	const { block, currencyKey, id, rate: rateValue, synth, timestamp } = rate;
 	const parsedRate =
-		networkId && networkId === NetworkId['Kovan-Ovm']
+		networkId && (networkId === NetworkId['Kovan-Ovm'] || networkId === NetworkId['Mainnet-Ovm'])
 			? rateValue
 			: ethers.utils.formatEther(rateValue);
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -192,7 +192,7 @@ const synthetixData = ({ networkId }: { networkId: NetworkId }): SynthetixData =
 			endpoints: {
 				[NetworkId.Mainnet]: l1Endpoints.rates,
 				[NetworkId['Kovan-Ovm']]: l2Endpoints.exchangesKovan,
-				[NetworkId['Mainnet-Ovm']]: l1Endpoints.rates,
+				[NetworkId['Mainnet-Ovm']]: l2Endpoints.exchanges,
 			},
 		});
 		return response != null


### PR DESCRIPTION
This reverts commit ebbf46b1d2bc6f531f212153353cd573d911c3d9.