### PR TITLE
Feat/switch network functions

### DIFF
--- a/packages/optimism-networks/__tests__/switch-to-l1.test.ts
+++ b/packages/optimism-networks/__tests__/switch-to-l1.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { switchToL1 } from '../src';
 
 describe('switchToL1', () => {

--- a/packages/optimism-networks/__tests__/switch-to-l1.test.ts
+++ b/packages/optimism-networks/__tests__/switch-to-l1.test.ts
@@ -1,0 +1,55 @@
+import { switchToL1 } from '../src';
+
+describe('switchToL1', () => {
+	test('Switch to mainnet when optimism mainnet selected', async () => {
+		const requestMock = jest.fn().mockResolvedValue(undefined);
+		const arg = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0xa',
+			},
+		} as any;
+
+		await switchToL1(arg);
+		expect(requestMock).toBeCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0x1' }],
+		});
+	});
+	test('Switch to kovan when optimism kovan selected', async () => {
+		const requestMock = jest.fn().mockResolvedValue(undefined);
+		const arg = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x45',
+			},
+		} as any;
+
+		await switchToL1(arg);
+		expect(requestMock).toBeCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0x2a' }],
+		});
+	});
+	test('Switch to mainnet when unsupported network selected', async () => {
+		const requestMock = jest.fn().mockResolvedValue(undefined);
+		const arg = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x1234',
+			},
+		} as any;
+
+		await switchToL1(arg);
+		expect(requestMock).toBeCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0x1' }],
+		});
+	});
+});

--- a/packages/optimism-networks/__tests__/switch-to-l2.test.ts
+++ b/packages/optimism-networks/__tests__/switch-to-l2.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { switchToL2 } from '../src';
 import { METAMASK_MISSING_NETWORK_ERROR_CODE } from '../src/constants';
 

--- a/packages/optimism-networks/__tests__/switch-to-l2.test.ts
+++ b/packages/optimism-networks/__tests__/switch-to-l2.test.ts
@@ -1,0 +1,126 @@
+import { switchToL2 } from '../src';
+import { METAMASK_MISSING_NETWORK_ERROR_CODE } from '../src/constants';
+
+describe('switchToL2', () => {
+	test('Switch to Optimism mainnet when mainnet selected ', async () => {
+		const requestMock = jest.fn().mockResolvedValue(undefined);
+		const deps = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x1',
+			},
+		} as any;
+
+		await switchToL2(deps);
+		expect(requestMock).toBeCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0xa' }],
+		});
+	});
+	test('Switch to Optimism Kovan when kovan selected ', async () => {
+		const requestMock = jest.fn().mockResolvedValue(undefined);
+		const deps = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x2a',
+			},
+		} as any;
+
+		await switchToL2(deps);
+		expect(requestMock).toBeCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0x45' }],
+		});
+	});
+	test('Switch to Optimism mainnet when unsupported network selected ', async () => {
+		const requestMock = jest.fn().mockResolvedValue(undefined);
+		const deps = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x12345',
+			},
+		} as any;
+
+		await switchToL2(deps);
+		expect(requestMock).toBeCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0xa' }],
+		});
+	});
+	test('switchToL2 adds optimism network mainnet when needed', async () => {
+		const requestMock = jest
+			.fn()
+			.mockRejectedValueOnce({ code: METAMASK_MISSING_NETWORK_ERROR_CODE }) // network missing in metamask
+			.mockResolvedValueOnce(undefined); // added network call
+		const deps = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x1',
+			},
+		} as any;
+		await switchToL2(deps);
+
+		expect(requestMock).toBeCalledTimes(2);
+		expect(requestMock).toHaveBeenNthCalledWith(1, {
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0xa' }],
+		});
+		expect(requestMock).toHaveBeenNthCalledWith(2, {
+			method: 'wallet_addEthereumChain',
+			params: [
+				{
+					blockExplorerUrls: ['https://optimistic.etherscan.io'],
+					chainId: '0xA',
+					chainName: 'Optimism Mainnet',
+					iconUrls: [
+						'https://optimism.io/images/metamask_icon.svg',
+						'https://optimism.io/images/metamask_icon.png',
+					],
+					rpcUrls: ['https://mainnet.optimism.io'],
+				},
+			],
+		});
+	});
+	test('switchToL2 adds optimism kovan network when needed', async () => {
+		const requestMock = jest
+			.fn()
+			.mockRejectedValueOnce({ code: METAMASK_MISSING_NETWORK_ERROR_CODE }) // network missing in metamask
+			.mockResolvedValueOnce(undefined); // added network call
+		const deps = {
+			ethereum: {
+				isMetaMask: true,
+				request: requestMock,
+				chainId: '0x2a',
+			},
+		} as any;
+		await switchToL2(deps);
+
+		expect(requestMock).toBeCalledTimes(2);
+		expect(requestMock).toHaveBeenNthCalledWith(1, {
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0x45' }],
+		});
+		expect(requestMock).toHaveBeenNthCalledWith(2, {
+			method: 'wallet_addEthereumChain',
+			params: [
+				{
+					blockExplorerUrls: ['https://kovan-optimistic.etherscan.io'],
+					chainId: '0x45',
+					chainName: 'Optimism Kovan',
+					iconUrls: [
+						'https://optimism.io/images/metamask_icon.svg',
+						'https://optimism.io/images/metamask_icon.png',
+					],
+					rpcUrls: ['https://kovan.optimism.io'],
+				},
+			],
+		});
+	});
+});

