### PR TITLE
fix: resolved version for downstream dispatch

### DIFF
--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -50,6 +50,6 @@ jobs:
         run: git push
       - name: Notify dApps
         run: |
-          echo "resolved_version=$(git tag | tail -1)" >> $GITHUB_ENV
+          export resolved_version=$(git tag | tail -1 | cut -c 2-)
           curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.resolved_version }}\"}}" https://api.github.com/repos/Synthetixio/staking/dispatches
           curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.resolved_version }}\"}}" https://api.github.com/repos/Kwenta/kwenta/dispatches


### PR DESCRIPTION
potential fix for downstream issue when specifying semver (ie. patch, minor, etc.) for monorepo packages.

this pulls the latest tag after lerna publish is complete

relevant error:
https://github.com/Synthetixio/staking/runs/3807316019?check_suite_focus=true