### PR TITLE
Export subgraphs

### DIFF
--- a/packages/queries/src/index.ts
+++ b/packages/queries/src/index.ts
@@ -152,3 +152,4 @@ export * from './abis/ERC20';
 
 export * from './constants';
 export * from './queries/gov/constants';
+export * from './subgraph/mainSubgraphQueries';


### PR DESCRIPTION
- This will help stop consumers of this lib doing deep imports