### PR TITLE
Minify production build and avoid eval devtool

### DIFF
--- a/v2/ui/package.json
+++ b/v2/ui/package.json
@@ -149,6 +149,7 @@
     "react-refresh": "^0.14.0",
     "remarkable-external-link": "^1.1.0",
     "stream-browserify": "^3.0.0",
+    "terser-webpack-plugin": "^5.3.6",
     "typescript": "^4.8.2",
     "webpack": "^5.74.0",
     "webpack-bundle-analyzer": "^4.6.1",

--- a/v2/ui/webpack.config.js
+++ b/v2/ui/webpack.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const generate = require('./scripts/minify-synthetix-contract');
 
@@ -113,7 +114,7 @@ const devServer = {
 };
 
 module.exports = {
-  devtool: 'eval',
+  devtool: isProd ? 'source-map' : 'eval',
   devServer,
   mode: isProd ? 'production' : 'development',
   entry: './index.ts',
@@ -131,10 +132,16 @@ module.exports = {
     runtimeChunk: false,
     splitChunks: {
       chunks: 'async',
+      maxAsyncRequests: 10,
+      maxInitialRequests: 10,
+      hidePathInfo: true,
+      automaticNameDelimiter: '--',
+      name: false,
     },
-    moduleIds: 'deterministic',
-    chunkIds: 'deterministic',
+    moduleIds: isProd ? 'deterministic' : 'named',
+    chunkIds: isProd ? 'deterministic' : 'named',
     minimize: isProd,
+    minimizer: [new TerserPlugin()],
     innerGraph: true,
     emitOnErrors: false,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,16 +1750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.18.9
-  resolution: "@babel/runtime@npm:7.18.9"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: 36dd736baba7164e82b3cc9d43e081f0cb2d05ff867ad39cac515d99546cee75b7f782018b02a3dcf5f2ef3d27f319faa68965fdfec49d4912c60c6002353a2e
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.7.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.19.0
   resolution: "@babel/runtime@npm:7.19.0"
   dependencies:
@@ -8139,6 +8130,7 @@ __metadata:
     styled-components: ^5.3.5
     styled-media-query: ^2.1.2
     synthetix: ^2.76.1
+    terser-webpack-plugin: ^5.3.6
     tippy.js: ^6.3.1
     typescript: ^4.8.2
     unstated-next: ^1.1.0
@@ -31884,9 +31876,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.0.3, terser-webpack-plugin@npm:^5.1.3, terser-webpack-plugin@npm:^5.3.3":
-  version: 5.3.4
-  resolution: "terser-webpack-plugin@npm:5.3.4"
+"terser-webpack-plugin@npm:^5.0.3, terser-webpack-plugin@npm:^5.1.3, terser-webpack-plugin@npm:^5.3.3, terser-webpack-plugin@npm:^5.3.6":
+  version: 5.3.6
+  resolution: "terser-webpack-plugin@npm:5.3.6"
   dependencies:
     "@jridgewell/trace-mapping": ^0.3.14
     jest-worker: ^27.4.5
@@ -31902,7 +31894,7 @@ __metadata:
       optional: true
     uglify-js:
       optional: true
-  checksum: 37f65cf0a3fd24c7ce48268e387e50d3315136c9afd27952e1c299995a951aa61c0d34d8eb07cf2eb667078176b5e0d56e7f7400b09984eaa74712d0c1e39203
+  checksum: 8f3448d7fdb0434ce6a0c09d95c462bfd2f4a5a430233d854163337f734a7f5c07c74513d16081e06d4ca33d366d5b1a36f5444219bc41a7403afd6162107bad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Current staging has dev build, that is not minified and uses eval sourcemap

![image](https://user-images.githubusercontent.com/28145325/190062419-e3799349-987b-4e35-ab3b-7b84738a289a.png)
