### PR TITLE
Ensure we can publish on repeated rebuilds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,19 @@ jobs:
       - run: npm run test
 
       # publish
-      - run: git config --global user.email "ci@cc.snxdao.io" && git config --global user.name "Synthetix CI"
-      - run: git fetch origin ${{ github.head_ref }}
-      - run: echo $(git rev-parse --short origin/${{ github.head_ref }})
-      - run: npm --workspaces version 0.0.0-$(git rev-parse --short origin/${{ github.head_ref }})
+      - name: Populate DEV_VERSION
+        run: |
+          GIT_SHA_FULL="${{ github.sha }}"
+          GIT_SHA="${GIT_SHA_FULL:0:8}"
+          if [ "${{ github.run_attempt }}" == "1" ]; then
+            export DEV_VERSION="0.0.0-$GIT_SHA"
+          else
+            export DEV_VERSION="0.0.0-$GIT_SHA.${{ github.run_attempt }}"
+          fi
+          echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_ENV
+          echo "DEV_VERSION=$DEV_VERSION"
+
+      - run: npm --workspaces version "$DEV_VERSION"
       - run: npm --workspaces publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
If we re-run the same workflow again, because we rely on the same git SHA version we cannot publish new version on NPM.

The fix: append release version with `.${{ github.run_attempt }}` in case it is greater than 1. So for all the one-time runs we still have same 8-char commit sha version like `0.0.0-c69c1461` but in case we manually rerun the workflow we will have versions like `0.0.0-c69c1461.2`

Alternative solution would be to skip publishing entirely on run_attempt > 1 but in that case we may not be able to publish something that could not be published on the initial run (in case of network error or smth). So republishing with extra number seems more robust.

Running smooth:
![image](https://user-images.githubusercontent.com/28145325/171321668-c4ab4582-4039-43a7-a604-8d561a98b401.png)


And the repeated build worked as expected too:
![image](https://user-images.githubusercontent.com/28145325/171322114-0ebe2b60-4e60-4dab-87e8-dab6f901a80b.png)
