### PR TITLE
theme change for old pages

### DIFF
--- a/v2/lib/Constants/index.ts
+++ b/v2/lib/Constants/index.ts
@@ -1,3 +1,4 @@
 export * from './Constants';
 export * from './dSnx';
 export * from './links';
+export * from './localStorage';

--- a/v2/lib/Constants/localStorage.ts
+++ b/v2/lib/Constants/localStorage.ts
@@ -1,0 +1,8 @@
+export const LOCAL_STORAGE_KEYS = {
+  SELECTED_WALLET: 'selectedWallet',
+  WATCHED_WALLETS: 'watchedWallets',
+  THALES_STAKING_INFO_VISIBLE: 'thalesStakingInfo',
+  WARNING_URL_BANNER_VISIBLE: 'isWarningUrlBannerVisible',
+  RE_ELECTION_NEW_START_TIME: 'reElectionNewStartTimeVisible',
+  STAKING_V2_ENABLED: 'STAKING_V2_ENABLED',
+};

--- a/v2/ui/Routes.tsx
+++ b/v2/ui/Routes.tsx
@@ -1,9 +1,11 @@
+import { ReactNode, FC } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 
 import { safeLazy } from '@synthetixio/safe-import';
 import AppLayout from './sections/shared/Layout/AppLayout';
 import { LOCAL_STORAGE_KEYS } from 'constants/storage';
 import useLocalStorage from 'hooks/useLocalStorage';
