### PR TITLE
remove trailing slashes

### DIFF
--- a/packages/optimism-networks/src/constants.ts
+++ b/packages/optimism-networks/src/constants.ts
@@ -17,7 +17,7 @@ export const OPTIMISM_NETWORKS: Record<number, OptimismNetwork> = {
 		chainId: '0xA',
 		chainName: 'Optimism Mainnet',
 		rpcUrls: ['https://mainnet.optimism.io'],
-		blockExplorerUrls: ['https://optimistic.etherscan.io/'],
+		blockExplorerUrls: ['https://optimistic.etherscan.io'],
 		iconUrls: [
 			'https://optimism.io/images/metamask_icon.svg',
 			'https://optimism.io/images/metamask_icon.png',
@@ -27,7 +27,7 @@ export const OPTIMISM_NETWORKS: Record<number, OptimismNetwork> = {
 		chainId: '0x45',
 		chainName: 'Optimism Kovan',
 		rpcUrls: ['https://kovan.optimism.io'],
-		blockExplorerUrls: ['https://kovan-optimistic.etherscan.io/'],
+		blockExplorerUrls: ['https://kovan-optimistic.etherscan.io'],
 		iconUrls: [
 			'https://optimism.io/images/metamask_icon.svg',
 			'https://optimism.io/images/metamask_icon.png',


### PR DESCRIPTION
the trailing slashes caused some issue on the kwenta front end. In my eyes, there shouldn't be a trailing slash in a library such as this one. 