### PR TITLE
Skip git tagging when updating npm version

### DIFF
--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Update packages version
         run: |
-          npm --workspaces version ${{ env.NEW_VERSION }} --include-workspace-root
+          npm --workspaces version ${{ env.NEW_VERSION }} --include-workspace-root --git-tag-version=false
 
       - name: Create git tag and commit changes
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "root",
-	"version": "2.71.0",
+	"version": "2.71.0-1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "root",
-			"version": "2.71.0",
+			"version": "2.71.0-1",
 			"workspaces": [
 				"packages/contracts-interface",
 				"packages/optimism-networks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "root",
-	"version": "2.71.0",
+	"version": "2.71.0-1",
 	"workspaces": [
 		"packages/contracts-interface",
 		"packages/optimism-networks",

--- a/packages/contracts-interface/package.json
+++ b/packages/contracts-interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/contracts-interface",
-	"version": "2.71.0",
+	"version": "2.71.0-1",
 	"description": "A library for interacting with Synthetix smart contracts",
 	"source": "./src/index.ts",
 	"main": "./build/node/src/index.js",

--- a/packages/optimism-networks/package.json
+++ b/packages/optimism-networks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/optimism-networks",
-	"version": "2.70.1",
+	"version": "2.71.0-1",
 	"description": "Javascript library for handling networks on Optimism Layer 2",
 	"source": "./src/index.ts",
 	"main": "./build/node/index.js",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/providers",
-	"version": "2.71.0",
+	"version": "2.71.0-1",
 	"description": "Javascript library for handling providers on Layer 1 & Optimism Layer 2",
 	"source": "./src/index.ts",
 	"main": "./build/node/index.js",

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/queries",
-	"version": "2.71.0",
+	"version": "2.71.0-1",
 	"description": "react-query for pulling synthetix data in react interfaces",
 	"source": "./src/index.ts",
 	"main": "./build/node/src/index.js",

--- a/packages/transaction-notifier/package.json
+++ b/packages/transaction-notifier/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/transaction-notifier",
-	"version": "2.70.1",
+	"version": "2.71.0-1",
 	"description": "Javascript library for handling networks on Optimism Layer 2",
 	"source": "./src/index.ts",
 	"main": "./build/node/index.js",

--- a/packages/wei/package.json
+++ b/packages/wei/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@synthetixio/wei",
-	"version": "2.70.1",
+	"version": "2.71.0-1",
 	"description": "Convenient BigNumber library for web3",
 	"source": "./src/index.ts",
 	"main": "./build/node/index.js",


### PR DESCRIPTION
Looks like npm created a tag already

![image](https://user-images.githubusercontent.com/28145325/171334091-9c0d194b-c22c-49e7-abd5-21f2be570f2c.png)

Running workflow on the branch Was successful after the fix https://github.com/Synthetixio/js-monorepo/runs/6683351414?check_suite_focus=true

![image](https://user-images.githubusercontent.com/28145325/171334892-0287ee2e-61d0-408a-8986-2e636217bfe7.png)


All the versions were updated and commit + tag were pushed OK 
![image](https://user-images.githubusercontent.com/28145325/171335331-f61e3584-6c6c-4f98-a1ea-b68e1fad804d.png)
