### PR TITLE
Fix notifying apps

### DIFF
--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Notify dApps
         run: |
-          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"ref\": \"dev\", \"inputs\": {\"monorepo_version\": \"${{ env.NEW_VERSION }}\"}}" https://api.github.com/repos/Synthetixio/staking/actions/workflows/updateDependency.yml/dispatches
-          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"ref\": \"develop\", \"inputs\": {\"monorepo_version\": \"${{ env.NEW_VERSION }}\"}}" https://api.github.com/repos/Synthetixio/futures-keepers/actions/workflows/updateDependency.yml/dispatches
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"ref\": \"dev\"}" https://api.github.com/repos/Synthetixio/staking/actions/workflows/updateDependency.yml/dispatches
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"ref\": \"develop\"}" https://api.github.com/repos/Synthetixio/futures-keepers/actions/workflows/updateDependency.yml/dispatches
           curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.NEW_VERSION }}\"}}" https://api.github.com/repos/Kwenta/kwenta/dispatches
           curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.NEW_VERSION }}\"}}" https://api.github.com/repos/Kwenta/kwenta-api/dispatches

--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -82,5 +82,3 @@ jobs:
         run: |
           curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"ref\": \"dev\"}" https://api.github.com/repos/Synthetixio/staking/actions/workflows/updateDependency.yml/dispatches
           curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"ref\": \"develop\"}" https://api.github.com/repos/Synthetixio/futures-keepers/actions/workflows/updateDependency.yml/dispatches
-          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.NEW_VERSION }}\"}}" https://api.github.com/repos/Kwenta/kwenta/dispatches
-          curl -H "Authorization: token ${{ secrets.GH_TOKEN_DAPPS }}" --request POST --data "{\"event_type\": \"update-dependency\", \"client_payload\": {\"version\": \"${{ env.NEW_VERSION }}\"}}" https://api.github.com/repos/Kwenta/kwenta-api/dispatches


### PR DESCRIPTION
I think the update dependency broke when we stopped listening to versions in the apps being notified.
This run:
https://github.com/Synthetixio/js-monorepo/runs/7031864303?check_suite_focus=true
Never made it to staking:
https://github.com/Synthetixio/staking/actions/workflows/updateDependency.yml

I also stopped notifying Kwenta's repos since they dont seem to rely on it for upgrading