### PR TITLE
updated subgraph url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"react-dom": "17.0.2",
 				"react-query": "3.16.0",
 				"react-test-renderer": "^17.0.2",
-				"synthetix": "2.57.2",
+				"synthetix": "2.58.0-alpha",
 				"web3-utils": "1.2.11"
 			},
 			"devDependencies": {
@@ -21178,9 +21178,9 @@
 			"dev": true
 		},
 		"node_modules/synthetix": {
-			"version": "2.57.2",
-			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.57.2.tgz",
-			"integrity": "sha512-r0BFmyeV50sgr4V6H9GU08VNhZaUTxBAcqhlNkJ29jA2fIw4TmmL+VkqLr/FWWCnhLvj+A4J5dCbjpBK7aO7oQ==",
+			"version": "2.58.0-alpha",
+			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.58.0-alpha.tgz",
+			"integrity": "sha512-Q3jXfpJqmQzIZWzX2HK6PF2c3WtvuJZqzekrQPKYWMzmtAsAWo82EXUtccpjAmdlDPxSjIMiVKPkfRsoHTy8aQ==",
 			"dependencies": {
 				"abi-decoder": "2.3.0",
 				"commander": "8.1.0",
@@ -40985,9 +40985,9 @@
 			"dev": true
 		},
 		"synthetix": {
-			"version": "2.57.2",
-			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.57.2.tgz",
-			"integrity": "sha512-r0BFmyeV50sgr4V6H9GU08VNhZaUTxBAcqhlNkJ29jA2fIw4TmmL+VkqLr/FWWCnhLvj+A4J5dCbjpBK7aO7oQ==",
+			"version": "2.58.0-alpha",
+			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.58.0-alpha.tgz",
+			"integrity": "sha512-Q3jXfpJqmQzIZWzX2HK6PF2c3WtvuJZqzekrQPKYWMzmtAsAWo82EXUtccpjAmdlDPxSjIMiVKPkfRsoHTy8aQ==",
 			"requires": {
 				"abi-decoder": "2.3.0",
 				"commander": "8.1.0",

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -10,11 +10,19 @@ const useGlobalStakingInfoQuery = (
 	ctx: QueryContext,
 	options?: UseQueryOptions<GlobalStakingInfo>
 ) => {
-	const snxHoldersQuery = useGetSNXHolders(ctx.subgraphEndpoints.subgraph, {
-		first: 1000,
-		orderBy: 'collateral',
-		orderDirection: 'desc',
-	});
+	const snxHoldersQuery = useGetSNXHolders(
+		ctx.subgraphEndpoints.subgraph,
+		{
+			first: 1000,
+			orderBy: 'collateral',
+			orderDirection: 'desc',
+		},
+		{
+			collateral: true,
+			debtEntryAtIndex: true,
+			initialDebtOwnership: true,
+		}
+	);
 
 	return useQuery<GlobalStakingInfo>(
 		['staking', 'snxLockedValue', ctx.networkId],

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -10,7 +10,7 @@ const useGlobalStakingInfoQuery = (
 	ctx: QueryContext,
 	options?: UseQueryOptions<GlobalStakingInfo>
 ) => {
-	const snxHoldersQuery = useGetSNXHolders(ctx.subgraphEndpoints.issuance, {
+	const snxHoldersQuery = useGetSNXHolders(ctx.subgraphEndpoints.subgraph, {
 		first: 1000,
 		orderBy: 'collateral',
 		orderDirection: 'desc',

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -45,7 +45,7 @@ const useGlobalStakingInfoQuery = (
 				ctx.snxjs!.contracts.SystemSettings.issuanceRatio(),
 			]);
 
-			const lastDebtLedgerEntry = wei(unformattedLastDebtLedgerEntry, 27);
+			const lastDebtLedgerEntry = wei(unformattedLastDebtLedgerEntry);
 
 			const [totalIssuedSynths, issuanceRatio, usdToSnxPrice] = [
 				unformattedTotalIssuedSynths,

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -4,7 +4,7 @@ import Wei, { wei } from '@synthetixio/wei';
 
 import { QueryContext } from '../../context';
 import { GlobalStakingInfo } from '../../types';
-import { useGetSNXHolders } from '../../../generated/issuanceSubgraphQueries';
+import { useGetSNXHolders } from '../../../generated/mainSubgraphQueries';
 
 const useGlobalStakingInfoQuery = (
 	ctx: QueryContext,
@@ -68,7 +68,7 @@ const useGlobalStakingInfoQuery = (
 					unformattedDebtEntryAtIndex,
 					unformattedInitialDebtOwnership,
 				].map((val) => (!val ? wei(0) : wei(val)));
-
+				debugger;
 				const debtBalance = debtEntryAtIndex.gt(0)
 					? totalIssuedSynths
 							.mul(lastDebtLedgerEntry)

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -18,9 +18,9 @@ const useGlobalStakingInfoQuery = (
 			orderDirection: 'desc',
 		},
 		{
+			initialDebtOwnership: true,
 			collateral: true,
 			debtEntryAtIndex: true,
-			initialDebtOwnership: true,
 		}
 	);
 

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -6,6 +6,9 @@ import { QueryContext } from '../../context';
 import { GlobalStakingInfo } from '../../types';
 import { useGetSNXHolders } from '../../../generated/mainSubgraphQueries';
 
+/**
+ * @deprecated Use useLockedSnxQuery instead
+ */
 const useGlobalStakingInfoQuery = (
 	ctx: QueryContext,
 	options?: UseQueryOptions<GlobalStakingInfo>
@@ -45,7 +48,7 @@ const useGlobalStakingInfoQuery = (
 				ctx.snxjs!.contracts.SystemSettings.issuanceRatio(),
 			]);
 
-			const lastDebtLedgerEntry = wei(unformattedLastDebtLedgerEntry);
+			const lastDebtLedgerEntry = wei(unformattedLastDebtLedgerEntry, 27);
 
 			const [totalIssuedSynths, issuanceRatio, usdToSnxPrice] = [
 				unformattedTotalIssuedSynths,

--- a/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
+++ b/packages/queries/src/queries/staking/useGlobalStakingInfoQuery.ts
@@ -68,7 +68,7 @@ const useGlobalStakingInfoQuery = (
 					unformattedDebtEntryAtIndex,
 					unformattedInitialDebtOwnership,
 				].map((val) => (!val ? wei(0) : wei(val)));
-				debugger;
+
 				const debtBalance = debtEntryAtIndex.gt(0)
 					? totalIssuedSynths
 							.mul(lastDebtLedgerEntry)

--- a/packages/queries/src/queries/staking/useLockedSnxQuery.ts
+++ b/packages/queries/src/queries/staking/useLockedSnxQuery.ts
@@ -1,0 +1,45 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import { useGetSNXHolders } from 'generated/issuanceSubgraphQueries';
+import { QueryContext } from 'src/context';
+import Wei, { wei } from '@synthetixio/wei';
+import { ethers } from 'ethers';
+
+type LockedSnx = {
+	lockedSupply: Wei;
+	lockedValue: Wei;
+};
+const useLockedSnxQuery = (ctx: QueryContext, options?: UseQueryOptions<LockedSnx>) => {
+	const snxHoldersQuery = useGetSNXHolders(
+		ctx.subgraphEndpoints.subgraph,
+		{
+			first: 1000,
+			orderBy: 'collateral',
+			orderDirection: 'desc',
+			where: { initialDebtOwnership_not: 0 },
+		},
+		{
+			initialDebtOwnership: true,
+			collateral: true,
+		}
+	);
+
+	const lockedSupply =
+		snxHoldersQuery.data?.reduce((acc, val) => acc.add(val.collateral || wei(0)), wei(0)) || wei(0);
+
+	return useQuery<LockedSnx>(
+		['staking', 'snxLockedValue', ctx.networkId, lockedSupply.toString()],
+		async () => {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const snxPrice = await ctx.snxjs!.contracts.ExchangeRates.rateForCurrency(
+				ethers.utils.formatBytes32String('SNX')
+			);
+
+			return { lockedSupply, lockedValue: lockedSupply.mul(snxPrice) };
+		},
+		{
+			enabled: ctx.snxjs != null,
+			...options,
+		}
+	);
+};
+export default useLockedSnxQuery;

--- a/packages/queries/src/queries/staking/useLockedSnxQuery.ts
+++ b/packages/queries/src/queries/staking/useLockedSnxQuery.ts
@@ -1,8 +1,8 @@
 import { useQuery, UseQueryOptions } from 'react-query';
-import { useGetSNXHolders } from 'generated/issuanceSubgraphQueries';
 import { QueryContext } from 'src/context';
 import Wei, { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
+import { useGetSNXHolders } from '../../../generated/mainSubgraphQueries';
 
 type LockedSnx = {
 	lockedSupply: Wei;


### PR DESCRIPTION
In staking we only care about lockedValue from `useGlobalStakingInfoQuery`. I depricated that hook and added a simpler `useLockedSnxQuery`.

Also upgrading `codegen-graph-ts`