### PR TITLE
Include targetThreshold in WalletDebtData

### DIFF
--- a/packages/queries/src/queries/debt/useGetDebtDataQuery.ts
+++ b/packages/queries/src/queries/debt/useGetDebtDataQuery.ts
@@ -13,6 +13,7 @@ type WalletDebtData = {
 	issuableSynths: Wei;
 	balance: Wei;
 	totalSupply: Wei;
+	targetThreshold: Wei;
 };
 
 const useGetDebtDataQuery = (


### PR DESCRIPTION
`targetThreshold` is returned but missing in type signature