### PR TITLE
update useTotalIssuedSynths query

### DIFF
--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/queries",
-	"version": "2.48.0",
+	"version": "2.48.1",
 	"description": "react-query for pulling synthetix data in react interfaces",
 	"source": "./src/index.ts",
 	"main": "./build/node/src/index.js",

--- a/packages/queries/src/queries/synths/useTotalIssuedSynthsExcludingEtherQuery.ts
+++ b/packages/queries/src/queries/synths/useTotalIssuedSynthsExcludingEtherQuery.ts
@@ -2,24 +2,24 @@ import Wei, { wei } from '@synthetixio/wei';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { QueryContext } from '../../context';
 
-const useTotalIssuedSynthsExcludingEtherQuery = (
+const totalIssuedSynthsExcludeOtherCollateralQuery = (
 	ctx: QueryContext,
 	currencyKey: string,
 	block?: number | null,
 	options?: UseQueryOptions<Wei>
 ) => {
 	return useQuery<Wei>(
-		['synth', 'totalIssuedExcludingEther', ctx.networkId, currencyKey],
+		['synth', 'totalIssuedSynthsExcludeOtherCollateral', ctx.networkId, currencyKey],
 		async () => {
-			const totalIssuedSynthsExclEther =
-				await ctx.snxjs!.contracts.Synthetix.totalIssuedSynthsExcludeEtherCollateral(
+			const totalIssuedSynthsExcludeOtherCollateral =
+				await ctx.snxjs!.contracts.Synthetix.totalIssuedSynthsExcludeOtherCollateral(
 					ctx.snxjs!.utils.formatBytes32String(currencyKey),
 					{
 						blockTag: block ? block : 'latest',
 					}
 				);
 
-			return wei(totalIssuedSynthsExclEther);
+			return wei(totalIssuedSynthsExcludeOtherCollateral);
 		},
 		{
 			enabled: !!ctx.snxjs,
@@ -28,4 +28,4 @@ const useTotalIssuedSynthsExcludingEtherQuery = (
 	);
 };
 
-export default useTotalIssuedSynthsExcludingEtherQuery;
+export default totalIssuedSynthsExcludeOtherCollateralQuery;


### PR DESCRIPTION
In the latest release 2.48.0 there were modifications to ```useTotalIssuedSynthsExcludingEtherQuery``` as seen here https://github.com/Synthetixio/synthetix/blob/master/contracts/interfaces/ISynthetix.sol#L42

This PR updates the function call so it gets the right value for display debt needed on the dApps