### PR TITLE
Amount is not passed in to the title

### DIFF
--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -207,7 +207,7 @@
     "actions": {
       "title": "Possible Actions",
       "claim": {
-        "title": "CLAIM {{amount}} SNX",
+        "title": "CLAIM SNX",
         "copy": "Claim your staking rewards before the end of this epoch",
         "copy-liquidation": "Claim your liquidation rewards",
         "tooltip": "No rewards to claim"


### PR DESCRIPTION
For some reason the new https://snx-v2.vercel.app/  have translations behaving a bit different.
The old setup would ignore template values if they weren't passed in. With the new setup it gets rendered like this:
<img width="279" alt="Screen Shot 2022-09-05 at 8 44 03 pm" src="https://user-images.githubusercontent.com/5688912/188431847-786bbc8a-081a-489d-83cf-166973975d07.png">


These are the only places `claim.title` is used:
https://github.com/Synthetixio/js-monorepo/blob/fix-claim-tile/v2/ui/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.tsx#L27
https://github.com/Synthetixio/js-monorepo/blob/fix-claim-tile/v2/ui/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.tsx#L42

So I just removed the template value