### PR TITLE
FIX for missing maxibon

### DIFF
--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -46,13 +46,13 @@
 		"ethers": "5.5.3",
 		"graphql": "15.5.0",
 		"graphql-request": "3.4.0",
-		"lodash": "^4.17.21"
+		"lodash": "^4.17.21",
+		"maxibon-codegen-graph-ts": "0.2.0"
 	},
 	"devDependencies": {
 		"@testing-library/react-hooks": "^7.0.0",
 		"@types/lodash": "4.14.169",
 		"@types/react": "^17.0.11",
-		"maxibon-codegen-graph-ts": "0.2.0",
 		"react": "17.0.2",
 		"react-dom": "17.0.2",
 		"react-query": "3.16.0",


### PR DESCRIPTION
Looks like codegen injects this dependency


![image](https://user-images.githubusercontent.com/28145325/171578126-ded1de7e-6142-40a2-a6ed-27ed021015aa.png)

![image](https://user-images.githubusercontent.com/28145325/171577811-8cb51ff8-6f4e-4b56-b3a8-616089e80bd3.png)
