### PR TITLE
Publishing

### DIFF
--- a/.github/workflows/publishSinglePackage.yml
+++ b/.github/workflows/publishSinglePackage.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - run: yarn workspaces focus '${{ github.event.inputs.package }}'
+      - run: yarn install --immutable
 
       - name: Config git identity
         run: |

--- a/.github/workflows/publishSinglePackage.yml
+++ b/.github/workflows/publishSinglePackage.yml
@@ -8,8 +8,8 @@ on:
         required: true
 
       version:
-        description: 'Package version (defaults to `patch`)'
-        default: 'patch'
+        description: 'Package version (defaults to `prerelease`)'
+        default: 'prerelease'
         required: false
 
 jobs:

--- a/tools/deps/version.js
+++ b/tools/deps/version.js
@@ -49,10 +49,31 @@ async function run() {
     await exec(`yarn workspace ${name} version --deferred ${version}`);
 
     for await (const pkg of cascade[name]) {
-      console.log(
-        `${fgCyan}Bumping dependency ${fgGreen}${pkg}${fgCyan} to ${fgYellow}patch${fgReset}`
-      );
-      await exec(`yarn workspace ${pkg} version --deferred patch`);
+      switch (true) {
+        // When publishing exact version like `1.2.3`, update all dependent packages with `patch` strategy
+        case /^\d+\.\d+\.\d+$/.test(version):
+        // Use `patch` strategy for any other full release
+        case ['major', 'minor', 'patch'].includes(version): {
+          console.log(
+            `${fgCyan}Bumping dependency ${fgGreen}${pkg}${fgCyan} to ${fgYellow}patch${fgReset}`
+          );
+          await exec(`yarn workspace ${pkg} version --deferred patch`);
+          break;
+        }
+
+        // When publishing pre-release version like `1.2.3-whatever`, update all dependent packages with `prerelease` strategy
+        case /^\d+\.\d+\.\d+-.+$/.test(version):
+        // Same for `prerelease`
+        case ['prerelease'].includes(version):
+        // And for any other unknown case
+        default: {
+          console.log(
+            `${fgCyan}Bumping dependency ${fgGreen}${pkg}${fgCyan} to ${fgYellow}prerelease${fgReset}`
+          );
+          await exec(`yarn workspace ${pkg} version --deferred prerelease`);
+          break;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
1. Default to `prerelease` strategy (safer)
2. Update cascade to `prerelease` or `patch` depending on the intended parent package version
3. As we operate on inversed dependency tree, it is necessary to install all dependencies and not focus workspace

<img width="1053" alt="Screen Shot 2022-08-26 at 13 10 23" src="https://user-images.githubusercontent.com/28145325/186830494-4699c6b0-44ac-4d17-b20d-4ffdb421accb.png">

<img width="1035" alt="Screen Shot 2022-08-26 at 13 10 31" src="https://user-images.githubusercontent.com/28145325/186830528-e9e6ebf5-53e8-4ef7-b783-180f5d657943.png">



```sh
yarn deps:version @synthetixio/wei prerelease
yarn version apply --all

~/syn/js
➜ git st
## publishing...origin/publishing
 M packages/queries/package.json
 M packages/wei/package.json
 M tools/codegen-graph-ts/package.json
 M tools/generate-subgraph-query/package.json
```

the diff has "pre-release" versions for all involved packages:

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/28145325/186830941-58c70835-0988-4bd4-bbf5-8b8f5e68058a.png">

