### PR TITLE
Use synths balances query type fix

### DIFF
--- a/packages/queries/src/queries/walletBalances/useSynthsBalancesQuery.ts
+++ b/packages/queries/src/queries/walletBalances/useSynthsBalancesQuery.ts
@@ -17,9 +17,13 @@ const useSynthsBalancesQuery = (
 	return useQuery<Balances>(
 		['walletBalances', 'synths', ctx.networkId, walletAddress],
 		async () => {
-			const balancesMap: Partial<SynthBalancesMap> = {};
-			const [currencyKeys, synthsBalances, synthsUSDBalances] =
-				(await ctx.snxjs!.contracts.SynthUtil!.synthsBalances(walletAddress)) as SynthBalancesTuple;
+			if (!ctx.snxjs) {
+				// This should never happen since the query is not enabled when ctx.snxjs is undefined
+				throw Error('ctx.snxjs is undefined');
+			}
+			const balancesMap: SynthBalancesMap = {};
+			const [currencyKeys, synthsBalances, synthsUSDBalances]: SynthBalancesTuple =
+				await ctx.snxjs.contracts.SynthUtil.synthsBalances(walletAddress);
 
 			let totalUSDBalance = wei(0);
 

--- a/packages/queries/src/queries/walletBalances/useSynthsBalancesQuery.ts
+++ b/packages/queries/src/queries/walletBalances/useSynthsBalancesQuery.ts
@@ -7,7 +7,7 @@ import { CurrencyKey } from '@synthetixio/contracts-interface';
 import { QueryContext } from '../../context';
 import { Balances, SynthBalancesMap } from '../../types';
 
-type SynthBalancesTuple = [CurrencyKey[], ethers.BigNumber[], ethers.BigNumber[]];
+type SynthBalancesTuple = [string[], ethers.BigNumber[], ethers.BigNumber[]];
 
 const useSynthsBalancesQuery = (
 	ctx: QueryContext,
@@ -27,12 +27,12 @@ const useSynthsBalancesQuery = (
 
 			let totalUSDBalance = wei(0);
 
-			currencyKeys.forEach((currencyKey: string, idx: number) => {
+			currencyKeys.forEach((currencyKeyBytes32, idx) => {
 				const balance = wei(synthsBalances[idx]);
 
 				// discard empty balances
 				if (balance.gt(0)) {
-					const synthName = ethers.utils.parseBytes32String(currencyKey) as CurrencyKey;
+					const synthName = ethers.utils.parseBytes32String(currencyKeyBytes32) as CurrencyKey;
 					const usdBalance = wei(synthsUSDBalances[idx]);
 
 					balancesMap[synthName] = {

--- a/packages/queries/src/queries/walletBalances/useSynthsBalancesQuery.ts
+++ b/packages/queries/src/queries/walletBalances/useSynthsBalancesQuery.ts
@@ -1,11 +1,11 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import { ethers } from 'ethers';
 import orderBy from 'lodash/orderBy';
-import Wei, { wei } from '@synthetixio/wei';
+import { wei } from '@synthetixio/wei';
 
 import { CurrencyKey } from '@synthetixio/contracts-interface';
 import { QueryContext } from '../../context';
-import { Balances, SynthBalance, SynthBalancesMap } from '../../types';
+import { Balances, SynthBalancesMap } from '../../types';
 
 type SynthBalancesTuple = [CurrencyKey[], ethers.BigNumber[], ethers.BigNumber[]];
 
@@ -46,10 +46,10 @@ const useSynthsBalancesQuery = (
 			});
 
 			return {
-				balancesMap: balancesMap as SynthBalancesMap,
+				balancesMap: balancesMap,
 				balances: orderBy(
-					Object.values(balancesMap as SynthBalancesMap),
-					(balance: SynthBalance) => balance.usdBalance.toNumber(),
+					Object.values(balancesMap),
+					(balance) => balance.usdBalance.toNumber(),
 					'desc'
 				),
 				totalUSDBalance,

--- a/packages/queries/src/types.ts
+++ b/packages/queries/src/types.ts
@@ -70,7 +70,7 @@ export type SynthBalance = {
 	usdBalance: Wei;
 };
 
-export type SynthBalancesMap = Record<CurrencyKey, SynthBalance>;
+export type SynthBalancesMap = { [key in CurrencyKey]?: SynthBalance };
 
 export type Balances = {
 	balancesMap: SynthBalancesMap;


### PR DESCRIPTION
The `BalanceMap` will only have synths keys for synths that have a balance greater than 0.

Previously typescript would not complain if you did:
`useSynthsBalancesQuery().data?.balancesMap.sUSD.balance`
But if your balance is 0 this would be a runtime error.

The correct usage to get the balance. and now enforced by typescript:
`useSynthsBalancesQuery().data?.balancesMap.sUSD?.balance`

I also made some other improvement, minimising `as` and `!` and correct return type for `SynthUtil.synthsBalances`