### PR TITLE
Add @synthetixio/safe-import

### DIFF
--- a/tools/safe-import/.eslintrc
+++ b/tools/safe-import/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"@typescript-eslint/no-var-requires": "off"
+	}
+}

--- a/tools/safe-import/index.js
+++ b/tools/safe-import/index.js
@@ -1,0 +1,6 @@
+const { safeLazy } = require('./safeLazy');
+const { safeImport } = require('./safeImport');
+module.exports = {
+	safeLazy,
+	safeImport,
+};

--- a/tools/safe-import/package.json
+++ b/tools/safe-import/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@synthetixio/safe-import",
+	"publishConfig": {
+		"access": "public"
+	},
+	"main": "index.js",
+	"files": [
+		"./*.js"
+	],
+	"version": "1.0.0",
+	"author": "Nikita <noisekit@btnk.au>",
+	"repository": "github:Synthetixio/js-monorepo",
+	"license": "MIT",
+	"dependencies": {
+		"react": "^17.0.2"
+	}
+}

--- a/tools/safe-import/safeImport.js
+++ b/tools/safe-import/safeImport.js
@@ -1,0 +1,24 @@
+/* global document */
+
+async function timeout(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function safeImport(importer, { RETRY_DELAY = 2000, RETRY_LIMIT = 10 } = {}) {
+	for (let step = 0; step < RETRY_LIMIT; step++) {
+		try {
+			return await importer();
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.error(error);
+			await timeout(RETRY_DELAY);
+		}
+	}
+
+	// We went over the limit, did not return the import result successfully so need a full reload
+	document.location.reload();
+}
+
+module.exports = {
+	safeImport,
+};

--- a/tools/safe-import/safeLazy.js
+++ b/tools/safe-import/safeLazy.js
@@ -1,0 +1,10 @@
+const { lazy } = require('react');
+const { safeImport } = require('./safeImport');
+
+function safeLazy(importer) {
+	return lazy(() => safeImport(importer));
+}
+
+module.exports = {
+	safeLazy,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,6 +2405,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@synthetixio/safe-import@workspace:tools/safe-import":
+  version: 0.0.0-use.local
+  resolution: "@synthetixio/safe-import@workspace:tools/safe-import"
+  dependencies:
+    react: ^17.0.2
+  languageName: unknown
+  linkType: soft
+
 "@synthetixio/transaction-notifier@workspace:packages/transaction-notifier":
   version: 0.0.0-use.local
   resolution: "@synthetixio/transaction-notifier@workspace:packages/transaction-notifier"


### PR DESCRIPTION
When using async chunks we need to ensure chunks are getting re-fetched in case of any network errors.

Currently if any of the chunks failed to load - whole app crashed until page refresh. With this lib we will pull the chunk over and over until it loads (or reload the page after limit reached)

This will enable us to proceed with async chunk loading (safely) in the Staking app

Usage example (works together with `Suspense`):
```js
import {safeLazy} from '@synthetixio/safe-import';

const Profile = safeLazy(() => import(/* webpackChunkName: "profile" */ './Profile'));

function App() {
  return (
    <Suspense fallback={<Loader />}>
      <Profile />
    </Suspense>
  );
}
```



Updated in `staking`

```js
import { safeLazy } from '@synthetixio/safe-import';
const StakedValue = safeLazy(
	() =>
		import(
			/* webpackChunkName: "dashboard" */ '../sections/shared/modals/StakedValueModal/StakedValueBox'
		)
);
```

Blocked and unblocked after 4 attempts - loaded fine

![image](https://user-images.githubusercontent.com/28145325/175856914-9a4e002f-5276-408f-aa50-06107aa434b3.png)
