### PR TITLE
Limit files published to NPM in wei and add src to the published packages

### DIFF
--- a/packages/contracts-interface/package.json
+++ b/packages/contracts-interface/package.json
@@ -8,7 +8,8 @@
 	"browser": "./build/node/src/index.js",
 	"types": "./build/node/src/index.d.ts",
 	"files": [
-		"build"
+		"build",
+		"src"
 	],
 	"scripts": {
 		"build": "node ./codegen.js && npm run build-browser && npm run build-node",

--- a/packages/optimism-networks/package.json
+++ b/packages/optimism-networks/package.json
@@ -8,7 +8,8 @@
 	"browser": "./build/node/index.js",
 	"types": "./build/node/index.d.ts",
 	"files": [
-		"build"
+		"build",
+		"src"
 	],
 	"scripts": {
 		"build": "npm run build-browser && npm run build-node",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -8,7 +8,8 @@
 	"browser": "./build/node/index.js",
 	"types": "./build/node/index.d.ts",
 	"files": [
-		"build"
+		"build",
+		"src"
 	],
 	"scripts": {
 		"build": "npm run build-browser && npm run build-node",

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -8,7 +8,8 @@
 	"browser": "./build/node/src/index.js",
 	"types": "./build/node/src/index.d.ts",
 	"files": [
-		"build"
+		"build",
+		"src"
 	],
 	"scripts": {
 		"build": "npm run codegen && npm run build-node",

--- a/packages/transaction-notifier/package.json
+++ b/packages/transaction-notifier/package.json
@@ -8,7 +8,8 @@
 	"browser": "./build/node/index.js",
 	"types": "./build/node/index.d.ts",
 	"files": [
-		"build"
+		"build",
+		"src"
 	],
 	"scripts": {
 		"build": "npm run build-browser && npm run build-node",

--- a/packages/wei/package.json
+++ b/packages/wei/package.json
@@ -2,11 +2,15 @@
 	"name": "@synthetixio/wei",
 	"version": "2.70.1",
 	"description": "Convenient BigNumber library for web3",
-	"main": "build/node/index.js",
-	"browser": "./build/node/index.js",
-	"module": "./build/node/index.js",
 	"source": "./src/index.ts",
+	"main": "./build/node/index.js",
+	"module": "./build/node/index.js",
+	"browser": "./build/node/index.js",
 	"types": "./build/node/index.d.ts",
+	"files": [
+		"build",
+		"src"
+	],
 	"scripts": {
 		"build": "npm run build-browser && npm run build-node",
 		"build-node": "tsc -p tsconfig.node.json",


### PR DESCRIPTION
Looks like wei was missing `files` limits on what we published so it shipped with a bunch of dev-only files

![image](https://user-images.githubusercontent.com/28145325/171095607-a5aa2a5b-08e6-41cd-a37f-873c01e11f57.png)


Additionally I have added `src` too. We do reference `source` in package.json but do not ship sources.

Generally shipping sources is good, because it gives developers opportunity to adjust bundling and build from our own sources, optimising overall bundle size of the end app.


After the update wei has only necessary files

![image](https://user-images.githubusercontent.com/28145325/171096431-e1c59a38-76c0-44e5-b2aa-d3efd77ea1b5.png)

