### PR TITLE
Wallet modal

### DIFF
--- a/v2/components/ExternalLink/ExternalLink.tsx
+++ b/v2/components/ExternalLink/ExternalLink.tsx
@@ -4,7 +4,7 @@ import { ArrowTopRight } from '@snx-v2/icons';
 
 export const ExternalLink = ({ children, ...props }: PropsWithChildren<LinkProps>) => {
   return (
-    <Link display="flex" alignItems="center" textColor="cyan" {...props} isExternal>
+    <Link display="flex" alignItems="center" textColor="cyan.400" {...props} isExternal>
       {children}
       <ArrowTopRight ml="1" />
     </Link>

--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Button,
   Center,
@@ -9,7 +10,6 @@ import {
   Text,
   useBreakpointValue,
 } from '@chakra-ui/react';
-
 import { NetworkId, NetworkIdByName } from '@synthetixio/contracts-interface';
 import {
   ChevronDown,
@@ -38,6 +38,7 @@ import { useSynthsBalances } from '@snx-v2/useSynthsBalances';
 import { EpochPrice } from '@snx-v2/EpochPrice';
 import { useExchangeRatesData } from '@snx-v2/useExchangeRatesData';
 import { useFeePoolData } from '@snx-v2/useFeePoolData';
+import { WalletModal } from '@snx-v2/WalletModal';
 
 interface NavigationProps {
   currentNetwork: NetworkId;
@@ -48,6 +49,7 @@ interface NavigationProps {
   isLoading: boolean;
   snxBalance: Wei;
   sUSDBalance: Wei;
+  disconnectWallet: () => Promise<void>;
 }
 
 const activeIcon = (currentNetwork: NetworkId) => {
@@ -75,9 +77,10 @@ export const NavigationUI = ({
   isLoading,
   snxBalance,
   sUSDBalance,
+  disconnectWallet,
 }: NavigationProps) => {
   const { t } = useTranslation();
-
+  const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
   const { name, icon } = activeIcon(currentNetwork);
   const navigate = useNavigate();
 
@@ -257,7 +260,7 @@ export const NavigationUI = ({
                 <Text ml={2}>{t('common.wallet.menu.gov')}</Text>
               </Center>
             </MenuItem>
-            <MenuItem onClick={() => navigate('/')}>
+            <MenuItem onClick={() => setIsWalletModalOpen(true)}>
               <Center>
                 <WalletIcon color="white" />
                 <Text ml={2}>{t('common.wallet.menu.wallet')}</Text>
@@ -276,6 +279,11 @@ export const NavigationUI = ({
           </MenuList>
         </Menu>
       </Flex>
+      <WalletModal
+        isWalletModalOpen={isWalletModalOpen}
+        setIsWalletModalOpen={setIsWalletModalOpen}
+        disconnectWallet={disconnectWallet}
+      />
     </Flex>
   );
 };
@@ -286,6 +294,7 @@ export const Navigation = ({
   connectWallet,
   isWalletConnected,
   walletAddress,
+  disconnectWallet,
 }: Omit<NavigationProps, 'snxBalance' | 'sUSDBalance' | 'isLoading'>) => {
   const { data: synthsBalances, isLoading: isSynthsLoading } = useSynthsBalances();
   const { data: debtData, isLoading: isDebtLoading } = useDebtData();
@@ -323,6 +332,7 @@ export const Navigation = ({
         isLoading={isLoading}
         snxBalance={debtData?.collateral || wei(0)}
         sUSDBalance={synthsBalances?.balancesMap['sUSD']?.balance || wei(0)}
+        disconnectWallet={disconnectWallet}
       />
       {size === 'mobile' && (
         <EpochPrice

--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -20,9 +20,9 @@ import {
   GuideIcon,
   NineDots,
   LoansIcon,
-  NotificationsIcon,
+  // NotificationsIcon,
   OptimismIcon,
-  SettingsIcon,
+  // SettingsIcon,
   StakingIcon,
   WalletIcon,
   StakingLogo,
@@ -189,7 +189,7 @@ export const NavigationUI = ({
             )}
           </Menu>
         </Center>
-        <Center
+        {/* <Center
           ml={2}
           height={10}
           width={10}
@@ -203,8 +203,8 @@ export const NavigationUI = ({
           }}
         >
           <NotificationsIcon color="white" />
-        </Center>
-        <>
+        </Center> */}
+        {/* <>
           <Center
             ml={2}
             height={10}
@@ -220,7 +220,7 @@ export const NavigationUI = ({
           >
             <SettingsIcon color="white" />
           </Center>
-        </>
+        </> */}
         <Menu>
           <Center
             ml={2}
@@ -263,12 +263,12 @@ export const NavigationUI = ({
                 <Text ml={2}>{t('common.wallet.menu.wallet')}</Text>
               </Center>
             </MenuItem>
-            <MenuItem onClick={() => navigate('/')}>
+            {/* <MenuItem onClick={() => navigate('/')}>
               <Center>
                 <SettingsIcon color="white" />
                 <Text ml={2}>{t('common.wallet.menu.settings')}</Text>
               </Center>
-            </MenuItem>
+            </MenuItem> */}
             <MenuItem onClick={() => navigate('/')}>
               <GuideIcon />
               <Text ml={2}>{t('common.wallet.menu.guide')}</Text>

--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Button,
   Center,
@@ -9,6 +8,7 @@ import {
   MenuList,
   Text,
   useBreakpointValue,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { NetworkId, NetworkIdByName } from '@synthetixio/contracts-interface';
 import {
@@ -80,7 +80,8 @@ export const NavigationUI = ({
   disconnectWallet,
 }: NavigationProps) => {
   const { t } = useTranslation();
-  const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
+
+  const { isOpen, onClose, onOpen } = useDisclosure();
   const { name, icon } = activeIcon(currentNetwork);
   const navigate = useNavigate();
 
@@ -260,7 +261,7 @@ export const NavigationUI = ({
                 <Text ml={2}>{t('common.wallet.menu.gov')}</Text>
               </Center>
             </MenuItem>
-            <MenuItem onClick={() => setIsWalletModalOpen(true)}>
+            <MenuItem onClick={onOpen}>
               <Center>
                 <WalletIcon color="white" />
                 <Text ml={2}>{t('common.wallet.menu.wallet')}</Text>
@@ -279,11 +280,7 @@ export const NavigationUI = ({
           </MenuList>
         </Menu>
       </Flex>
-      <WalletModal
-        isWalletModalOpen={isWalletModalOpen}
-        setIsWalletModalOpen={setIsWalletModalOpen}
-        disconnectWallet={disconnectWallet}
-      />
+      <WalletModal isOpen={isOpen} onClose={onClose} disconnectWallet={disconnectWallet} />
     </Flex>
   );
 };

--- a/v2/components/Navigation/package.json
+++ b/v2/components/Navigation/package.json
@@ -7,6 +7,7 @@
     "@chakra-ui/react": "^2.2.8",
     "@snx-v2/EpochPrice": "workspace:^",
     "@snx-v2/UserBalances": "workspace:*",
+    "@snx-v2/WalletModal": "workspace:*",
     "@snx-v2/formatters": "workspace:*",
     "@snx-v2/icons": "workspace:*",
     "@snx-v2/useDebtData": "workspace:*",
@@ -16,6 +17,7 @@
     "@storybook/react": "^6.5.10",
     "@synthetixio/contracts-interface": "workspace:*",
     "@synthetixio/wei": "workspace:*",
+    "react": "^18.2.0",
     "react-i18next": "^11.18.3",
     "react-router-dom": "^6.3.0"
   }

--- a/v2/components/WalletModal/WalletModal.stories.tsx
+++ b/v2/components/WalletModal/WalletModal.stories.tsx
@@ -1,0 +1,40 @@
+import { WalletModalUi } from './WalletModal';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { SNXIcon } from '@snx-v2/icons';
+
+export default {
+  title: 'WalletModalUi',
+  component: WalletModalUi,
+} as ComponentMeta<typeof WalletModalUi>;
+
+const Template: ComponentStory<typeof WalletModalUi> = (props) => <WalletModalUi {...props} />;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  onClose: () => {},
+  isOpen: true,
+  disconnectWallet: async () => {},
+  walletAddress: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+  networkId: 1,
+  balances: [
+    {
+      currencyKey: 'SNX',
+      balance: 100,
+      usdBalance: 200,
+      icon: <SNXIcon />,
+    },
+    {
+      currencyKey: 'sUSD',
+      balance: 100,
+      usdBalance: 200,
+      icon: (
+        <img
+          width="24px"
+          height="24px"
+          src="https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/sUSD.svg"
+        ></img>
+      ),
+    },
+  ],
+};

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -1,0 +1,177 @@
+import { FC, useContext, useState, useEffect, ReactElement } from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react';
+import { ContractContext } from '@snx-v2/ContractContext';
+import { formatNumber, formatNumberToUsd, truncateAddress } from '@snx-v2/formatters';
+import { AvatarIcon, CopyIcon, SNXIcon } from '@snx-v2/icons';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { ExternalLink } from '@snx-v2/ExternalLink';
+import { getEtherscanBaseUrl } from '@snx-v2/txnLink';
+import { useSynthsBalances } from '@snx-v2/useSynthsBalances';
+import { useDebtData } from '@snx-v2/useDebtData';
+import { useExchangeRatesData } from '@snx-v2/useExchangeRatesData';
+import Wei from '@synthetixio/wei';
+import { useNavigate } from 'react-router-dom';
+import { theme } from '@synthetixio/v3-theme';
+import { useTranslation } from 'react-i18next';
+
+type BalanceObject = {
+  currencyKey: string;
+  balance: Wei;
+  usdBalance: Wei;
+  icon?: ReactElement;
+};
+export const WalletModalUi: FC<{
+  isWalletModalOpen: boolean;
+  setIsWalletModalOpen: (x: boolean) => void;
+  disconnectWallet: () => Promise<void>;
+  walletAddress: string | null;
+  networkId: number | null;
+  balances?: BalanceObject[];
+}> = ({
+  isWalletModalOpen,
+  setIsWalletModalOpen,
+  disconnectWallet,
+  networkId,
+  walletAddress,
+  balances,
+}) => {
+  const { t } = useTranslation();
+  const [copiedAddress, setCopiedAddress] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let intervalId: number | undefined;
+    if (copiedAddress) {
+      intervalId = Number(
+        setInterval(() => {
+          setCopiedAddress(false);
+        }, 3000)
+      );
+    }
+    () => {
+      clearInterval(intervalId);
+    };
+  }, [copiedAddress]);
+  return (
+    <Modal isOpen={isWalletModalOpen} onClose={() => setIsWalletModalOpen(false)}>
+      <ModalOverlay />
+      <ModalContent
+        bg="gray.900"
+        bgGradient={theme.gradients['dark'][500]}
+        pt="10"
+        pb="3"
+        borderWidth="1px"
+        borderColor="gray.900"
+        data-testid="transaction modal"
+      >
+        <ModalCloseButton />
+        <ModalHeader fontWeight={700} fontSize="xl" pb={0} textAlign="center">
+          {t('staking-v2.wallet-modal.headline')}
+        </ModalHeader>
+        <ModalBody>
+          <Box p={4} bg="black" border="1px" borderColor="gray.800" borderRadius="base">
+            <Flex alignItems="center" justifyContent="space-between">
+              <Flex>
+                <AvatarIcon mr={2} /> {walletAddress && truncateAddress(walletAddress)}
+              </Flex>
+              <Button onClick={() => disconnectWallet()} variant="ghost">
+                {t('staking-v2.wallet-modal.disconnect')}
+              </Button>
+            </Flex>
+            <Flex>
+              <CopyToClipboard text={walletAddress!} onCopy={() => setCopiedAddress(true)}>
+                <Button fontSize="sm" fontWeight={400} variant="ghost">
+                  <CopyIcon mr={2} /> {copiedAddress ? 'Copied' : 'Copy Address'}
+                </Button>
+              </CopyToClipboard>
+              <ExternalLink
+                fontSize="sm"
+                fontWeight={400}
+                href={`${networkId && getEtherscanBaseUrl(networkId)}/account/${walletAddress}`}
+              >
+                {t('staking-v2.wallet-modal.explorer')}
+              </ExternalLink>
+            </Flex>
+          </Box>
+          <Box mt={4} p={4} bg="black" border="1px" borderColor="gray.800" borderRadius="base">
+            {balances?.map(({ usdBalance, balance, icon, currencyKey }) => {
+              return (
+                <Flex justifyContent="space-between">
+                  <Flex display="flex" alignItems="center">
+                    {icon} <Text ml={1}>{currencyKey}</Text>
+                  </Flex>
+                  <Flex flexDirection="column">
+                    <Text textAlign="right">{formatNumber(balance.toNumber())}</Text>
+                    <Text color="gray.800" textAlign="right">
+                      {formatNumberToUsd(usdBalance.toNumber())}
+                    </Text>
+                  </Flex>
+                </Flex>
+              );
+            })}
+            <Button
+              display="block"
+              variant="ghost"
+              onClick={() => navigate('/synths')}
+              margin="0 auto"
+            >
+              {t('staking-v2.wallet-modal.view-all')}
+            </Button>
+          </Box>
+          <Divider my={4} />
+          <Button onClick={() => navigate('/escrow')} margin="0 auto" display="block">
+            {t('staking-v2.wallet-modal.escrow')}
+          </Button>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+const getSynthIcon = (currencyKey: string) =>
+  `https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/${currencyKey}.svg`;
+
+export const WalletModal: FC<{
+  isWalletModalOpen: boolean;
+  setIsWalletModalOpen: (x: boolean) => void;
+  disconnectWallet: () => Promise<void>;
+}> = (props) => {
+  const { data: synthBalancesData } = useSynthsBalances();
+  const { data: debtData } = useDebtData();
+  const { data: exchangeRateData } = useExchangeRatesData();
+  const { walletAddress, networkId } = useContext(ContractContext);
+  const snxBalance =
+    debtData && exchangeRateData
+      ? {
+          currencyKey: 'SNX',
+          balance: debtData.collateral,
+          usdBalance: debtData.collateral.mul(exchangeRateData.SNX || 0),
+          icon: <SNXIcon />,
+        }
+      : undefined;
+
+  const synthBalances = synthBalancesData?.balances.slice(0, 5).map((x) => ({
+    ...x,
+    icon: <img width="24px" height="24px" src={getSynthIcon(x.currencyKey)} />,
+  }));
+  const balances = snxBalance && synthBalances ? [snxBalance].concat(synthBalances) : undefined;
+  return (
+    <WalletModalUi
+      {...props}
+      balances={balances}
+      walletAddress={walletAddress}
+      networkId={networkId}
+    />
+  );
+};

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -33,26 +33,19 @@ type BalanceObject = {
   icon?: ReactElement;
 };
 export const WalletModalUi: FC<{
-  isWalletModalOpen: boolean;
-  setIsWalletModalOpen: (x: boolean) => void;
+  isOpen: boolean;
+  onClose: () => void;
   disconnectWallet: () => Promise<void>;
   walletAddress: string | null;
   networkId: number | null;
   balances?: BalanceObject[];
-}> = ({
-  isWalletModalOpen,
-  setIsWalletModalOpen,
-  disconnectWallet,
-  networkId,
-  walletAddress,
-  balances,
-}) => {
+}> = ({ isOpen, onClose, disconnectWallet, networkId, walletAddress, balances }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { hasCopied, onCopy } = useClipboard(walletAddress || '');
 
   return (
-    <Modal isOpen={isWalletModalOpen} onClose={() => setIsWalletModalOpen(false)}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent
         bg="gray.900"
@@ -129,8 +122,8 @@ const getSynthIcon = (currencyKey: string) =>
   `https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/${currencyKey}.svg`;
 
 export const WalletModal: FC<{
-  isWalletModalOpen: boolean;
-  setIsWalletModalOpen: (x: boolean) => void;
+  isOpen: boolean;
+  onClose: () => void;
   disconnectWallet: () => Promise<void>;
 }> = (props) => {
   const { data: synthBalancesData } = useSynthsBalances();

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -21,15 +21,14 @@ import { getEtherscanBaseUrl } from '@snx-v2/txnLink';
 import { useSynthsBalances } from '@snx-v2/useSynthsBalances';
 import { useDebtData } from '@snx-v2/useDebtData';
 import { useExchangeRatesData } from '@snx-v2/useExchangeRatesData';
-import Wei from '@synthetixio/wei';
 import { useNavigate } from 'react-router-dom';
 import { theme } from '@synthetixio/v3-theme';
 import { useTranslation } from 'react-i18next';
 
 type BalanceObject = {
   currencyKey: string;
-  balance: Wei;
-  usdBalance: Wei;
+  balance: number;
+  usdBalance: number;
   icon?: ReactElement;
 };
 export const WalletModalUi: FC<{
@@ -92,9 +91,9 @@ export const WalletModalUi: FC<{
                     {icon} <Text ml={1}>{currencyKey}</Text>
                   </Flex>
                   <Flex flexDirection="column">
-                    <Text textAlign="right">{formatNumber(balance.toNumber())}</Text>
+                    <Text textAlign="right">{formatNumber(balance)}</Text>
                     <Text color="gray.800" textAlign="right">
-                      {formatNumberToUsd(usdBalance.toNumber())}
+                      {formatNumberToUsd(usdBalance)}
                     </Text>
                   </Flex>
                 </Flex>
@@ -134,14 +133,16 @@ export const WalletModal: FC<{
     debtData && exchangeRateData
       ? {
           currencyKey: 'SNX',
-          balance: debtData.collateral,
-          usdBalance: debtData.collateral.mul(exchangeRateData.SNX || 0),
+          balance: debtData.collateral.toNumber(),
+          usdBalance: debtData.collateral.mul(exchangeRateData.SNX || 0).toNumber(),
           icon: <SNXIcon />,
         }
       : undefined;
 
   const synthBalances = synthBalancesData?.balances.slice(0, 5).map((x) => ({
-    ...x,
+    currencyKey: x.currencyKey,
+    balance: x.balance.toNumber(),
+    usdBalance: x.usdBalance.toNumber(),
     icon: <img width="24px" height="24px" src={getSynthIcon(x.currencyKey)} />,
   }));
   const balances = snxBalance && synthBalances ? [snxBalance].concat(synthBalances) : undefined;

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useState, useEffect, ReactElement } from 'react';
+import { FC, useContext, ReactElement } from 'react';
 import {
   Box,
   Button,
@@ -11,11 +11,11 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  useClipboard,
 } from '@chakra-ui/react';
 import { ContractContext } from '@snx-v2/ContractContext';
 import { formatNumber, formatNumberToUsd, truncateAddress } from '@snx-v2/formatters';
 import { AvatarIcon, CopyIcon, SNXIcon } from '@snx-v2/icons';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { ExternalLink } from '@snx-v2/ExternalLink';
 import { getEtherscanBaseUrl } from '@snx-v2/txnLink';
 import { useSynthsBalances } from '@snx-v2/useSynthsBalances';
@@ -48,22 +48,9 @@ export const WalletModalUi: FC<{
   balances,
 }) => {
   const { t } = useTranslation();
-  const [copiedAddress, setCopiedAddress] = useState<boolean>(false);
   const navigate = useNavigate();
+  const { hasCopied, onCopy } = useClipboard(walletAddress || '');
 
-  useEffect(() => {
-    let intervalId: number | undefined;
-    if (copiedAddress) {
-      intervalId = Number(
-        setInterval(() => {
-          setCopiedAddress(false);
-        }, 3000)
-      );
-    }
-    () => {
-      clearInterval(intervalId);
-    };
-  }, [copiedAddress]);
   return (
     <Modal isOpen={isWalletModalOpen} onClose={() => setIsWalletModalOpen(false)}>
       <ModalOverlay />
@@ -91,11 +78,10 @@ export const WalletModalUi: FC<{
               </Button>
             </Flex>
             <Flex>
-              <CopyToClipboard text={walletAddress!} onCopy={() => setCopiedAddress(true)}>
-                <Button fontSize="sm" fontWeight={400} variant="ghost">
-                  <CopyIcon mr={2} /> {copiedAddress ? 'Copied' : 'Copy Address'}
-                </Button>
-              </CopyToClipboard>
+              <Button fontSize="sm" fontWeight={400} variant="ghost" onClick={onCopy}>
+                <CopyIcon mr={2} /> {hasCopied ? 'Copied' : 'Copy Address'}
+              </Button>
+
               <ExternalLink
                 fontSize="sm"
                 fontWeight={400}

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -85,7 +85,7 @@ export const WalletModalUi: FC<{
               <ExternalLink
                 fontSize="sm"
                 fontWeight={400}
-                href={`${networkId && getEtherscanBaseUrl(networkId)}/account/${walletAddress}`}
+                href={`${networkId && getEtherscanBaseUrl(networkId)}/address/${walletAddress}`}
               >
                 {t('staking-v2.wallet-modal.explorer')}
               </ExternalLink>

--- a/v2/components/WalletModal/index.ts
+++ b/v2/components/WalletModal/index.ts
@@ -1,0 +1,1 @@
+export * from './WalletModal';

--- a/v2/components/WalletModal/package.json
+++ b/v2/components/WalletModal/package.json
@@ -13,8 +13,8 @@
     "@snx-v2/useDebtData": "workspace:*",
     "@snx-v2/useExchangeRatesData": "workspace:*",
     "@snx-v2/useSynthsBalances": "workspace:*",
+    "@storybook/react": "^6.5.10",
     "@synthetixio/v3-theme": "workspace:*",
-    "@synthetixio/wei": "workspace:*",
     "react": "^18.2.0",
     "react-i18next": "^11.18.3",
     "react-router-dom": "^6.3.0"

--- a/v2/components/WalletModal/package.json
+++ b/v2/components/WalletModal/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@snx-v2/WalletModal",
+  "private": true,
+  "main": "index.tsx",
+  "version": "0.0.1",
+  "dependencies": {
+    "@chakra-ui/react": "^2.2.8",
+    "@snx-v2/ContractContext": "workspace:*",
+    "@snx-v2/ExternalLink": "workspace:*",
+    "@snx-v2/formatters": "workspace:*",
+    "@snx-v2/icons": "workspace:*",
+    "@snx-v2/txnLink": "workspace:*",
+    "@snx-v2/useDebtData": "workspace:*",
+    "@snx-v2/useExchangeRatesData": "workspace:*",
+    "@snx-v2/useSynthsBalances": "workspace:*",
+    "@synthetixio/v3-theme": "workspace:*",
+    "@synthetixio/wei": "workspace:*",
+    "react": "^18.2.0",
+    "react-copy-to-clipboard": "^5.1.0",
+    "react-i18next": "^11.18.3",
+    "react-router-dom": "^6.3.0"
+  }
+}

--- a/v2/components/WalletModal/package.json
+++ b/v2/components/WalletModal/package.json
@@ -16,7 +16,6 @@
     "@synthetixio/v3-theme": "workspace:*",
     "@synthetixio/wei": "workspace:*",
     "react": "^18.2.0",
-    "react-copy-to-clipboard": "^5.1.0",
     "react-i18next": "^11.18.3",
     "react-router-dom": "^6.3.0"
   }

--- a/v2/components/icons/AvatarIcon/AvatarIcon.tsx
+++ b/v2/components/icons/AvatarIcon/AvatarIcon.tsx
@@ -1,0 +1,20 @@
+import { Icon, IconProps } from '@chakra-ui/react';
+
+export const AvatarIcon = ({ width = '24px', height = '24px', ...props }: IconProps) => {
+  return (
+    <Icon width={width} height={height} color="cyan.400" viewBox="0 0 24 24" fill="none" {...props}>
+      <rect width="24" height="24" rx="12" fill="#E2E2F0" />
+      <g clipPath="url(#avatarPath)">
+        <path
+          d="M12 13.5c2.84 0 5.143-2.35 5.143-5.25S14.84 3 12 3C9.16 3 6.857 5.35 6.857 8.25S9.16 13.5 12 13.5Zm3.6 1.313h-.671a6.881 6.881 0 0 1-2.929.656 6.895 6.895 0 0 1-2.929-.656H8.4c-2.981 0-5.4 2.469-5.4 5.512v1.706C3 23.118 3.864 24 4.929 24H19.07C20.136 24 21 23.118 21 22.031v-1.706c0-3.043-2.419-5.512-5.4-5.512Z"
+          fill="#fff"
+        />
+      </g>
+      <defs>
+        <clipPath id="avatarPath">
+          <path fill="#fff" d="M3 3h18v21H3z" />
+        </clipPath>
+      </defs>
+    </Icon>
+  );
+};

--- a/v2/components/icons/AvatarIcon/index.tsx
+++ b/v2/components/icons/AvatarIcon/index.tsx
@@ -1,0 +1,1 @@
+export * from './AvatarIcon';

--- a/v2/components/icons/CopyIcon/CopyIcon.tsx
+++ b/v2/components/icons/CopyIcon/CopyIcon.tsx
@@ -1,0 +1,19 @@
+import { Icon, IconProps } from '@chakra-ui/react';
+
+export const CopyIcon = ({
+  width = '12px',
+  height = '12px',
+  color = 'cyan.400',
+  ...props
+}: IconProps) => {
+  return (
+    <Icon width={width} height={height} color={color} viewBox="0 0 12 12" fill="none" {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.625 1.5A.625.625 0 0 0 3 2.125V3h-.875a.625.625 0 0 0-.625.625v6.25c0 .345.28.625.625.625h6.25c.345 0 .625-.28.625-.625V9h.875c.345 0 .625-.28.625-.625v-6.25a.625.625 0 0 0-.625-.625h-6.25ZM9 8.25h.75v-6h-6V3h4.625C8.72 3 9 3.28 9 3.625V8.25Zm-6.75-4.5v6h6v-6h-6Z"
+        fill="currentColor"
+      />
+    </Icon>
+  );
+};

--- a/v2/components/icons/CopyIcon/index.tsx
+++ b/v2/components/icons/CopyIcon/index.tsx
@@ -1,0 +1,1 @@
+export * from './CopyIcon';

--- a/v2/components/icons/index.tsx
+++ b/v2/components/icons/index.tsx
@@ -43,3 +43,5 @@ export * from './NineDots';
 export * from './BridgeIcon';
 export * from './DebtPoolIcon';
 export * from './ArrowRight';
+export * from './AvatarIcon';
+export * from './CopyIcon';

--- a/v2/lib/txnLink/txnLink.test.ts
+++ b/v2/lib/txnLink/txnLink.test.ts
@@ -1,0 +1,18 @@
+import { getEtherscanBaseUrl } from './txnLink';
+describe('getEtherscanBaseUrl', () => {
+  it('handles mainnet', () => {
+    expect(getEtherscanBaseUrl(1)).toBe('https://etherscan.io');
+  });
+  it('handles goerli', () => {
+    expect(getEtherscanBaseUrl(5)).toBe('https://goerli.etherscan.io');
+  });
+  it('handles optimism', () => {
+    expect(getEtherscanBaseUrl(10)).toBe('https://optimistic.etherscan.io');
+  });
+  it('handles optimism-goerli', () => {
+    expect(getEtherscanBaseUrl(420)).toBe('https://goerli-optimism.etherscan.io');
+  });
+  it('returns mainnet when unkown', () => {
+    expect(getEtherscanBaseUrl(123456)).toBe('https://etherscan.io');
+  });
+});

--- a/v2/lib/txnLink/txnLink.ts
+++ b/v2/lib/txnLink/txnLink.ts
@@ -3,12 +3,16 @@ import { ContractContext } from '@snx-v2/ContractContext';
 import { NetworkIdByName, NetworkNameById } from '@snx-v2/useSynthetixContracts';
 import type { NetworkId } from '@snx-v2/useSynthetixContracts';
 
-export const getTxnLink = (networkId: NetworkId, txnId: string | null) => {
-  if (!txnId) return null;
+export const getEtherscanBaseUrl = (networkId: number) => {
   if (networkId !== NetworkIdByName.mainnet) {
-    return `https://${NetworkNameById[networkId]}.etherscan.io/tx/${txnId}`;
+    return `https://${NetworkNameById[networkId]}.etherscan.io`;
   }
-  return `https://etherscan.io/tx/${txnId}`;
+  return `https://etherscan.io`;
+};
+export const getTxnLink = (networkId: number, txnId: string | null) => {
+  if (!txnId) return null;
+  const baseUrl = getEtherscanBaseUrl(networkId);
+  return `${baseUrl}/tx/${txnId}`;
 };
 
 export const useGetTxnLink = (txnHash: string | null) => {

--- a/v2/lib/txnLink/txnLink.ts
+++ b/v2/lib/txnLink/txnLink.ts
@@ -4,8 +4,15 @@ import { NetworkIdByName, NetworkNameById } from '@snx-v2/useSynthetixContracts'
 import type { NetworkId } from '@snx-v2/useSynthetixContracts';
 
 export const getEtherscanBaseUrl = (networkId: number) => {
-  if (networkId !== NetworkIdByName.mainnet) {
-    return `https://${NetworkNameById[networkId]}.etherscan.io`;
+  const networkName =
+    networkId in NetworkNameById ? NetworkNameById[networkId as NetworkId] : undefined;
+  if (networkId !== NetworkIdByName.mainnet && networkName) {
+    const subDomain = networkName.includes('ovm')
+      ? networkName.includes('goerli')
+        ? 'goerli-optimism'
+        : 'optimistic'
+      : networkName;
+    return `https://${subDomain}.etherscan.io`;
   }
   return `https://etherscan.io`;
 };

--- a/v2/lib/useSynthsBalances/useSynthsBalances.ts
+++ b/v2/lib/useSynthsBalances/useSynthsBalances.ts
@@ -7,6 +7,9 @@ import { ContractContext } from '@snx-v2/ContractContext';
 import { useSynthUtil } from '@snx-v2/useSynthetixContracts';
 import Wei, { wei } from '@synthetixio/wei';
 
+function notNill<Value>(value: Value | null | undefined): value is Value {
+  return value !== null && value !== undefined;
+}
 export type SynthBalance = {
   currencyKey: string;
   balance: Wei;
@@ -42,8 +45,8 @@ export const processSynthsBalances = (balances: SynthBalancesTuple) => {
   return {
     balancesMap: balancesMap,
     balances: orderBy(
-      Object.values(balancesMap).filter((val) => val !== null && val !== undefined),
-      (balance) => balance?.usdBalance.toNumber(),
+      Object.values(balancesMap).filter(notNill),
+      (balance) => balance.usdBalance.toNumber(),
       'desc'
     ),
     totalUSDBalance,

--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -196,6 +196,13 @@
       "c-ratio": "C-Ratio",
       "susd-balance": "sUSD Balance",
       "active-debt": "Active Debt"
+    },
+    "wallet-modal": {
+      "headline": "My Account",
+      "disconnect": "Disconnect",
+      "explorer": "View on Explorer",
+      "view-all": "View All",
+      "escrow": "Escrow"
     }
   },
   "meta": {

--- a/v2/ui/v2-components/Header/Header.tsx
+++ b/v2/ui/v2-components/Header/Header.tsx
@@ -4,8 +4,14 @@ import { Navigation } from '@snx-v2/Navigation';
 import Connector from 'containers/Connector';
 
 export const Header: FC = () => {
-  const { isWalletConnected, walletAddress, connectWallet, switchNetwork, network } =
-    Connector.useContainer();
+  const {
+    isWalletConnected,
+    walletAddress,
+    connectWallet,
+    switchNetwork,
+    network,
+    disconnectWallet,
+  } = Connector.useContainer();
 
   const [localNetwork, setLocalNetwork] = useState<NetworkId>(
     network?.id ? (network.id as NetworkId) : (NetworkIdByName.mainnet as NetworkId)
@@ -29,6 +35,7 @@ export const Header: FC = () => {
 
   return (
     <Navigation
+      disconnectWallet={disconnectWallet}
       isWalletConnected={isWalletConnected}
       connectWallet={() => connectWallet(localNetwork)}
       currentNetwork={localNetwork}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7129,6 +7129,7 @@ __metadata:
     "@chakra-ui/react": ^2.2.8
     "@snx-v2/EpochPrice": "workspace:^"
     "@snx-v2/UserBalances": "workspace:*"
+    "@snx-v2/WalletModal": "workspace:*"
     "@snx-v2/formatters": "workspace:*"
     "@snx-v2/icons": "workspace:*"
     "@snx-v2/useDebtData": "workspace:*"
@@ -7138,6 +7139,7 @@ __metadata:
     "@storybook/react": ^6.5.10
     "@synthetixio/contracts-interface": "workspace:*"
     "@synthetixio/wei": "workspace:*"
+    react: ^18.2.0
     react-i18next: ^11.18.3
     react-router-dom: ^6.3.0
   languageName: unknown
@@ -7252,6 +7254,28 @@ __metadata:
     "@snx-v2/icons": "workspace:*"
     "@storybook/react": ^6.5.10
     react: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
+"@snx-v2/WalletModal@workspace:*, @snx-v2/WalletModal@workspace:v2/components/WalletModal":
+  version: 0.0.0-use.local
+  resolution: "@snx-v2/WalletModal@workspace:v2/components/WalletModal"
+  dependencies:
+    "@chakra-ui/react": ^2.2.8
+    "@snx-v2/ContractContext": "workspace:*"
+    "@snx-v2/ExternalLink": "workspace:*"
+    "@snx-v2/formatters": "workspace:*"
+    "@snx-v2/icons": "workspace:*"
+    "@snx-v2/txnLink": "workspace:*"
+    "@snx-v2/useDebtData": "workspace:*"
+    "@snx-v2/useExchangeRatesData": "workspace:*"
+    "@snx-v2/useSynthsBalances": "workspace:*"
+    "@synthetixio/v3-theme": "workspace:*"
+    "@synthetixio/wei": "workspace:*"
+    react: ^18.2.0
+    react-copy-to-clipboard: ^5.1.0
+    react-i18next: ^11.18.3
+    react-router-dom: ^6.3.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7273,7 +7273,6 @@ __metadata:
     "@synthetixio/v3-theme": "workspace:*"
     "@synthetixio/wei": "workspace:*"
     react: ^18.2.0
-    react-copy-to-clipboard: ^5.1.0
     react-i18next: ^11.18.3
     react-router-dom: ^6.3.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -7270,8 +7270,8 @@ __metadata:
     "@snx-v2/useDebtData": "workspace:*"
     "@snx-v2/useExchangeRatesData": "workspace:*"
     "@snx-v2/useSynthsBalances": "workspace:*"
+    "@storybook/react": ^6.5.10
     "@synthetixio/v3-theme": "workspace:*"
-    "@synthetixio/wei": "workspace:*"
     react: ^18.2.0
     react-i18next: ^11.18.3
     react-router-dom: ^6.3.0


### PR DESCRIPTION
Some differences compared to the design, need to have a chart with Jade.. But at least a start 
<img width="464" alt="Screen Shot 2022-10-28 at 12 46 45 pm" src="https://user-images.githubusercontent.com/5688912/198453331-145a3456-dc08-4714-8883-ef4d6ea1ad22.png">

Things to chat with Jade about:
- Icons, the design is using perps icons
- The description under the synth name, is currently not included. If we want we could use the description from here: https://github.com/Synthetixio/synthetix/blob/develop/publish/assets.json?
- "Connected with MetaMask" note, not sure how much value that adds and also not sure how easy it is to know what wallet is used
- Leaving out Delegated and Watch Wallet. I think we need designs for these. currently they opens in a modal. It would be a little weird to open a modal from a modal.
- How should this popup look when we're not connected? Should the Account menu item be hidden?
-  We will only show synths if you have any balance, and maximum 5 of them. SNX is always on top, even if you dont have any. Is this the expected behavoiur?