### PR TITLE
Allow depcheck config override per packages

### DIFF
--- a/tools/deps/deps.js
+++ b/tools/deps/deps.js
@@ -17,7 +17,6 @@ const options = {
   skipMissing: false, // skip calculation of missing dependencies
   ignorePatterns: [
     // files matching these patterns will be ignored
-    'dist',
     'build',
     'generated',
     'coverage',
@@ -64,6 +63,7 @@ async function run() {
 
     const { dependencies, devDependencies, missing } = await depcheck(location, {
       ...options,
+      ...packageJson.depcheck,
       package: packageJson,
     });
 

--- a/v3/ui/package.json
+++ b/v3/ui/package.json
@@ -51,5 +51,13 @@
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.3"
+  },
+  "depcheck": {
+    "ignorePatterns": [
+      "dist"
+    ],
+    "ignoreMatches": [
+      "webpack-dev-server"
+    ]
   }
 }


### PR DESCRIPTION
Now possible to override config in package.json directly.
This is essential for `staking` -> `v2/ui` migration as there are quite a few overrides necessary