+import { BoxProps, Box } from '@chakra-ui/react';
 
 const DashboardPage = safeLazy(
   () => import(/* webpackChunkName: "dashboard" */ './content/DashboardPage')
@@ -42,6 +44,21 @@ const V2SwapLinksPage = safeLazy(
   () => import(/* webpackChunkName: "v2-swap-links" */ './content/V2SwapLinks')
 );
 
+interface WrapperProps extends BoxProps {
+  children: ReactNode;
+}
+
+const Wrapper: FC<WrapperProps> = ({ children, ...props }) => {
+  const [STAKING_V2_ENABLED] = useLocalStorage(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED, false);
+  return STAKING_V2_ENABLED ? (
+    <Box {...props} m={12}>
+      {children}
+    </Box>
+  ) : (
+    <>{children}</>
+  );
+};
+
 export default function AppRoutes() {
   const [STAKING_V2_ENABLED] = useLocalStorage(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED, false);
   return (
@@ -64,42 +81,175 @@ export default function AppRoutes() {
             </Route>
           )}
 
-          <Route path="/loans" element={<LoansPage />}>
-            <Route path=":action" element={<LoansPage />} />
-            <Route path=":loanType/:loanId/:loanAction" element={<LoansPage />} />
+          <Route
+            path="/loans"
+            element={
+              <Wrapper>
+                <LoansPage />
+              </Wrapper>
+            }
+          >
+            <Route
+              path=":action"
+              element={
+                <Wrapper>
+                  <LoansPage />
+                </Wrapper>
+              }
+            />
+            <Route
+              path=":loanType/:loanId/:loanAction"
+              element={
+                <Wrapper>
+                  <LoansPage />
+                </Wrapper>
+              }
+            />
           </Route>
 
-          <Route path="/synths" element={<SynthsPage />} />
+          <Route
+            path="/synths"
+            element={
+              <Wrapper pb={4}>
+                <SynthsPage />
+              </Wrapper>
+            }
+          />
 
-          <Route path="/gov" element={<GovPage />}>
-            <Route path=":spaceKey/:panel" element={<GovPage />} />
+          <Route
+            path="/gov"
+            element={
+              <Wrapper>
+                <GovPage />
+              </Wrapper>
+            }
+          >
+            <Route
+              path=":spaceKey/:panel"
+              element={
+                <Wrapper>
+                  <GovPage />
+                </Wrapper>
+              }
+            />
           </Route>
 
-          <Route path="/earn" element={<EarnPage />}>
-            <Route path=":pool" element={<EarnPage />}>
-              <Route path=":action" element={<EarnPage />} />
+          <Route
+            path="/earn"
+            element={
+              <Wrapper>
+                <EarnPage />
+              </Wrapper>
+            }
+          >
+            <Route
+              path=":pool"
+              element={
+                <Wrapper>
+                  <EarnPage />
+                </Wrapper>
+              }
+            >
+              <Route
+                path=":action"
+                element={
+                  <Wrapper>
+                    <EarnPage />
+                  </Wrapper>
+                }
+              />
             </Route>
           </Route>
 
-          <Route path="/debt" element={<DebtPage />} />
+          <Route
+            path="/debt"
+            element={
+              <Wrapper>
+                <DebtPage />
+              </Wrapper>
+            }
+          />
 
-          <Route path="/migrate-escrow" element={<MigrateEscrowPage />} />
+          <Route
+            path="/migrate-escrow"
+            element={
+              <Wrapper>
+                <MigrateEscrowPage />
+              </Wrapper>
+            }
+          />
 
-          <Route path="/escrow" element={<EscrowPage />}>
-            <Route path=":action" element={<EscrowPage />} />
+          <Route
+            path="/escrow"
+            element={
+              <Wrapper>
+                <EscrowPage />
+              </Wrapper>
+            }
+          >
+            <Route
+              path=":action"
+              element={
+                <Wrapper>
+                  <EscrowPage />
+                </Wrapper>
+              }
+            />
           </Route>
 
-          <Route path="/history" element={<HistoryPage />} />
+          <Route
+            path="/history"
+            element={
+              <Wrapper>
+                <HistoryPage />
+              </Wrapper>
+            }
+          />
 
-          <Route path="/delegate" element={<DelegatePage />} />
+          <Route
+            path="/delegate"
+            element={
+              <Wrapper>
+                <DelegatePage />
+              </Wrapper>
+            }
+          />
 
-          <Route path="/merge-accounts" element={<MergeAccountsPage />}>
-            <Route path=":action" element={<MergeAccountsPage />} />
+          <Route
+            path="/merge-accounts"
+            element={
+              <Wrapper>
+                <MergeAccountsPage />
+              </Wrapper>
+            }
+          >
+            <Route
+              path=":action"
+              element={
+                <Wrapper>
+                  <MergeAccountsPage />
+                </Wrapper>
+              }
+            />
           </Route>
 
-          <Route path="/bridge" element={<BridgePage />} />
+          <Route
+            path="/bridge"
+            element={
+              <Wrapper>
+                <BridgePage />
+              </Wrapper>
+            }
+          />
 
-          <Route path="*" element={<NotFound />} />
+          <Route
+            path="*"
+            element={
+              <Wrapper>
+                <NotFound />
+              </Wrapper>
+            }
+          />
         </Routes>
       </AppLayout>
     </BrowserRouter>

--- a/v2/ui/components/Tab/Tab.tsx
+++ b/v2/ui/components/Tab/Tab.tsx
@@ -65,7 +65,7 @@ export const TabPanel = ({
     </TabPanelContainer>
   ) : null;
 
-const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === 'true';
+const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === true;
 
 export const TabPanelContainer = styled.div<{ height?: number; padding: number }>`
   outline: none;

--- a/v2/ui/components/Tab/Tab.tsx
+++ b/v2/ui/components/Tab/Tab.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from 'react';
 import styled, { css, useTheme } from 'styled-components';
-
+import { theme as chakraTheme } from '@synthetixio/v3-theme';
 import { resetButtonCSS } from '@snx-v1/styles';
+import localStore from 'utils/localStore';
+import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
 
 type TabButtonProps = {
   name: string;
@@ -63,6 +65,8 @@ export const TabPanel = ({
     </TabPanelContainer>
   ) : null;
 
+const isV2 = !!localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED);
+
 export const TabPanelContainer = styled.div<{ height?: number; padding: number }>`
   outline: none;
   background: ${(props) => props.theme.colors.navy};
@@ -82,25 +86,40 @@ export const StyledTabButton = styled.button<TabButtonProps>`
   padding: 0;
   background: ${(props) =>
     props.active
-      ? props.inverseTabColor
+      ? isV2
+        ? chakraTheme.colors.navy['900']
+        : props.inverseTabColor
         ? props.theme.colors.black
         : props.theme.colors.backgroundBlue
+      : isV2
+      ? chakraTheme.colors.blackAlpha['300']
       : props.inverseTabColor
       ? props.theme.colors.backgroundBlue
       : props.theme.colors.black};
   color: ${(props) => (props.active ? props.theme.colors.white : props.theme.colors.gray)};
-
   ${(props) =>
     props.active
       ? css`
-          border-top: ${`2px solid ${props.color || props.theme.colors.blue}`};
-          border-right: ${`1px solid ${props.theme.colors.grayBlue}`};
-          border-left: ${`1px solid ${props.theme.colors.backgroundBlue}`};
-          border-bottom: ${`1px solid ${props.theme.colors.backgroundBlue}`};
+          border-top: ${`2px solid ${
+            props.color || isV2 ? chakraTheme.colors.cyan['500'] : props.theme.colors.blue
+          }`};
+          border-right: ${`1px solid ${
+            isV2 ? chakraTheme.colors.navy['900'] : props.theme.colors.grayBlue
+          }`};
+          border-left: ${`1px solid ${
+            isV2 ? chakraTheme.colors.navy['900'] : props.theme.colors.backgroundBlue
+          }`};
+          border-bottom: ${`1px solid ${
+            isV2 ? chakraTheme.colors.navy['900'] : props.theme.colors.backgroundBlue
+          }`};
         `
       : css`
-          border-top: ${`2px solid ${props.theme.colors.black}`};
-          border-bottom: ${`1px solid ${props.theme.colors.grayBlue}`};
+          border-top: ${`2px solid ${
+            isV2 ? chakraTheme.colors.navy['900'] : props.theme.colors.black
+          }`};
+          border-bottom: ${`1px solid ${
+            isV2 ? chakraTheme.colors.navy['900'] : props.theme.colors.grayBlue
+          }`};
         `}
 
   ${(props) =>
@@ -121,7 +140,11 @@ export const StyledTabButton = styled.button<TabButtonProps>`
   &:hover {
     color: ${(props) => (props.active ? props.theme.colors.white : props.color)};
     background: ${(props) =>
-      props.inverseTabColor ? props.theme.colors.black : props.theme.colors.backgroundBlue};
+      props.inverseTabColor
+        ? props.theme.colors.black
+        : isV2
+        ? chakraTheme.colors.navy['900']
+        : props.theme.colors.backgroundBlue};
     border-top: 2px solid ${(props) => (props.active ? 'none' : props.color)};
   }
 

--- a/v2/ui/components/Tab/Tab.tsx
+++ b/v2/ui/components/Tab/Tab.tsx
@@ -65,7 +65,7 @@ export const TabPanel = ({
     </TabPanelContainer>
   ) : null;
 
-const isV2 = !!localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED);
+const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === 'true';
 
 export const TabPanelContainer = styled.div<{ height?: number; padding: number }>`
   outline: none;

--- a/v2/ui/content/theme.ts
+++ b/v2/ui/content/theme.ts
@@ -161,7 +161,6 @@ const Button: ComponentStyleConfig = {
     warning: {
       bg: 'warning',
     },
-
     success: {
       bg: 'success',
     },

--- a/v2/ui/package.json
+++ b/v2/ui/package.json
@@ -37,6 +37,7 @@
     "@snx-v2/Burn": "workspace:*",
     "@snx-v2/CRatioBanner": "workspace:*",
     "@snx-v2/CRatioHealthCard": "workspace:*",
+    "@snx-v2/Constants": "workspace:*",
     "@snx-v2/ContractContext": "workspace:*",
     "@snx-v2/EthGasPriceEstimator": "workspace:*",
     "@snx-v2/GasSpeedContext": "workspace:*",

--- a/v2/ui/sections/gov/components/List/CouncilBoard.tsx
+++ b/v2/ui/sections/gov/components/List/CouncilBoard.tsx
@@ -20,7 +20,7 @@ import { theme as chakraTheme } from '@synthetixio/v3-theme';
 import localStore from 'utils/localStore';
 import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
 
-const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === 'true';
+const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === true;
 
 const CouncilBoard: React.FC = () => {
   const { t } = useTranslation();

--- a/v2/ui/sections/gov/components/List/CouncilBoard.tsx
+++ b/v2/ui/sections/gov/components/List/CouncilBoard.tsx
@@ -20,7 +20,7 @@ import { theme as chakraTheme } from '@synthetixio/v3-theme';
 import localStore from 'utils/localStore';
 import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
 
-const isV2 = !!localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED);
+const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === 'true';
 
 const CouncilBoard: React.FC = () => {
   const { t } = useTranslation();

--- a/v2/ui/sections/gov/components/List/CouncilBoard.tsx
+++ b/v2/ui/sections/gov/components/List/CouncilBoard.tsx
@@ -16,6 +16,11 @@ import { Card } from 'sections/gov/components/common';
 import useSynthetixQueries from '@synthetixio/queries';
 import Connector from '../../../../containers/Connector';
 import scGif from './SC-NFT.gif';
+import { theme as chakraTheme } from '@synthetixio/v3-theme';
+import localStore from 'utils/localStore';
+import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
+
+const isV2 = !!localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED);
 
 const CouncilBoard: React.FC = () => {
   const { t } = useTranslation();
@@ -94,7 +99,8 @@ const Title = styled.p`
 `;
 
 const MemberRow = styled(FlexDivRowCentered)`
-  border-bottom: 1px solid ${(props) => props.theme.colors.grayBlue};
+  border-bottom: 1px solid
+    ${(props) => (isV2 ? chakraTheme.colors.blackAlpha['500'] : props.theme.colors.grayBlue)};
   justify-content: space-between;
   margin: 8px 0px;
   padding: 4px 16px;

--- a/v2/ui/styles/theme/colors.ts
+++ b/v2/ui/styles/theme/colors.ts
@@ -1,3 +1,9 @@
+import { theme as chakraTheme } from '@synthetixio/v3-theme';
+import localStore from 'utils/localStore';
+import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
+
+const isV2 = !!localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED);
+
 export default {
   // primary
   blue: '#00D1FF',
@@ -33,7 +39,7 @@ export default {
   // ui
   black: '#06061B',
   blackHover: '#070725',
-  navy: '#09092F',
+  navy: isV2 ? chakraTheme.colors.navy['900'] : '#09092F',
   mediumBlue: '#10104E',
   mediumBlueHover: '#16166A',
   grayBlue: '#161B44',

--- a/v2/ui/styles/theme/colors.ts
+++ b/v2/ui/styles/theme/colors.ts
@@ -2,7 +2,7 @@ import { theme as chakraTheme } from '@synthetixio/v3-theme';
 import localStore from 'utils/localStore';
 import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
 
-const isV2 = !!localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED);
+const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === 'true';
 
 export default {
   // primary

--- a/v2/ui/styles/theme/colors.ts
+++ b/v2/ui/styles/theme/colors.ts
@@ -2,7 +2,7 @@ import { theme as chakraTheme } from '@synthetixio/v3-theme';
 import localStore from 'utils/localStore';
 import { LOCAL_STORAGE_KEYS } from '@snx-v2/Constants';
 
-const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === 'true';
+const isV2 = localStore.get(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED) === true;
 
 export default {
   // primary

--- a/yarn.lock
+++ b/yarn.lock
@@ -6699,7 +6699,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v2/Constants@workspace:*, @snx-v2/Constants@workspace:v2/lib/Constants":
+"@snx-v2/Constants@workspace:*, @snx-v2/Constants@workspace:^, @snx-v2/Constants@workspace:v2/lib/Constants":
   version: 0.0.0-use.local
   resolution: "@snx-v2/Constants@workspace:v2/lib/Constants"
   dependencies:
@@ -9048,6 +9048,7 @@ __metadata:
     "@snx-v2/Burn": "workspace:*"
     "@snx-v2/CRatioBanner": "workspace:*"
     "@snx-v2/CRatioHealthCard": "workspace:*"
+    "@snx-v2/Constants": "workspace:^"
     "@snx-v2/ContractContext": "workspace:*"
     "@snx-v2/EthGasPriceEstimator": "workspace:*"
     "@snx-v2/GasSpeedContext": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6699,7 +6699,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v2/Constants@workspace:*, @snx-v2/Constants@workspace:^, @snx-v2/Constants@workspace:v2/lib/Constants":
+"@snx-v2/Constants@workspace:*, @snx-v2/Constants@workspace:v2/lib/Constants":
   version: 0.0.0-use.local
   resolution: "@snx-v2/Constants@workspace:v2/lib/Constants"
   dependencies:
@@ -9048,7 +9048,7 @@ __metadata:
     "@snx-v2/Burn": "workspace:*"
     "@snx-v2/CRatioBanner": "workspace:*"
     "@snx-v2/CRatioHealthCard": "workspace:*"
-    "@snx-v2/Constants": "workspace:^"
+    "@snx-v2/Constants": "workspace:*"
     "@snx-v2/ContractContext": "workspace:*"
     "@snx-v2/EthGasPriceEstimator": "workspace:*"
     "@snx-v2/GasSpeedContext": "workspace:*"


### PR DESCRIPTION
Updates for pages other than home/mint/burn

Updating the theme itself was the easiest - navy moves to navy.900 in v2.

<img width="1450" alt="Screen Shot 2022-10-08 at 6 13 26 am" src="https://user-images.githubusercontent.com/52280438/194637762-adc103de-036c-4734-aba6-63988ed2f882.png">
<img width="1433" alt="Screen Shot 2022-10-08 at 6 13 36 am" src="https://user-images.githubusercontent.com/52280438/194637766-62a7ac8e-13f0-42e0-8e7b-fbd36589909e.png">
