### PR TITLE
Self liquidation

### DIFF
--- a/v2/components/SelfLiquidation/SelfLiquidation.tsx
+++ b/v2/components/SelfLiquidation/SelfLiquidation.tsx
@@ -1,0 +1,65 @@
+/* The designs for this disappeared, I still think we should have a page for this, so just committing this unstyled page displaying the data */
+
+import { formatNumber, formatPercent } from '@snx-v2/formatters';
+import { FC } from 'react';
+import { Text, Box, SkeletonText, Heading, Flex } from '@chakra-ui/react';
+import { InfoIcon } from '@snx-v2/icons';
+import { useSelfLiquidationData } from '../../lib/useSelfLiquidationData';
+import { useDebtData } from '@snx-v2/useDebtData';
+
+export const SelfLiquidationUi: FC<{
+  selfLiquidationPenalty?: number;
+  selfLiquidationPenaltySNX?: number;
+  selfLiquidationPenaltyDollar?: number;
+  targetCRatioPercentage?: number;
+}> = ({
+  selfLiquidationPenalty,
+  selfLiquidationPenaltySNX,
+  targetCRatioPercentage,
+  selfLiquidationPenaltyDollar,
+}) => {
+  return (
+    <Box>
+      <Heading>
+        Unflag my Yes, I want to Self Liquidate and incur{' '}
+        {selfLiquidationPenalty ? formatPercent(selfLiquidationPenalty) : '0%'}
+      </Heading>
+      <Text>
+        Penalty Opting to Self Liquidate incurs a{' '}
+        {selfLiquidationPenalty ? formatPercent(selfLiquidationPenalty) : '0%'}
+        Penalty on your Staked SNX in order to bring your Ratio back to the Target Ratio of{' '}
+        {targetCRatioPercentage ? formatPercent(targetCRatioPercentage) : '0%'}
+      </Text>
+      <Flex>
+        <Flex flexDirection="column">
+          <Text>
+            20% SelfLiquidation penalty <InfoIcon />
+          </Text>
+          <Text>{selfLiquidationPenaltySNX ? formatNumber(selfLiquidationPenaltySNX) : 0}</Text>
+        </Flex>
+        <Flex flexDirection="column">
+          <Text>
+            Penalty Value in USD <InfoIcon />
+          </Text>
+          <Text>
+            {selfLiquidationPenaltyDollar ? formatNumber(selfLiquidationPenaltyDollar) : 0}
+          </Text>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};
+export const SelfLiquidation = () => {
+  const { data: selfLiquidationData } = useSelfLiquidationData();
+  const { data: debtData } = useDebtData();
+  return (
+    <SkeletonText isLoaded={Boolean(selfLiquidationData && debtData)}>
+      <SelfLiquidationUi
+        selfLiquidationPenaltyDollar={selfLiquidationData?.selfLiquidationPenaltyDollar.toNumber()}
+        selfLiquidationPenalty={selfLiquidationData?.selfLiquidationPenalty.toNumber()}
+        selfLiquidationPenaltySNX={selfLiquidationData?.selfLiquidationPenaltySNX.toNumber()}
+        targetCRatioPercentage={debtData?.targetCRatioPercentage.toNumber()}
+      />
+    </SkeletonText>
+  );
+};

--- a/v2/components/SelfLiquidation/SelfLiquidation.tsx
+++ b/v2/components/SelfLiquidation/SelfLiquidation.tsx
@@ -4,7 +4,7 @@ import { formatNumber, formatPercent } from '@snx-v2/formatters';
 import { FC } from 'react';
 import { Text, Box, SkeletonText, Heading, Flex } from '@chakra-ui/react';
 import { InfoIcon } from '@snx-v2/icons';
-import { useSelfLiquidationData } from '../../lib/useSelfLiquidationData';
+import { useSelfLiquidationData } from '@snx-v2/useSelfLiquidationData';
 import { useDebtData } from '@snx-v2/useDebtData';
 
 export const SelfLiquidationUi: FC<{

--- a/v2/components/SelfLiquidation/index.ts
+++ b/v2/components/SelfLiquidation/index.ts
@@ -1,0 +1,1 @@
+export * from './SelfLiquidation';

--- a/v2/components/SelfLiquidation/package.json
+++ b/v2/components/SelfLiquidation/package.json
@@ -8,6 +8,7 @@
     "@snx-v2/formatters": "workspace:*",
     "@snx-v2/icons": "workspace:*",
     "@snx-v2/useDebtData": "workspace:*",
+    "@snx-v2/useSelfLiquidationData": "workspace:*",
     "react": "^18.2.0"
   }
 }

