### PR TITLE
fix(queries): added decimal argument to wei conversion in token balance query

### DIFF
--- a/packages/queries/src/queries/walletBalances/useTokensBalancesQuery.ts
+++ b/packages/queries/src/queries/walletBalances/useTokensBalancesQuery.ts
@@ -50,7 +50,7 @@ const useTokensBalancesQuery = (
 				const token = tokensMap[symbol];
 
 				return {
-					balance: wei(balance),
+					balance: wei(balance, token.decimals, true),
 					token,
 				};
 			});

--- a/packages/queries/src/queries/walletBalances/useTokensBalancesQuery.ts
+++ b/packages/queries/src/queries/walletBalances/useTokensBalancesQuery.ts
@@ -11,13 +11,13 @@ import { ethers } from 'ethers';
 import { CRYPTO_CURRENCY_MAP } from '../../currency';
 
 import { QueryContext } from '../../context';
-import { TokenBalances } from '../../types';
+import { Token, TokenBalances } from '../../types';
 
 const ethcallProvider = new Provider();
 
 const useTokensBalancesQuery = (
 	ctx: QueryContext,
-	tokens: any[],
+	tokens: Token[],
 	walletAddress: string | null,
 	options?: UseQueryOptions<TokenBalances>
 ) => {
@@ -50,7 +50,7 @@ const useTokensBalancesQuery = (
 				const token = tokensMap[symbol];
 
 				return {
-					balance: wei(balance, token.decimals, true),
+					balance: wei(balance, token.decimals ?? 18),
 					token,
 				};
 			});


### PR DESCRIPTION
We were converting all currency balances to wei with the default 18 decimal standard. This fixes the conversation for tokens that don't use 18 decimals (ie. USDC, USDT)