### PR TITLE
new features for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,10 @@ jobs:
 
       # publish
       - run: git config --global user.email "ci@cc.snxdao.io" && git config --global user.name "Synthetix CI"
-      - run: npx lerna version 0.0.0-$(git rev-parse --short HEAD) --exact --no-push -y
-      - run: npx lerna publish from-package --npm-tag dev --skip-git -y
+      - run: git fetch origin ${{ github.head_ref }}
+      - run: echo $(git rev-parse --short origin/${{ github.head_ref }})
+      #- run: npx lerna version 0.0.0-$(git rev-parse --short origin/${{ github.head_ref }}) --exact --no-push -y
+      - run: npx lerna exec npm version 0.0.0-$(git rev-parse --short origin/${{ github.head_ref }})
+      - run: npx lerna exec npm publish -- --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Main Workflow
 on:
-  push: {}
+  pull_request:
+    branches:
+    - main
+    - master
 
 jobs:
   build:
@@ -17,9 +20,10 @@ jobs:
       - run: npm run lint
       - run: npx lerna run build
       - run: npx lerna run test
-      - run: git config --global user.email "you@example.com" && git config --global user.name "Your Name"
+
+      # publish
+      - run: git config --global user.email "ci@cc.snxdao.io" && git config --global user.name "Synthetix CI"
       - run: npx lerna version 0.0.0-$(git rev-parse --short HEAD) --exact --no-push -y
       - run: npx lerna publish from-package --npm-tag dev --skip-git -y
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: echo "npm pushed to 0.0.0-$(git rev-parse --short HEAD)"

--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -1,9 +1,14 @@
 name: Publish Library
 
 on:
-  repository_dispatch:
-    types: update-synthetix
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      synthetix_version:
+        description: 'Upstream `synthetix` repo version (leave empty if no update)'
+        required: false
+      monorepo_version:
+        description: 'New Monorepo Version (ex. 2.50.0-alpha) (leave empty to "bump")'
+        required: false
 
 jobs:
   update_version:
@@ -15,14 +20,20 @@ jobs:
         with:
           node-version: '14'
           registry-url: 'https://registry.npmjs.org'
+      - name: resolve version
+        run: |
+          # there are 3 possible values we will find version number
+          export theversion="bump"
+          if [ -n "${{ github.event.inputs.monorepo_version }}" ]; then export theversion="${{ github.event.inputs.monorepo_version }}"; fi
+          echo "Resolved version $theversion"
+          echo "new_version=$theversion" >> $GITHUB_ENV
       - name: Update  @synthetixio/contracts-interface
+        if: github.event.inputs.synthetix_version
         run: |
-          echo "Update @synthetixio/contracts-interface with synthetix@${{ github.event.client_payload.version }}"
-          cd packages/contracts-interface && npm install synthetix@${{ github.event.client_payload.version }} --save-exact
-      - name: Commit changes
-        run: |
-          git config --global user.email "team@synthetix.io" && git config --global user.name "Synthetix Team"
-          git commit -am 'synthetix@${{ github.event.client_payload.version }}'
+          echo "Update @synthetixio/contracts-interface with synthetix@${{ github.event.inputs.synthetix_version }}"
+          cd packages/contracts-interface && npm install synthetix@${{ github.event.inputs.synthetix_version }} --save-exact
+          git config --global user.email "ci@cc.snxdao.io" && git config --global user.name "Synthetix CI"
+          git commit -am "synthetix@${{ env.new_version }}"
       - name: Lints and build
         run: |
           npm ci
@@ -31,7 +42,7 @@ jobs:
           npm run build
           npm run test-all
       - name: Update packages version
-        run: lerna version ${{ github.event.client_payload.version }} --exact --yes
+        run: lerna version ${{ env.new_version }} --exact --yes
       - name: Publish packages
         run: lerna publish from-package --yes
         env:
@@ -40,5 +51,5 @@ jobs:
         run: git push
       - name: Notify dApps
         run: |
-          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ github.event.client_payload.version }}\"}}" https://api.github.com/repos/Synthetixio/staking/dispatches
-          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ github.event.client_payload.version }}\"}}" https://api.github.com/repos/Kwenta/kwenta/dispatches
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.new_version }}\"}}" https://api.github.com/repos/Synthetixio/staking/dispatches
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.new_version }}\"}}" https://api.github.com/repos/Kwenta/kwenta/dispatches

--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -22,7 +22,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: resolve version
         run: |
-          # there are 3 possible values we will find version number
           export theversion="bump"
           if [ -n "${{ github.event.inputs.monorepo_version }}" ]; then export theversion="${{ github.event.inputs.monorepo_version }}"; fi
           echo "Resolved version $theversion"
@@ -33,7 +32,7 @@ jobs:
           echo "Update @synthetixio/contracts-interface with synthetix@${{ github.event.inputs.synthetix_version }}"
           cd packages/contracts-interface && npm install synthetix@${{ github.event.inputs.synthetix_version }} --save-exact
           git config --global user.email "ci@cc.snxdao.io" && git config --global user.name "Synthetix CI"
-          git commit -am "synthetix@${{ env.new_version }}"
+          git commit -am "synthetix@${{ github.event.inputs.synthetix_version }}"
       - name: Lints and build
         run: |
           npm ci


### PR DESCRIPTION
* `main` pipeline will not run unless attached to a PR or on main branch (might want to omit main branch as well but that comes later)
* `updateDependency` pipeline updated to `workflow_dispatch` which allows for triggering update by just clicking a button on GitHub UI

because of the second update, `updateDependency` now takes 2 parameters, one for the upstream version number, and one for the monorepo
new version. If no version is supplied, the version will be automatically bump ed by lerna