--- a/v2/components/SelfLiquidation/package.json
+++ b/v2/components/SelfLiquidation/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@snx-v2/SelfLiquidation",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.0",
+  "dependencies": {
+    "@chakra-ui/react": "^2.2.8",
+    "@snx-v2/formatters": "workspace:*",
+    "@snx-v2/icons": "workspace:*",
+    "@snx-v2/useDebtData": "workspace:*",
+    "react": "^18.2.0"
+  }
+}

--- a/v2/lib/useSelfLiquidationData/index.ts
+++ b/v2/lib/useSelfLiquidationData/index.ts
@@ -1,0 +1,1 @@
+export * from './useSelfLiquidationData';

--- a/v2/lib/useSelfLiquidationData/package.json
+++ b/v2/lib/useSelfLiquidationData/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@snx-v2/useSelfLiquidationData",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.0",
+  "dependencies": {
+    "@snx-v2/ContractContext": "workspace:*",
+    "@snx-v2/useDebtData": "workspace:*",
+    "@snx-v2/useExchangeRatesData": "workspace:*",
+    "@snx-v2/useLiquidationData": "workspace:*",
+    "@snx-v2/useSynthetixContracts": "workspace:*",
+    "@synthetixio/wei": "workspace:*",
+    "@tanstack/react-query": "^4.3.4",
+    "react": "^18.2.0"
+  }
+}

--- a/v2/lib/useSelfLiquidationData/useSelfLiquidationData.test.ts
+++ b/v2/lib/useSelfLiquidationData/useSelfLiquidationData.test.ts
@@ -41,7 +41,7 @@ describe('useSelfLiquidationData', () => {
     jest.resetModules();
   });
 