--- a/packages/optimism-networks/package-lock.json
+++ b/packages/optimism-networks/package-lock.json
@@ -6,10 +6,11 @@
 	"packages": {
 		"": {
 			"name": "@synthetixio/optimism-networks",
-			"version": "2.52.1-alpha",
+			"version": "2.52.2",
 			"license": "MIT",
 			"dependencies": {
-				"@eth-optimism/watcher": "^0.0.1-alpha.9"
+				"@eth-optimism/watcher": "^0.0.1-alpha.9",
+				"@metamask/providers": "8.1.1"
 			},
 			"devDependencies": {
 				"@types/lodash": "4.14.169",
@@ -790,6 +791,73 @@
 				"@ethersproject/strings": "^5.4.0"
 			}
 		},
+		"node_modules/@metamask/object-multiplex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz",
+			"integrity": "sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==",
+			"dependencies": {
+				"end-of-stream": "^1.4.4",
+				"once": "^1.4.0",
+				"readable-stream": "^2.3.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@metamask/providers": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-8.1.1.tgz",
+			"integrity": "sha512-CG1sAuD6Mp4MZ5U90anf1FT0moDbStGXT+80TQFYXJbBeTQjhp321WgC/F2IgIJ3mFqOiByC3MQHLuunEVMQOA==",
+			"dependencies": {
+				"@metamask/object-multiplex": "^1.1.0",
+				"@metamask/safe-event-emitter": "^2.0.0",
+				"@types/chrome": "^0.0.136",
+				"detect-browser": "^5.2.0",
+				"eth-rpc-errors": "^4.0.2",
+				"extension-port-stream": "^2.0.1",
+				"fast-deep-equal": "^2.0.1",
+				"is-stream": "^2.0.0",
+				"json-rpc-engine": "^6.1.0",
+				"json-rpc-middleware-stream": "^3.0.0",
+				"pump": "^3.0.0",
+				"webextension-polyfill-ts": "^0.25.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@metamask/safe-event-emitter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+			"integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+		},
+		"node_modules/@types/chrome": {
+			"version": "0.0.136",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.136.tgz",
+			"integrity": "sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==",
+			"dependencies": {
+				"@types/filesystem": "*",
+				"@types/har-format": "*"
+			}
+		},
+		"node_modules/@types/filesystem": {
+			"version": "0.0.32",
+			"resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+			"integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+			"dependencies": {
+				"@types/filewriter": "*"
+			}
+		},
+		"node_modules/@types/filewriter": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+			"integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+		},
+		"node_modules/@types/har-format": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+			"integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ=="
+		},
 		"node_modules/@types/lodash": {
 			"version": "4.14.169",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.169.tgz",
@@ -1005,6 +1073,11 @@
 			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
 			"dev": true
 		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+		},
 		"node_modules/cosmiconfig": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -1058,6 +1131,11 @@
 			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
+		"node_modules/detect-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+			"integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
+		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -1082,7 +1160,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
 			}
