### PR TITLE
Inject custom Provider and Signer before app starts up

### DIFF
--- a/v2/cypress/cypress/support/e2e.js
+++ b/v2/cypress/cypress/support/e2e.js
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 beforeEach(() => {
   cy.intercept('https://analytics.synthetix.io/matomo.js', { statusCode: 204 }).as('matomo');
 
@@ -13,7 +15,49 @@ beforeEach(() => {
     });
   }).as('graphql');
 
-  cy.window().then((w) => {
-    w.localStorage.UNSAFE_IMPORT = 'true';
+  cy.on('window:before:load', (win) => {
+    win.localStorage.setItem('UNSAFE_IMPORT', 'true');
+    win.localStorage.setItem('selectedWallet', '["MetaMask"]');
+
+    class Signer {
+      constructor(provider) {
+        this._isSigner = true;
+        this.getAddress = async () => Cypress.env('WALLET_ADDRESS');
+        this.provider = provider;
+        this.wallet = ethers.Wallet.fromMnemonic(Cypress.env('WALLET_MNEMONIC'));
+        this.signMessage = (message) => this.wallet.signMessage(message);
+      }
+    }
+
+    win.ethereum = new Proxy(
+      new ethers.providers.JsonRpcProvider(Cypress.env('TENDERLY_RPC_URL')),
+      {
+        get(target, prop, _receiver) {
+          switch (prop) {
+            case 'isMetaMask':
+              return true;
+
+            case 'getSigner':
+              return () => new Signer(win.ethereum);
+
+            case 'request':
+              return async ({ method, params }) => {
+                switch (method) {
+                  case 'eth_accounts':
+                  case 'eth_requestAccounts':
+                    return [Cypress.env('WALLET_ADDRESS')];
+                  case 'eth_chainId':
+                    return '0x1';
+                  default:
+                    return await target.send(method, params);
+                }
+              };
+
+            default:
+              return target[prop];
+          }
+        },
+      }
+    );
   });
 });

--- a/v2/cypress/cypress/support/e2e.js
+++ b/v2/cypress/cypress/support/e2e.js
@@ -46,8 +46,6 @@ beforeEach(() => {
                   case 'eth_accounts':
                   case 'eth_requestAccounts':
                     return [Cypress.env('WALLET_ADDRESS')];
-                  case 'eth_chainId':
-                    return '0x1';
                   default:
                     return await target.send(method, params);
                 }

--- a/v2/cypress/package.json
+++ b/v2/cypress/package.json
@@ -21,6 +21,7 @@
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
     "cypress": "^10.8.0",
+    "ethers": "^5.5.3",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "webpack": "^5.74.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6270,6 +6270,7 @@ __metadata:
     buffer: ^6.0.3
     crypto-browserify: ^3.12.0
     cypress: ^10.8.0
+    ethers: ^5.5.3
     process: ^0.11.10
     stream-browserify: ^3.0.0
     webpack: ^5.74.0


### PR DESCRIPTION
No actual test changes in this PR. Just a prep. But after opening home page it is possible to click around and get txns signed automatically

These ENVs are required before running:
```sh
export CYPRESS_TENDERLY_RPC_URL=""
export CYPRESS_WALLET_ADDRESS=""
export CYPRESS_WALLET_MNEMONIC=""
```

NOTE: for development it is convenient to work with single wallet on the same fork for easy debugging. To run in CI we will create fork automatically, generate and fund wallet, set ENVs, perform tests and kill the fork afterwards.

# getting a loan
![auto-wallet in cypress](https://user-images.githubusercontent.com/28145325/191417590-2bb4ad74-37ce-43c1-9738-85be8e3ffc8b.gif)

# claiming closed loan eth
![auto-wallet in cypress - claim](https://user-images.githubusercontent.com/28145325/191417648-b9f53a06-791f-486e-bfc8-f3981e50e709.gif)

# minting susd
![auto-wallet in cypress - minting](https://user-images.githubusercontent.com/28145325/191417670-82d6bfa0-2e46-4535-ba99-1280cfe86749.gif)