-  test('Returns undefined values when exchangeRateData data is undefined', async () => {
+  test('Returns undefined values when useDebtData data is undefined', async () => {
     useDebtData.mockReturnValue({ data: undefined });
     useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
     useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });
@@ -105,7 +105,7 @@ describe('useSelfLiquidationData', () => {
     expect(options).toEqual({ enabled: false, staleTime: 10000 });
   });
 
-  test('Returns correct data when dependent query have returned data', async () => {
+  test('Returns self liquidation data when dependent query have returned data', async () => {
     useDebtData.mockReturnValue({ data: { collateral: wei(50), debtBalance: wei(200) } });
     useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
     useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });

--- a/v2/lib/useSelfLiquidationData/useSelfLiquidationData.test.ts
+++ b/v2/lib/useSelfLiquidationData/useSelfLiquidationData.test.ts
@@ -1,0 +1,164 @@
+import { wei } from '@synthetixio/wei';
+
+describe('useSelfLiquidationData', () => {
+  let useLiquidator;
+  let useDebtData;
+  let useExchangeRatesData;
+  let useLiquidationData;
+  let react;
+  let reactQuery;
+  let ContractContext;
+  let useSelfLiquidationData;
+
+  beforeEach(async () => {
+    react = {
+      useContext: jest.fn(() => ({
+        networkId: 1,
+        gasSpeed: 'average',
+      })),
+    };
+    ContractContext = jest.fn();
+
+    reactQuery = {
+      useQuery: jest.fn(() => 'useQuery'),
+    };
+    useExchangeRatesData = jest.fn();
+    useDebtData = jest.fn();
+    useLiquidationData = jest.fn();
+    useLiquidator = jest.fn();
+    jest.doMock('react', () => react);
+    jest.doMock('@tanstack/react-query', () => reactQuery);
+    jest.doMock('@snx-v2/ContractContext', () => ContractContext);
+    jest.doMock('@snx-v2/useSynthetixContracts', () => ({ useLiquidator }));
+    jest.doMock('@snx-v2/useExchangeRatesData', () => ({ useExchangeRatesData }));
+    jest.doMock('@snx-v2/useDebtData', () => ({ useDebtData }));
+    jest.doMock('@snx-v2/useLiquidationData', () => ({ useLiquidationData }));
+
+    ({ useSelfLiquidationData } = await import('./useSelfLiquidationData'));
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('Returns undefined values when exchangeRateData data is undefined', async () => {
+    useDebtData.mockReturnValue({ data: undefined });
+    useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
+    useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });
+    useLiquidator.mockReturnValue({
+      data: {
+        calculateAmountToFixCollateral: jest.fn().mockReturnValue({ data: wei(100) }),
+      },
+    });
+
+    const result = useSelfLiquidationData();
+    const [cacheKey, _query, options] = reactQuery.useQuery.mock.lastCall;
+    expect(cacheKey).toEqual(['useSelfLiquidationData', 1, false]);
+
+    expect(result.data).toEqual(undefined);
+    expect(options).toEqual({ enabled: false, staleTime: 10000 });
+  });
+
+  test('Returns undefined values when useExchangeRatesData data is undefined', async () => {
+    useExchangeRatesData.mockReturnValue({ data: undefined });
+    useDebtData.mockReturnValue({ data: { collateral: wei(50), debtBalance: wei(200) } });
+    useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });
+    useLiquidator.mockReturnValue({
+      data: {
+        calculateAmountToFixCollateral: jest.fn().mockReturnValue({ data: wei(100) }),
+      },
+    });
+
+    const result = useSelfLiquidationData();
+    const [cacheKey, _query, options] = reactQuery.useQuery.mock.lastCall;
+    expect(cacheKey).toEqual(['useSelfLiquidationData', 1, false]);
+    expect(result.data).toEqual(undefined);
+    expect(options).toEqual({ enabled: false, staleTime: 10000 });
+  });
+  test('Returns undefined values when useLiquidator data is undefined', async () => {
+    useLiquidator.mockReturnValue({ data: undefined });
+    useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });
+    useDebtData.mockReturnValue({ data: { collateral: wei(50), debtBalance: wei(200) } });
+    useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
+
+    const result = useSelfLiquidationData();
+    const [cacheKey, _query, options] = reactQuery.useQuery.mock.lastCall;
+    expect(cacheKey).toEqual(['useSelfLiquidationData', 1, false]);
+
+    expect(result.data).toEqual(undefined);
+    expect(options).toEqual({ enabled: false, staleTime: 10000 });
+  });
+  test('Returns undefined values when useLiquidationData data is undefined', async () => {
+    useLiquidationData.mockReturnValue({ data: undefined });
+    useDebtData.mockReturnValue({ data: { collateral: wei(50), debtBalance: wei(200) } });
+    useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
+    useLiquidator.mockReturnValue({
+      data: {
+        calculateAmountToFixCollateral: jest.fn().mockReturnValue({ data: wei(100) }),
+      },
+    });
+    const result = useSelfLiquidationData();
+    const [cacheKey, _query, options] = reactQuery.useQuery.mock.lastCall;
+    expect(cacheKey).toEqual(['useSelfLiquidationData', 1, false]);
+
+    expect(result.data).toEqual(undefined);
+    expect(options).toEqual({ enabled: false, staleTime: 10000 });
+  });
+
+  test('Returns correct data when dependent query have returned data', async () => {
+    useDebtData.mockReturnValue({ data: { collateral: wei(50), debtBalance: wei(200) } });
+    useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
+    useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });
+    useLiquidator.mockReturnValue({
+      data: {
+        calculateAmountToFixCollateral: jest
+          .fn()
+          .mockReturnValueOnce(wei(100))
+          .mockReturnValueOnce(wei(80)),
+      },
+    });
+
+    useSelfLiquidationData();
+
+    const [cacheKey, query, options] = reactQuery.useQuery.mock.lastCall;
+    expect(cacheKey).toEqual(['useSelfLiquidationData', 1, true]);
+    expect(options).toEqual({ enabled: true, staleTime: 10000 });
+
+    const queryResult = await query();
+    expect(queryResult).toEqual({
+      selfLiquidationPenalty: wei(0.2),
+      selfLiquidationPenaltyDollar: wei(20),
+      selfLiquidationPenaltySNX: wei(20).div(3),
+      amountToLiquidate: wei(100),
+      amountToLiquidateNoPenalty: wei(80),
+    });
+  });
+  test('Handles calculateAmountToFixCollateral returning 0', async () => {
+    useDebtData.mockReturnValue({ data: { collateral: wei(50), debtBalance: wei(200) } });
+    useExchangeRatesData.mockReturnValue({ data: { SNX: wei(3) } });
+    useLiquidationData.mockReturnValue({ data: { selfLiquidationPenalty: wei(0.2) } });
+    useLiquidator.mockReturnValue({
+      data: {
+        calculateAmountToFixCollateral: jest
+          .fn()
+          .mockReturnValueOnce(wei(0))
+          .mockReturnValueOnce(wei(0)),
+      },
+    });
+
+    useSelfLiquidationData();
+
+    const [cacheKey, query, options] = reactQuery.useQuery.mock.lastCall;
+    expect(cacheKey).toEqual(['useSelfLiquidationData', 1, true]);
+    expect(options).toEqual({ enabled: true, staleTime: 10000 });
+
+    const queryResult = await query();
+    expect(queryResult).toEqual({
+      selfLiquidationPenalty: wei(0.2),
+      selfLiquidationPenaltyDollar: wei(0),
+      selfLiquidationPenaltySNX: wei(0),
+      amountToLiquidate: wei(0),
+      amountToLiquidateNoPenalty: wei(0),
+    });
+  });
+});

