### PR TITLE
map subgraph functions with context same as rest of query library

### DIFF
--- a/packages/queries/src/index.ts
+++ b/packages/queries/src/index.ts
@@ -31,7 +31,7 @@ type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...arg
 
 type Queries<T> = {
 	[Property in keyof T]: OmitFirstArg<T[Property]>;
-}
+};
 
 export type SynthetixQueries = {
 	exchanges: Queries<typeof exchanges>;
@@ -78,17 +78,26 @@ export function createQueryContext({
 
 	modFuncs.exchanges = {};
 	for (const f in exchanges) {
-		(modFuncs.exchanges as any)[f] = partial(modFuncs[f] as UseSubgraphFunction, ctx.subgraphEndpoints.exchanges);
+		(modFuncs.exchanges as any)[f] = partial(
+			modFuncs[f] as UseSubgraphFunction,
+			ctx.subgraphEndpoints.exchanges
+		);
 	}
 
 	modFuncs.exchanger = {};
 	for (const f in exchanger) {
-		(modFuncs.exchanger as any)[f] = partial(modFuncs[f] as UseSubgraphFunction, ctx.subgraphEndpoints.exchanger);
+		(modFuncs.exchanger as any)[f] = partial(
+			modFuncs[f] as UseSubgraphFunction,
+			ctx.subgraphEndpoints.exchanger
+		);
 	}
 
 	modFuncs.issuance = {};
 	for (const f in issuance) {
-		(modFuncs.issuance as any)[f] = partial(modFuncs[f] as UseSubgraphFunction, ctx.subgraphEndpoints.issuance);
+		(modFuncs.issuance as any)[f] = partial(
+			modFuncs[f] as UseSubgraphFunction,
+			ctx.subgraphEndpoints.issuance
+		);
 	}
 
 	const allFuncs = modFuncs as SynthetixQueries;

--- a/packages/queries/src/index.ts
+++ b/packages/queries/src/index.ts
@@ -93,7 +93,7 @@ export function createQueryContext({
 	modFuncs.exchanges = {};
 	for (const f in exchanges) {
 		(modFuncs.exchanges as any)[f] = partial(
-			modFuncs[f] as UseSubgraphFunction,
+			(exchanges as any)[f] as UseSubgraphFunction,
 			ctx.subgraphEndpoints.exchanges
 		);
 	}
@@ -101,7 +101,7 @@ export function createQueryContext({
 	modFuncs.exchanger = {};
 	for (const f in exchanger) {
 		(modFuncs.exchanger as any)[f] = partial(
-			modFuncs[f] as UseSubgraphFunction,
+			(exchanger as any)[f] as UseSubgraphFunction,
 			ctx.subgraphEndpoints.exchanger
 		);
 	}
@@ -109,7 +109,7 @@ export function createQueryContext({
 	modFuncs.issuance = {};
 	for (const f in issuance) {
 		(modFuncs.issuance as any)[f] = partial(
-			modFuncs[f] as UseSubgraphFunction,
+			(issuance as any)[f] as UseSubgraphFunction,
 			ctx.subgraphEndpoints.issuance
 		);
 	}


### PR DESCRIPTION
after implementing downstream, it has become apparent that resolving and passing the `subgraphUrl` every
time is not a very good pattern. As the subgraph data must be injected into the context for the queries library anyway, this will
allow for calling of subgraph functions directly from `useSynthetixQueries` with the first `subgraphUrl` argument
mapped with the url of the corresponding subgraph.