@@ -1115,6 +1192,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/eth-rpc-errors": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+			"integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+			"dependencies": {
+				"fast-safe-stringify": "^2.0.6"
 			}
 		},
 		"node_modules/ethers": {
@@ -1175,6 +1260,36 @@
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
+		},
+		"node_modules/extension-port-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.1.tgz",
+			"integrity": "sha512-ltrv4Dh/979I04+D4Te6TFygfRSOc5EBzzlHRldWMS8v73V80qWluxH88hqF0qyUsBXTb8NmzlmSipcre6a+rg==",
+			"dependencies": {
+				"webextension-polyfill-ts": "^0.22.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/extension-port-stream/node_modules/webextension-polyfill-ts": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+			"integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+			"deprecated": "This project has moved to @types/webextension-polyfill",
+			"dependencies": {
+				"webextension-polyfill": "^0.7.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+		},
+		"node_modules/fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
 		},
 		"node_modules/figures": {
 			"version": "3.2.0",
@@ -1392,7 +1507,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -1411,6 +1525,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -1434,6 +1553,27 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
+		},
+		"node_modules/json-rpc-engine": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+			"integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+			"dependencies": {
+				"@metamask/safe-event-emitter": "^2.0.0",
+				"eth-rpc-errors": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/json-rpc-middleware-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
+			"integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
+			"dependencies": {
+				"@metamask/safe-event-emitter": "^2.0.0",
+				"readable-stream": "^2.3.3"
+			}
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.1.6",
@@ -1624,7 +1764,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -1794,14 +1933,32 @@
 				"semver-compare": "^1.0.0"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -1837,6 +1994,11 @@
 			"engines": {
 				"npm": ">=2.0.0"
 			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/scrypt-js": {
 			"version": "3.0.1",
@@ -1906,6 +2068,14 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string-argv": {
@@ -2014,6 +2184,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"node_modules/webextension-polyfill": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+			"integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+		},
+		"node_modules/webextension-polyfill-ts": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz",
+			"integrity": "sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==",
+			"deprecated": "This project has moved to @types/webextension-polyfill",
+			"dependencies": {
+				"webextension-polyfill": "^0.7.0"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2052,8 +2241,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/ws": {
 			"version": "7.4.6",
@@ -2540,6 +2728,67 @@
 				"@ethersproject/strings": "^5.4.0"
 			}
 		},
+		"@metamask/object-multiplex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz",
+			"integrity": "sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==",
+			"requires": {
+				"end-of-stream": "^1.4.4",
+				"once": "^1.4.0",
+				"readable-stream": "^2.3.3"
+			}
+		},
+		"@metamask/providers": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-8.1.1.tgz",
+			"integrity": "sha512-CG1sAuD6Mp4MZ5U90anf1FT0moDbStGXT+80TQFYXJbBeTQjhp321WgC/F2IgIJ3mFqOiByC3MQHLuunEVMQOA==",
+			"requires": {
+				"@metamask/object-multiplex": "^1.1.0",
+				"@metamask/safe-event-emitter": "^2.0.0",
+				"@types/chrome": "^0.0.136",
+				"detect-browser": "^5.2.0",
+				"eth-rpc-errors": "^4.0.2",
+				"extension-port-stream": "^2.0.1",
+				"fast-deep-equal": "^2.0.1",
+				"is-stream": "^2.0.0",
+				"json-rpc-engine": "^6.1.0",
+				"json-rpc-middleware-stream": "^3.0.0",
+				"pump": "^3.0.0",
+				"webextension-polyfill-ts": "^0.25.0"
+			}
+		},
+		"@metamask/safe-event-emitter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+			"integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+		},
+		"@types/chrome": {
+			"version": "0.0.136",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.136.tgz",
+			"integrity": "sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==",
+			"requires": {
+				"@types/filesystem": "*",
+				"@types/har-format": "*"
+			}
+		},
+		"@types/filesystem": {
+			"version": "0.0.32",
+			"resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+			"integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+			"requires": {
+				"@types/filewriter": "*"
+			}
+		},
+		"@types/filewriter": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+			"integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+		},
+		"@types/har-format": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+			"integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ=="
+		},
 		"@types/lodash": {
 			"version": "4.14.169",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.169.tgz",
@@ -2701,6 +2950,11 @@
 			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
 			"dev": true
 		},
