### PR TITLE
Ensure liquidation and target labels dont overlap when c-ratio is relly large

### DIFF
--- a/v2/components/CRatioHealthCard/CRatioHealthCard.cy.tsx
+++ b/v2/components/CRatioHealthCard/CRatioHealthCard.cy.tsx
@@ -84,5 +84,23 @@ describe('CRatioHealthCard.cy.tsx', () => {
     cy.contains('p', 'Target 200%').should('be.visible');
 
     cy.get('[role="progressbar"]').should('have.css', 'background-color', 'rgb(255, 74, 96)');
+
+    cy.get('[data-testid="current c-ration triangle"]').should('be.visible');
+  });
+  it('avoids overlapping labels when really large c-ratio', () => {
+    cy.viewport(500, 300);
+    cy.mount(
+      <Box paddingY="7" paddingX="4" bg="navy.900" flex="1">
+        <CRatioHealthCardUi
+          {...{
+            targetCratioPercentage: 350,
+            liquidationCratioPercentage: 100,
+            currentCRatioPercentage: 1500,
+          }}
+        />
+      </Box>
+    );
+
+    cy.get('[data-testid="current c-ration triangle"]').should('not.be.visible');
   });
 });

--- a/v2/components/CRatioHealthCard/CRatioProgressBar.tsx
+++ b/v2/components/CRatioHealthCard/CRatioProgressBar.tsx
@@ -54,7 +54,12 @@ export const CRatioProgressBar: FC<{
   ) {
     return <Skeleton w="100%" minHeight="100px" mb={4} />;
   }
-  const maxRatioShown = Math.max(targetCratioPercentage, currentCRatioPercentage) * 1.1;
+  const maxRatioShown = Math.min(
+    Math.max(targetCratioPercentage, currentCRatioPercentage) * 1.1,
+    // If the c-ratio is bigger than 2.5x the target ratio the target and liquidation labels will overlap due to the big scale difference.
+    // So when this is the case we opt not to show the current c-ratio arrows and set maxRatioShown to target * 2.5.
+    targetCratioPercentage * 2.5
+  );
   const scaleFactor = maxRatioShown / 100;
   const variant = getHealthVariant({
     targetCratioPercentage,
@@ -63,7 +68,13 @@ export const CRatioProgressBar: FC<{
   });
 
   return (
-    <Box position="relative" height="100px" width="full" data-testid="c ratio progressbar">
+    <Box
+      position="relative"
+      height="100px"
+      width="full"
+      data-testid="c ratio progressbar"
+      overflowX="hidden"
+    >
       <LineWithText
         left={liquidationCratioPercentage / scaleFactor}
         text={`Liquidated < ${liquidationCratioPercentage.toFixed(0)}%`}
@@ -94,6 +105,7 @@ export const CRatioProgressBar: FC<{
         margin="auto"
       >
         <TriangleDownIcon
+          data-testid="current c-ration triangle"
           position="absolute"
           right={0}
           top={0}
@@ -101,6 +113,7 @@ export const CRatioProgressBar: FC<{
           color={variant}
         />
         <TriangleUpIcon
+          data-testid="current c-ration triangle"
           position="absolute"
           right={0}
           bottom={0}


### PR DESCRIPTION
Test and comment tries to explain, let me know if it doesn't make sense. I talked through this solution with jade
Before:
<img width="508" alt="Screen Shot 2022-10-27 at 5 04 21 pm" src="https://user-images.githubusercontent.com/5688912/198204358-728ed8c2-81e8-4c24-a0a5-91cb5a446328.png">

After:
<img width="528" alt="Screen Shot 2022-10-27 at 5 04 44 pm" src="https://user-images.githubusercontent.com/5688912/198204321-718bb697-0626-4702-b995-7d30f5dc668b.png">