--- a/v2/lib/useSelfLiquidationData/useSelfLiquidationData.ts
+++ b/v2/lib/useSelfLiquidationData/useSelfLiquidationData.ts
@@ -1,0 +1,69 @@
+import { useContext } from 'react';
+import { useLiquidator } from '@snx-v2/useSynthetixContracts';
+import { useQuery } from '@tanstack/react-query';
+import { ContractContext } from '@snx-v2/ContractContext';
+import { wei } from '@synthetixio/wei';
+import { useDebtData } from '@snx-v2/useDebtData';
+import { useExchangeRatesData } from '@snx-v2/useExchangeRatesData';
+import { useLiquidationData } from '@snx-v2/useLiquidationData';
+
+export const useSelfLiquidationData = () => {
+  const { networkId } = useContext(ContractContext);
+
+  const { data: Liquidator } = useLiquidator();
+  const { data: debtData } = useDebtData();
+  const { data: exchangeRateData } = useExchangeRatesData();
+  const { data: liquidationData } = useLiquidationData();
+  const { debtBalance, collateral } = debtData || {};
+  const { SNX: SNXRate } = exchangeRateData || {};
+  const { selfLiquidationPenalty } = liquidationData || {};
+  const collateralInUsd = SNXRate ? collateral?.mul(SNXRate) : undefined;
+  const enabled = Boolean(
+    collateralInUsd && debtBalance && selfLiquidationPenalty && SNXRate && Liquidator
+  );
+  return useQuery(
+    ['useSelfLiquidationData', networkId, enabled],
+    async () => {
+      if (
+        !networkId ||
+        !Liquidator ||
+        !collateralInUsd ||
+        !debtBalance ||
+        !selfLiquidationPenalty ||
+        !SNXRate
+      ) {
+        throw Error('Query should not be enabled if contracts or network are missing');
+      }
+      const [amountToLiquidateBn, amountToLiquidateNoPenaltyBn] = await Promise.all([
+        Liquidator.calculateAmountToFixCollateral(
+          debtBalance.toBN(),
+          collateralInUsd.toBN(),
+          selfLiquidationPenalty.toBN()
+        ),
+        Liquidator.calculateAmountToFixCollateral(
+          debtBalance.toBN(),
+          collateralInUsd.toBN(),
+          wei(0).toBN()
+        ),
+      ]);
+      const amountToLiquidate = wei(amountToLiquidateBn);
+      const amountToLiquidateNoPenalty = wei(amountToLiquidateNoPenaltyBn);
+      const selfLiquidationPenaltyDollar = amountToLiquidate.sub(amountToLiquidateNoPenalty);
+      const selfLiquidationPenaltySNX = selfLiquidationPenaltyDollar.gt(0)
+        ? selfLiquidationPenaltyDollar.div(SNXRate)
+        : wei(0);
+
+      return {
+        selfLiquidationPenalty: selfLiquidationPenalty,
+        selfLiquidationPenaltyDollar,
+        selfLiquidationPenaltySNX,
+        amountToLiquidate,
+        amountToLiquidateNoPenalty,
+      };
+    },
+    {
+      enabled,
+      staleTime: 10000,
+    }
+  );
+};

