### PR TITLE
Avoid infinity loop

### DIFF
--- a/packages/queries/codegen.js
+++ b/packages/queries/codegen.js
@@ -12,7 +12,7 @@ function findQueries(p, requireSoFar) {
 	for (const f of fs.readdirSync(p)) {
 		if (fs.statSync(`${p}/${f}`).isDirectory()) {
 			findQueries(`${p}/${f}`, `${requireSoFar}/${f}`);
-		} else if (f.startsWith('use')) {
+		} else if (f.startsWith('use') && !f.endsWith('.test.ts')) {
 			// remove extension
 			const name = f.slice(0, f.length - 3);
 

--- a/packages/queries/src/mutations/useEVMTxn.test.ts
+++ b/packages/queries/src/mutations/useEVMTxn.test.ts
@@ -5,7 +5,7 @@ import { getWrapper } from '../../testUtils';
 import useEVMTxn from './useEVMTxn';
 
 describe('useEVMTxn', () => {
-	test('Does not call estimateGas when tnx is null', async () => {
+	test('Does not call estimateGas when txn is null', async () => {
 		const estimateGasMock = jest.fn().mockResolvedValue(10);
 		const sendTransactionMock = jest.fn();
 

--- a/packages/queries/src/mutations/useEVMTxn.test.ts
+++ b/packages/queries/src/mutations/useEVMTxn.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { renderHook } from '@testing-library/react-hooks';
+import { BigNumber } from 'ethers';
+import { getWrapper } from '../../testUtils';
+import useEVMTxn from './useEVMTxn';
+
+describe('useEVMTxn', () => {
+	test('Does not call estimateGas when tnx is null', async () => {
+		const estimateGasMock = jest.fn().mockResolvedValue(10);
+		const sendTransactionMock = jest.fn();
+
+		const mockCTX = {
+			signer: {
+				estimateGas: estimateGasMock,
+				sendTransaction: sendTransactionMock,
+			},
+		};
+
+		const wrapper = getWrapper();
+
+		const hookResult = renderHook(() => useEVMTxn(mockCTX as any, null), {
+			wrapper,
+		});
+		try {
+			// We do not expect any state update so this should timeout
+			await hookResult.waitForNextUpdate({ timeout: 100 });
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect(estimateGasMock).not.toBeCalled();
+		}
+	});
+	test('Does not call estimateGas twice when the txn is the same', async () => {
+		const estimateGasMock = jest.fn().mockResolvedValue(10);
+		const sendTransactionMock = jest.fn();
+
+		const mockCTX = {
+			signer: {
+				estimateGas: estimateGasMock,
+				sendTransaction: sendTransactionMock,
+			},
+		};
+
+		const wrapper = getWrapper();
+		const hookResult = renderHook(
+			() =>
+				useEVMTxn(mockCTX as any, {
+					data: 'byte',
+					value: BigNumber.from(10),
+					nonce: undefined,
+					from: '1',
+					to: '2',
+				}),
+			{
+				wrapper,
+			}
+		);
+		await hookResult.waitForNextUpdate();
+
+		expect(estimateGasMock).toBeCalledTimes(1);
+		expect(estimateGasMock).toBeCalledWith({
+			data: 'byte',
+			value: BigNumber.from(10),
+			nonce: undefined,
+			from: '1',
+			to: '2',
+		});
+		expect(hookResult.result.current.gasLimit?.toString(0)).toBe('10');
+
+		// This asserts a infinity rerender bug we had due to not calling toString on txn.value,
+		// without calling toString we will end up in a infinity loop and this will fail
+		hookResult.rerender();
+		expect(estimateGasMock).toBeCalledTimes(1);
+	});
+});

--- a/packages/queries/src/mutations/useEVMTxn.ts
+++ b/packages/queries/src/mutations/useEVMTxn.ts
@@ -43,7 +43,7 @@ const useEVMTxn = (
 		if (txn != null && ctx.signer != null && (!options || options.enabled)) {
 			// remove gas price from the estimate because it will cause unusual error if its below the base
 			// it will be used at the end when the actual transaction is submitted
-			return ctx.signer.estimateGas(omit(txn!, ['gasPrice']));
+			return ctx.signer.estimateGas(omit(txn, ['gasPrice']));
 		}
 
 		return null;

--- a/packages/queries/src/mutations/useEVMTxn.ts
+++ b/packages/queries/src/mutations/useEVMTxn.ts
@@ -74,8 +74,9 @@ const useEVMTxn = (
 				});
 		}
 	}
-
-	useEffect(refresh, [txn?.to]);
+	const transactionValueAsString = txn?.value ? txn.value.toString() : undefined;
+	const nonceAsString = txn?.nonce ? txn.nonce.toString() : undefined;
+	useEffect(refresh, [txn?.data, transactionValueAsString, nonceAsString, txn?.from, txn?.to]);
 
 	return {
 		gasLimit,

--- a/packages/queries/src/mutations/useEVMTxn.ts
+++ b/packages/queries/src/mutations/useEVMTxn.ts
@@ -43,7 +43,7 @@ const useEVMTxn = (
 		if (txn != null && ctx.signer != null && (!options || options.enabled)) {
 			// remove gas price from the estimate because it will cause unusual error if its below the base
 			// it will be used at the end when the actual transaction is submitted
-			return ctx.signer!.estimateGas(omit(txn!, ['gasPrice']));
+			return ctx.signer.estimateGas(omit(txn!, ['gasPrice']));
 		}
 
 		return null;
@@ -75,7 +75,7 @@ const useEVMTxn = (
 		}
 	}
 
-	useEffect(refresh, [txn?.data, txn?.value, txn?.nonce, txn?.from, txn?.to]);
+	useEffect(refresh, [txn?.to]);
 
 	return {
 		gasLimit,


### PR DESCRIPTION
I think we only need to update the `gasLimit` when the `to` address changes?

With the previous implementation we were in an infinity loop. Fetching gas meant that the transaction got its `data` and `value` set. When it finished those properties gets set to null causing the useEffect to be triggered again.