### PR TITLE
Cache holders query

### DIFF
--- a/packages/queries/src/queries/staking/useSNXData.ts
+++ b/packages/queries/src/queries/staking/useSNXData.ts
@@ -91,12 +91,13 @@ const useSNXData = (
 		],
 		async () => {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const snxPrice = await ctx.snxjs!.contracts.ExchangeRates.rateForCurrency(
+			const snxPriceP = ctx.snxjs!.contracts.ExchangeRates.rateForCurrency(
 				ethers.utils.formatBytes32String('SNX')
 			);
 
-			const totalSNXSupply = wei(await snxJSL1.contracts.Synthetix.totalSupply());
+			const totalSNXSupplyP = snxJSL1.contracts.Synthetix.totalSupply();
 
+			const [snxPrice, totalSNXSupply] = await Promise.all([snxPriceP, totalSNXSupplyP]);
 			if (
 				snxHoldersQueryL1.isSuccess &&
 				snxHoldersQueryL1.data.length > 100 &&
@@ -105,7 +106,7 @@ const useSNXData = (
 			) {
 				const lockedSupply = lockedSupplyL1.add(lockedSupplyL2);
 				return {
-					totalSNXSupply,
+					totalSNXSupply: wei(totalSNXSupply),
 					lockedSupply,
 					lockedValue: lockedSupply.mul(snxPrice),
 				};

--- a/packages/queries/src/queries/staking/useSNXData.ts
+++ b/packages/queries/src/queries/staking/useSNXData.ts
@@ -11,6 +11,8 @@ interface SNXData {
 	lockedValue: Wei;
 	totalSNXSupply: Wei;
 }
+const ONE_HOUR_MS = 1000 * 60 * 60;
+
 const useSNXData = (
 	ctx: QueryContext,
 	L1Provider?: providers.BaseProvider,
@@ -31,6 +33,11 @@ const useSNXData = (
 		},
 		{
 			queryKey: ['L1', 'SNXHoldersL1'],
+			staleTime: ONE_HOUR_MS,
+			cacheTime: ONE_HOUR_MS,
+			refetchOnMount: false,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
 		}
 	);
 
@@ -49,6 +56,11 @@ const useSNXData = (
 		},
 		{
 			queryKey: ['L2', 'SNXHoldersL2'],
+			staleTime: ONE_HOUR_MS,
+			cacheTime: ONE_HOUR_MS,
+			refetchOnMount: false,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
 		}
 	);
 


### PR DESCRIPTION
The two holder queries in this hook will generate 16 request since the graph need to paginate every 1000 items.
The number of holder should be fairly consistent so to avoid sending off 16 request frequently we cache it for one hour and disable refetching.

Also fetch the price and the total supply in parallel



