### PR TITLE
deprecate rates subgraph

### DIFF
--- a/packages/data/codegen.yml
+++ b/packages/data/codegen.yml
@@ -1,13 +1,11 @@
 overwrite: true
 schema:
   [
-    'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-binary-options',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-loans',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-liquidations',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-depot',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-exchanger',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-exchanges',
-    'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-rates',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-shorts',
     'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix',
   ]

--- a/packages/data/src/constants.ts
+++ b/packages/data/src/constants.ts
@@ -4,7 +4,6 @@ export const l1Endpoints = {
 	depot: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-depot',
 	exchanges: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-exchanges',
 	exchangesKovan: 'https://api.thegraph.com/subgraphs/name/vbstreetz/exchanges-kovan',
-	rates: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-rates',
 	binaryOptions:
 		'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-binary-options',
 	etherCollateral: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-loans',

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -190,7 +190,7 @@ const synthetixData = ({ networkId }: { networkId: NetworkId }) => ({
 			queryMethod: queries.createSnxPriceQuery,
 			networkId,
 			endpoints: {
-				[NetworkId.Mainnet]: l1Endpoints.rates,
+				[NetworkId.Mainnet]: l1Endpoints.exchanges,
 				[NetworkId.Kovan]: l1Endpoints.exchangesKovan,
 				[NetworkId['Kovan-Ovm']]: l2Endpoints.exchangesKovan,
 				[NetworkId['Mainnet-Ovm']]: l2Endpoints.exchanges,
@@ -206,7 +206,7 @@ const synthetixData = ({ networkId }: { networkId: NetworkId }) => ({
 			queryMethod: queries.createRateUpdatesQuery,
 			networkId,
 			endpoints: {
-				[NetworkId.Mainnet]: l1Endpoints.rates,
+				[NetworkId.Mainnet]: l1Endpoints.exchanges,
 				[NetworkId.Kovan]: l1Endpoints.exchangesKovan,
 				[NetworkId['Kovan-Ovm']]: l2Endpoints.exchangesKovan,
 				[NetworkId['Mainnet-Ovm']]: l2Endpoints.exchanges,


### PR DESCRIPTION
rates subgraph has been replaced entirely with `exchanges`. This updates the queries
library to only use exchanges endpoints.