### PR TITLE
Fix network switcher

### DIFF
--- a/v3/contracts/package.json
+++ b/v3/contracts/package.json
@@ -47,7 +47,7 @@
     "compile": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat compile",
     "test": "echo Skip contract tests || hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain",
-    "cannon-build": "hardhat cannon:build --write-deployments ./deployments/hardhat",
+    "cannon-build": "hardhat cannon:build cannonfile.dev.toml --write-deployments ./deployments/hardhat",
     "write-ts": "node ./scripts/write-ts-contracts.js"
   },
   "dependencies": {

--- a/v3/contracts/scripts/write-ts-contracts.js
+++ b/v3/contracts/scripts/write-ts-contracts.js
@@ -4,7 +4,7 @@ const ethers = require('ethers');
 const prettier = require('prettier');
 
 const prettierOptions = JSON.parse(fs.readFileSync('../../.prettierrc', 'utf8'));
-const networks = ['goerli', 'optimism-goerli'];
+const networks = ['hardhat', 'goerli', 'optimism-goerli'];
 
 function generateTS(network) {
   const deploymentFiles = fs.readdirSync(path.resolve(__dirname, `../deployments/${network}`));

--- a/v3/ui/src/App.tsx
+++ b/v3/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Spinner, useColorMode } from '@chakra-ui/react';
 import { Route, Routes } from 'react-router-dom';
 import { DefaultLayout } from './layouts/Default';
@@ -18,9 +18,12 @@ import { NotFoundPage } from './pages/404';
 
 export const Synthetix: React.FC = () => {
   const { colorMode, toggleColorMode } = useColorMode();
-  if (colorMode == 'light') {
-    toggleColorMode();
-  }
+
+  useEffect(() => {
+    if (colorMode === 'dark') {
+      toggleColorMode();
+    }
+  });
 
   return (
     <Suspense fallback={<Spinner />}>

--- a/v3/ui/ts-deployments/goerli/WETH.ts
+++ b/v3/ui/ts-deployments/goerli/WETH.ts
@@ -1,4 +1,4 @@
-export const address = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6';
+export const address = '0xf7968E6e5ddE5682534992398d7f392709b79C8b';
 export const abi = [
   'event Approval(address indexed src, address indexed guy, uint256 wad)',
   'event Deposit(address indexed dst, uint256 wad)',


### PR DESCRIPTION
- Removed `window.ethereum` event handler.
- When user has no query param, default to whatever the active chain the connected wallet is on.
- When user has a query param with a chain name that isn't supported, default to goerli (configurable)
- When user changes chain on wallet OR via the rainbowkit button on the page, url and local chain are synced appropriately.

These are in conjunction to all the rules that already exist.  I'm also sure there's some way to clean up the logic, it's a bit confusing but i added plenty of comments to make it obvious.