### PR TITLE
feat: serialize wei as string instead of hex

### DIFF
--- a/packages/wei/__tests__/wei.ts
+++ b/packages/wei/__tests__/wei.ts
@@ -218,4 +218,22 @@ describe('Wei numeric type', () => {
 			expect(Wei.avg(wei(5), wei(2), wei(8)).eq(5));
 		});
 	});
+
+	describe('serialization', () => {
+		it('JSON.stringify', () => {
+			expect(JSON.stringify(new Wei(100))).toEqual(
+				JSON.stringify({
+					p: 18,
+					value: '100000000000000000000',
+				})
+			);
+		});
+
+		it('serialize and deserialize as new wei', () => {
+			const wei = new Wei(100);
+			const deserialized = JSON.parse(JSON.stringify(wei));
+			const deserializedWei = new Wei(deserialized.value, deserialized.p, true);
+			expect(deserializedWei).toEqual(wei);
+		});
+	});
 });

--- a/packages/wei/__tests__/wei.ts
+++ b/packages/wei/__tests__/wei.ts
@@ -221,18 +221,13 @@ describe('Wei numeric type', () => {
 
 	describe('serialization', () => {
 		it('JSON.stringify', () => {
-			expect(JSON.stringify(new Wei(100))).toEqual(
-				JSON.stringify({
-					p: 18,
-					value: '100000000000000000000',
-				})
-			);
+			expect(JSON.stringify(new Wei(100))).toMatch(/"100.000000000000000000"/);
 		});
 
 		it('serialize and deserialize as new wei', () => {
 			const wei = new Wei(100);
 			const deserialized = JSON.parse(JSON.stringify(wei));
-			const deserializedWei = new Wei(deserialized.value, deserialized.p, true);
+			const deserializedWei = new Wei(deserialized);
 			expect(deserializedWei).toEqual(wei);
 		});
 	});

--- a/packages/wei/src/wei.ts
+++ b/packages/wei/src/wei.ts
@@ -270,10 +270,7 @@ export default class Wei {
 	}
 
 	toJSON() {
-		return {
-			p: this.p,
-			value: this.toString(0, true),
-		};
+		return this.toString();
 	}
 }
 

--- a/packages/wei/src/wei.ts
+++ b/packages/wei/src/wei.ts
@@ -268,6 +268,13 @@ export default class Wei {
 	lte(other: WeiSource): boolean {
 		return this.cmp(other) <= 0;
 	}
+
+	toJSON() {
+		return {
+			p: this.p,
+			value: this.toString(0, true),
+		};
+	}
 }
 
 /** convenience function for not writing `new Wei(s)` every time. */


### PR DESCRIPTION
```
// Example serialization for wei(100)
"100.000000000000000000"
// Example serialization for wei(100, 0, true)
"100"
```