--- a/v2/ui/orphans.ts
+++ b/v2/ui/orphans.ts
@@ -1,3 +1,3 @@
 // Temporary include orphan component here until incorporated into the app
 import '@snx-v2/EthGasPriceEstimator';
-import '@snx-v2/SwapLinks';
+import '@snx-v2/SelfLiquidation';

--- a/v2/ui/package.json
+++ b/v2/ui/package.json
@@ -41,6 +41,7 @@
     "@snx-v2/GasSpeedContext": "workspace:*",
     "@snx-v2/MainActionCards": "workspace:*",
     "@snx-v2/Navigation": "workspace:*",
+    "@snx-v2/SelfLiquidation": "workspace:*",
     "@snx-v2/SignerContext": "workspace:*",
     "@snx-v2/SwapLinks": "workspace:*",
     "@snx-v2/UnflagOptions": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6260,6 +6260,7 @@ __metadata:
     "@snx-v2/formatters": "workspace:*"
     "@snx-v2/icons": "workspace:*"
     "@snx-v2/useDebtData": "workspace:*"
+    "@snx-v2/useSelfLiquidationData": "workspace:*"
     react: ^18.2.0
   languageName: unknown
   linkType: soft
@@ -6520,7 +6521,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v2/useSelfLiquidationData@workspace:v2/lib/useSelfLiquidationData":
+"@snx-v2/useSelfLiquidationData@workspace:*, @snx-v2/useSelfLiquidationData@workspace:v2/lib/useSelfLiquidationData":
   version: 0.0.0-use.local
   resolution: "@snx-v2/useSelfLiquidationData@workspace:v2/lib/useSelfLiquidationData"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6252,6 +6252,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@snx-v2/SelfLiquidation@workspace:*, @snx-v2/SelfLiquidation@workspace:v2/components/SelfLiquidation":
+  version: 0.0.0-use.local
+  resolution: "@snx-v2/SelfLiquidation@workspace:v2/components/SelfLiquidation"
+  dependencies:
+    "@chakra-ui/react": ^2.2.8
+    "@snx-v2/formatters": "workspace:*"
+    "@snx-v2/icons": "workspace:*"
+    "@snx-v2/useDebtData": "workspace:*"
+    react: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@snx-v2/SignerContext@workspace:*, @snx-v2/SignerContext@workspace:v2/lib/SignerContext":
   version: 0.0.0-use.local
   resolution: "@snx-v2/SignerContext@workspace:v2/lib/SignerContext"
@@ -6501,6 +6513,21 @@ __metadata:
   resolution: "@snx-v2/useRewardsAvailable@workspace:v2/lib/useRewardsAvailable"
   dependencies:
     "@snx-v2/ContractContext": "workspace:*"
+    "@snx-v2/useSynthetixContracts": "workspace:*"
+    "@synthetixio/wei": "workspace:*"
+    "@tanstack/react-query": ^4.3.4
+    react: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
+"@snx-v2/useSelfLiquidationData@workspace:v2/lib/useSelfLiquidationData":
+  version: 0.0.0-use.local
+  resolution: "@snx-v2/useSelfLiquidationData@workspace:v2/lib/useSelfLiquidationData"
+  dependencies:
+    "@snx-v2/ContractContext": "workspace:*"
+    "@snx-v2/useDebtData": "workspace:*"
+    "@snx-v2/useExchangeRatesData": "workspace:*"
+    "@snx-v2/useLiquidationData": "workspace:*"
     "@snx-v2/useSynthetixContracts": "workspace:*"
     "@synthetixio/wei": "workspace:*"
     "@tanstack/react-query": ^4.3.4
@@ -8347,6 +8374,7 @@ __metadata:
     "@snx-v2/GasSpeedContext": "workspace:*"
     "@snx-v2/MainActionCards": "workspace:*"
     "@snx-v2/Navigation": "workspace:*"
+    "@snx-v2/SelfLiquidation": "workspace:*"
     "@snx-v2/SignerContext": "workspace:*"
     "@snx-v2/SwapLinks": "workspace:*"
     "@snx-v2/UnflagOptions": "workspace:*"


### PR DESCRIPTION
I think there was a misunderstanding on our design call. The self liquidation page got removed completely. I'm pretty sure we still want that page to display penalty. 

So when reviewing this, the `useSelfLiquidationData` hook is what's important. The UI just displays the data unstyled