### PR TITLE
Correct balance translation

### DIFF
--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -1276,7 +1276,7 @@
       "no-wallet-connected": "No wallet connected",
       "unsupported-network": "Unsupported Network",
       "switch-to-supported": "Switch to a supported network:",
-      "balance": "Balance: {{balance}}",
+      "balance": "Balance:",
       "transferable": "<0>Transferable</0> {{transferable}}",
       "not-connected": "Not connected",
       "or": "or",


### PR DESCRIPTION
Fixes this:
![Screen Shot 2022-09-09 at 2 52 30 pm](https://user-images.githubusercontent.com/5688912/189274490-455e5b2a-bfd7-403d-86af-3cd00572eb56.png)
Balance is not passed in to translation: 
https://github.com/Synthetixio/js-monorepo/blob/fix-balance-transaltion/v2/ui/sections/staking/components/StakingInput/StakingInput.tsx#L305