### PR TITLE
Dependencies audit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
 
       - run: yarn install --immutable
 
+      - run: yarn npm audit --recursive --severity=critical
+
       - run: yarn deps
       - run: yarn deps:mismatched
       - run: yarn deps:circular


### PR DESCRIPTION
Fail the build on any critical vulns found

For comparison check with `high` severity fails

![image](https://user-images.githubusercontent.com/28145325/172537010-ea346f59-57fb-4627-b8e0-b3350eea59c1.png)
