### PR TITLE
Trezor requires value to be defined

### DIFF
--- a/packages/queries/src/mutations/useContractTxn.ts
+++ b/packages/queries/src/mutations/useContractTxn.ts
@@ -18,6 +18,7 @@ const useContractTxn = (
 			{
 				to: contract.address,
 				data: contract.interface.encodeFunctionData(method, args),
+				value: txnOptions.value || ethers.BigNumber.from(0),
 				...txnOptions,
 			},
 			options


### PR DESCRIPTION
Most wallets are fine with having `value` on a transaction be undefined. Trezor requires us to pass 0. 