### PR TITLE
Add tooltip to balance box

### DIFF
--- a/v2/components/BalanceBox/BalanceBox.tsx
+++ b/v2/components/BalanceBox/BalanceBox.tsx
@@ -19,7 +19,7 @@ export const BalanceBox = ({
         <Text fontFamily="heading" fontWeight="extrabold" lineHeight="md" fontSize="xs" mr={1.5}>
           {t('staking-v2.balance-box.heading')}
         </Text>
-        <Tooltip label="Soonthetix" hasArrow>
+        <Tooltip label={t('staking-v2.balance-box.heading-tooltip')} hasArrow>
           <Center>
             <InfoIcon width="10px" height="10px" />
           </Center>

--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -40,6 +40,7 @@
     },
     "balance-box": {
       "heading": "My Balances",
+      "heading-tooltip": "Here you can find you SNX balance. How much you have staked and much is available to your disposal",
       "box-heading": "SNX Total",
       "staked": "Staked",
       "transferable": "Transferable"


### PR DESCRIPTION
Missed that darda had updated this
<img width="442" alt="image" src="https://user-images.githubusercontent.com/5688912/189016905-f8604c00-0c85-41f3-b8d2-a4ae9e4f01b3.png">
