### PR TITLE
[optimism-networks] fix: remove 'fraudProofWindow' from optimism network config

### DIFF
--- a/packages/optimism-networks/src/constants.ts
+++ b/packages/optimism-networks/src/constants.ts
@@ -20,7 +20,6 @@ export const OPTIMISM_NETWORKS: Record<number, OptimismNetwork> = {
 			'https://optimism.io/images/metamask_icon.svg',
 			'https://optimism.io/images/metamask_icon.png',
 		],
-		fraudProofWindow: 604800000,
 	},
 	69: {
 		chainId: '0x45',
@@ -31,7 +30,6 @@ export const OPTIMISM_NETWORKS: Record<number, OptimismNetwork> = {
 			'https://optimism.io/images/metamask_icon.svg',
 			'https://optimism.io/images/metamask_icon.png',
 		],
-		fraudProofWindow: 0,
 	},
 };
 

--- a/packages/optimism-networks/src/types.ts
+++ b/packages/optimism-networks/src/types.ts
@@ -4,7 +4,6 @@ export type OptimismNetwork = {
 	rpcUrls: string[];
 	blockExplorerUrls: string[];
 	iconUrls: string[];
-	fraudProofWindow: number;
 };
 
 export enum NetworkId {

--- a/packages/optimism-networks/src/types.ts
+++ b/packages/optimism-networks/src/types.ts
@@ -4,6 +4,7 @@ export type OptimismNetwork = {
 	rpcUrls: string[];
 	blockExplorerUrls: string[];
 	iconUrls: string[];
+	fraudProofWindow?: number;
 };
 
 export enum NetworkId {

--- a/packages/queries/src/queries/ovm-bridge/useGetBridgeDataQuery.ts
+++ b/packages/queries/src/queries/ovm-bridge/useGetBridgeDataQuery.ts
@@ -81,8 +81,9 @@ const useGetBridgeDataQuery = (
 					if (isFromL2) {
 						const msgHashes = await watcher!.getMessageHashesFromL1Tx(l.transactionHash);
 						const receipt = await watcher!.getL2TransactionReceipt(msgHashes[0], false);
+						const fraudProofWindow = OPTIMISM_NETWORKS[ctx.networkId!]?.fraudProofWindow;
 						const readyToRelay =
-							Date.now() - timestamp > OPTIMISM_NETWORKS[ctx.networkId!].fraudProofWindow;
+							fraudProofWindow !== undefined ? Date.now() - timestamp > fraudProofWindow : false;
 
 						return {
 							timestamp,


### PR DESCRIPTION
Metamask throws an error when trying to use optimism via the current config.

![image](https://user-images.githubusercontent.com/16483341/133864169-6f1fd0cd-9633-49a4-91bb-8dfd2600f91b.png)