+		"core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+		},
 		"cosmiconfig": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -2740,6 +2994,11 @@
 			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
+		"detect-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+			"integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
+		},
 		"elliptic": {
 			"version": "6.5.4",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -2764,7 +3023,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2792,6 +3050,14 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
+		},
+		"eth-rpc-errors": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+			"integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+			"requires": {
+				"fast-safe-stringify": "^2.0.6"
+			}
 		},
 		"ethers": {
 			"version": "5.0.0",
@@ -2845,6 +3111,34 @@
 				"signal-exit": "^3.0.2",
 				"strip-final-newline": "^2.0.0"
 			}
+		},
+		"extension-port-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.1.tgz",
+			"integrity": "sha512-ltrv4Dh/979I04+D4Te6TFygfRSOc5EBzzlHRldWMS8v73V80qWluxH88hqF0qyUsBXTb8NmzlmSipcre6a+rg==",
+			"requires": {
+				"webextension-polyfill-ts": "^0.22.0"
+			},
+			"dependencies": {
+				"webextension-polyfill-ts": {
+					"version": "0.22.0",
+					"resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+					"integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+					"requires": {
+						"webextension-polyfill": "^0.7.0"
+					}
+				}
+			}
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+		},
+		"fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
 		},
 		"figures": {
 			"version": "3.2.0",
@@ -3001,14 +3295,18 @@
 		"is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
 			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -3032,6 +3330,24 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
+		},
+		"json-rpc-engine": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+			"integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+			"requires": {
+				"@metamask/safe-event-emitter": "^2.0.0",
+				"eth-rpc-errors": "^4.0.2"
+			}
+		},
+		"json-rpc-middleware-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
+			"integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
+			"requires": {
+				"@metamask/safe-event-emitter": "^2.0.0",
+				"readable-stream": "^2.3.3"
+			}
 		},
 		"lines-and-columns": {
 			"version": "1.1.6",
@@ -3179,7 +3495,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -3295,14 +3610,32 @@
 				"semver-compare": "^1.0.0"
 			}
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"resolve-from": {
@@ -3329,6 +3662,11 @@
 			"requires": {
 				"tslib": "^1.9.0"
 			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"scrypt-js": {
 			"version": "3.0.1",
@@ -3383,6 +3721,14 @@
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
 				"is-fullwidth-code-point": "^3.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"string-argv": {
@@ -3464,6 +3810,24 @@
 			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 			"dev": true
 		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"webextension-polyfill": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+			"integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+		},
+		"webextension-polyfill-ts": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz",
+			"integrity": "sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==",
+			"requires": {
+				"webextension-polyfill": "^0.7.0"
+			}
+		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3493,8 +3857,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
 			"version": "7.4.6",

--- a/packages/optimism-networks/package.json
+++ b/packages/optimism-networks/package.json
@@ -31,7 +31,8 @@
 		"url": "https://github.com/Synthetixio/js-monorepo/issues"
 	},
 	"dependencies": {
-		"@eth-optimism/watcher": "^0.0.1-alpha.9"
+		"@eth-optimism/watcher": "^0.0.1-alpha.9",
+		"@metamask/providers": "8.1.1"
 	},
 	"devDependencies": {
 		"@types/lodash": "4.14.169",

--- a/packages/optimism-networks/src/constants.ts
+++ b/packages/optimism-networks/src/constants.ts
@@ -1,5 +1,6 @@
 import { OptimismNetwork, NetworkMapper, LayerTwoNetworkId, MessengerAddress } from './types';
 
+export const DEFAULT_MAINNET_NETWORK = 1;
 export const L1_TO_L2_NETWORK_MAPPER: NetworkMapper = {
 	1: 10,
 	42: 69,

--- a/packages/optimism-networks/src/constants.ts
+++ b/packages/optimism-networks/src/constants.ts
@@ -1,6 +1,9 @@
 import { OptimismNetwork, NetworkMapper, LayerTwoNetworkId, MessengerAddress } from './types';
 
+export const METAMASK_MISSING_NETWORK_ERROR_CODE = 4902;
+
 export const DEFAULT_MAINNET_NETWORK = 1;
+export const DEFAULT_LAYER2_NETWORK = 10;
 export const L1_TO_L2_NETWORK_MAPPER: NetworkMapper = {
 	1: 10,
 	42: 69,

--- a/packages/optimism-networks/src/index.ts
+++ b/packages/optimism-networks/src/index.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import type { MetaMaskInpageProvider } from '@metamask/providers';
 import { Watcher } from '@eth-optimism/watcher';
 
 import {
@@ -25,11 +25,12 @@ const getOptimismNetwork = ({
 const addOptimismNetworkToMetamask = async ({
 	ethereum,
 }: {
-	ethereum: EthereumProvider;
-}): Promise<null> => {
+	ethereum: MetaMaskInpageProvider;
+}): Promise<void> => {
 	if (!ethereum || !ethereum.isMetaMask) throw new Error('Metamask is not installed');
 	const optimismNetworkConfig = getOptimismNetwork({ layerOneNetworkId: Number(ethereum.chainId) });
-	return await ethereum.request({
+
+	await ethereum.request({
 		method: 'wallet_addEthereumChain',
 		params: [optimismNetworkConfig],
 	});

--- a/packages/optimism-networks/src/index.ts
+++ b/packages/optimism-networks/src/index.ts
@@ -6,6 +6,7 @@ import {
 	L1_TO_L2_NETWORK_MAPPER,
 	L2_TO_L1_NETWORK_MAPPER,
 	MESSENGER_ADDRESSES,
+	DEFAULT_MAINNET_NETWORK,
 } from './constants';
 import { EthereumProvider, OptimismNetwork, OptimismWatcher } from './types';
 
@@ -15,9 +16,10 @@ const getOptimismNetwork = ({
 	layerOneNetworkId: number;
 }): OptimismNetwork => {
 	if (!layerOneNetworkId) throw new Error('NetworkId required');
-	if (!L1_TO_L2_NETWORK_MAPPER[layerOneNetworkId])
-		throw new Error('Network not supported on Layer 2');
-	return OPTIMISM_NETWORKS[L1_TO_L2_NETWORK_MAPPER[layerOneNetworkId]];
+	// If user is on a unsupported network, just add optimism mainnet.
+	const optimismNetwork =
+		L1_TO_L2_NETWORK_MAPPER[layerOneNetworkId] || L1_TO_L2_NETWORK_MAPPER[DEFAULT_MAINNET_NETWORK];
+	return OPTIMISM_NETWORKS[optimismNetwork];
 };
 
 const addOptimismNetworkToMetamask = async ({

--- a/packages/optimism-networks/src/index.ts
+++ b/packages/optimism-networks/src/index.ts
@@ -1,4 +1,5 @@
 import type { MetaMaskInpageProvider } from '@metamask/providers';
+import { ethers, BigNumber } from 'ethers';
 import { Watcher } from '@eth-optimism/watcher';
 
 import {
@@ -7,8 +8,10 @@ import {
 	L2_TO_L1_NETWORK_MAPPER,
 	MESSENGER_ADDRESSES,
 	DEFAULT_MAINNET_NETWORK,
+	DEFAULT_LAYER2_NETWORK,
+	METAMASK_MISSING_NETWORK_ERROR_CODE,
 } from './constants';
-import { EthereumProvider, OptimismNetwork, OptimismWatcher } from './types';
+import { OptimismNetwork, OptimismWatcher } from './types';
 
 const getOptimismNetwork = ({
 	layerOneNetworkId,
@@ -34,6 +37,37 @@ const addOptimismNetworkToMetamask = async ({
 		method: 'wallet_addEthereumChain',
 		params: [optimismNetworkConfig],
 	});
+};
+const switchToL1 = async ({ ethereum }: { ethereum: MetaMaskInpageProvider }): Promise<void> => {
+	if (!ethereum || !ethereum.isMetaMask) throw new Error('Metamask is not installed');
+	const networkId =
+		L2_TO_L1_NETWORK_MAPPER[Number(ethereum.chainId)] ||
+		L2_TO_L1_NETWORK_MAPPER[DEFAULT_LAYER2_NETWORK];
+	const formattedChainId = ethers.utils.hexStripZeros(BigNumber.from(networkId).toHexString());
+	await ethereum.request({
+		method: 'wallet_switchEthereumChain',
+		params: [{ chainId: formattedChainId }],
+	});
+};
+const switchToL2 = async ({ ethereum }: { ethereum: MetaMaskInpageProvider }): Promise<void> => {
+	if (!ethereum || !ethereum.isMetaMask) throw new Error('Metamask is not installed');
+	try {
+		const networkId =
+			L1_TO_L2_NETWORK_MAPPER[Number(ethereum.chainId)] ||
+			L1_TO_L2_NETWORK_MAPPER[DEFAULT_MAINNET_NETWORK];
+
+		const formattedChainId = ethers.utils.hexStripZeros(BigNumber.from(networkId).toHexString());
+		await ethereum.request({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: formattedChainId }],
+		});
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} catch (e: any) {
+		if (e?.code === METAMASK_MISSING_NETWORK_ERROR_CODE) {
+			addOptimismNetworkToMetamask({ ethereum });
+			return;
+		}
+	}
 };
 
 const optimismMessengerWatcher = ({
@@ -69,4 +103,6 @@ export {
 	MESSENGER_ADDRESSES,
 	L1_TO_L2_NETWORK_MAPPER,
 	L2_TO_L1_NETWORK_MAPPER,
+	switchToL1,
+	switchToL2,
 };

--- a/packages/optimism-networks/src/types.ts
+++ b/packages/optimism-networks/src/types.ts
@@ -12,12 +12,6 @@ export enum NetworkId {
 	Kovan = 69,
 }
 
-export type EthereumProvider = {
-	isMetaMask: boolean;
-	chainId: string;
-	request: ({ method, params }: { method: string; params: OptimismNetwork[] }) => Promise<null>;
-};
-
 export type OptimismWatcher = {
 	getMessageHashesFromL1Tx: (transactionHash: string) => string[];
 	getMessageHashesFromL2Tx: (transactionHash: string) => string[];


### PR DESCRIPTION
Add `switchToL1` and `switchToL2` functions.
- If user is on a network we don't support switch to mainnet instead of throwing
- If optimism is missing `switchToL2` will add the network
- Added `@metamask/providers` package to get the correct type for the provider (`MetaMaskInpageProvider`)
 