### PR TITLE
Adding library target to data package

### DIFF
--- a/packages/data/webpack.config.js
+++ b/packages/data/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
 		path: path.resolve(__dirname, 'build'),
 		filename: 'index.js',
 		libraryTarget: 'umd',
+		library: 'snxData',
 	},
 	resolve: {
 		extensions: ['.ts', '.js'],

--- a/packages/data/webpack.config.js
+++ b/packages/data/webpack.config.js
@@ -24,11 +24,9 @@ module.exports = {
 	output: {
 		path: path.resolve(__dirname, 'build'),
 		filename: 'index.js',
-		library: {
-			name: 'snxData',
-			type: 'umd',
-			export: 'default',
-		},
+		libraryTarget: 'umd',
+		library: 'snxData',
+		libraryExport: 'default',
 	},
 	resolve: {
 		extensions: ['.ts', '.js'],

--- a/packages/data/webpack.config.js
+++ b/packages/data/webpack.config.js
@@ -24,8 +24,11 @@ module.exports = {
 	output: {
 		path: path.resolve(__dirname, 'build'),
 		filename: 'index.js',
-		libraryTarget: 'umd',
-		library: 'snxData',
+		library: {
+			name: 'snxData',
+			type: 'umd',
+			export: 'default',
+		},
 	},
 	resolve: {
 		extensions: ['.ts', '.js'],


### PR DESCRIPTION
Useful for browser-based projects like this codepen: https://codepen.io/justinjmoses/full/EzoEbM 

The library field copies the named `library` parameter to `window` for ease of use.