### PR TITLE
Burn fixes

### DIFF
--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -423,7 +423,7 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
 
       case 'max': {
         setActiveBadge('max');
-        const burnAmountString = formatNumber(susdBalance.toNumber());
+        const burnAmountString = formatNumber(debtData.debtBalance.toNumber());
         const snxUnstakingAmount = formatNumber(stakedSnx.toNumber());
         setBurnAmountSusd(burnAmountString);
         setSnxUnstakingAmount(snxUnstakingAmount);
@@ -468,11 +468,11 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
               const snxUnstakingAmount = burnAmount
                 ? calculateUnstakingAmountFromBurn({
                     burnAmount: parsedBurnAmount,
-                      targetCRatio: debtData.targetCRatio.toNumber(),
-                      collateralPrice: snxPrice,
-                      debtBalance: debtData.debtBalance.toNumber(),
-                      issuableSynths: debtData.issuableSynths.toNumber(),
-                    })
+                    targetCRatio: debtData.targetCRatio.toNumber(),
+                    collateralPrice: snxPrice,
+                    debtBalance: debtData.debtBalance.toNumber(),
+                    issuableSynths: debtData.issuableSynths.toNumber(),
+                  })
                 : undefined;
               setActiveBadge(undefined);
               setBurnAmountSusd(burnAmount);

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -237,7 +237,7 @@ export const BurnUi = ({
               onClick={() => handleBadgePress('toTarget')}
             >
               {t('staking-v2.burn.burn-cratio')}
-              <Tooltip label="Soonthetix" hasArrow>
+              <Tooltip label="Amount of debt to burn" hasArrow>
                 <Flex alignItems="center">
                   <InfoIcon
                     width="12px"
@@ -267,7 +267,10 @@ export const BurnUi = ({
           >
             {t('staking-v2.burn.unstaking')}
           </Text>
-          <Tooltip label="Soonthetix" hasArrow>
+          <Tooltip
+            label="When you're c-ratio is below target all your SNX is considered staked"
+            hasArrow
+          >
             <Flex>
               <InfoIcon width="12px" height="12px" />
             </Flex>
@@ -318,10 +321,7 @@ export const BurnUi = ({
             </Flex>
           </Flex>
         </Box>
-        <MintOrBurnChanges
-          collateralChange={parseFloatWithCommas(snxUnstakingAmount)}
-          action="burn"
-        />
+        <MintOrBurnChanges debtChange={parseFloatWithCommas(burnAmountSusd)} action="burn" />
         {gasError || notEnoughBalance ? (
           <Center>
             <FailedIcon width="40px" height="40px" />
@@ -469,14 +469,18 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
               setSnxUnstakingAmount(snxUnstakingAmount);
             }}
             onUnstakeAmountChange={(val) => {
-              const burnAmount = calculateBurnAmountFromUnstaking(
-                val,
-                debtData?.targetCRatio.toNumber(),
-                exchangeRateData?.SNX?.toNumber()
-              );
+              if (!debtData) return;
+
+              const burnAmount = calculateBurnAmountFromUnstaking({
+                unStakingAmount: val,
+                targetCRatio: debtData?.targetCRatio.toNumber(),
+                collateralPrice: exchangeRateData?.SNX?.toNumber(),
+                debtBalance: debtData.debtBalance.toNumber(),
+                issuableSynths: debtData.issuableSynths.toNumber(),
+              });
               setActiveBadge(undefined);
               setSnxUnstakingAmount(val);
-              setBurnAmountSusd(burnAmount);
+              setBurnAmountSusd(formatNumber(burnAmount));
             }}
             onBadgeClick={handleBadgeClick}
             gasError={gasError}

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -52,6 +52,7 @@ interface BurnProps {
   onBadgeClick: (badge: ActiveBadge) => void;
   stakedSnx: number;
   debtBalance?: number;
+  sUsdAmountToTarget: number;
 }
 
 type ActiveBadge = 'max' | 'toTarget';
@@ -93,6 +94,7 @@ export const BurnUi = ({
   debtBalance,
   gasError,
   isGasEnabledAndNotFetched,
+  sUsdAmountToTarget,
 }: BurnProps) => {
   const { t } = useTranslation();
   const [activeBadge, setActiveBadge] = useState<ActiveBadge | null>(null);
@@ -249,11 +251,13 @@ export const BurnUi = ({
             </Badge>
           </Flex>
         </Box>
-        {activeBadge === 'toTarget' && (
+        {snxUnstakingAmount === '0.00' && (
           <Alert my={4} status="info" variant="left-accent" py={2} px={3}>
             <AlertIcon width="20px" height="20px" />
-            <AlertDescription pl={2} pr={[0, 0, 24]} fontSize="sm" fontFamily="heading">
-              {t('staking-v2.burn.description-cratio')}
+            <AlertDescription pl={2} pr={0} fontSize="sm" fontFamily="heading">
+              {t('staking-v2.burn.unstaking-note', {
+                sUsdAmountToTarget: sUsdAmountToTarget ? formatNumber(sUsdAmountToTarget) : 0,
+              })}
             </AlertDescription>
           </Alert>
         )}
@@ -453,6 +457,10 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
             isLoading={isLoading}
             susdBalance={susdBalance?.toNumber()}
             snxUnstakingAmount={snxUnstakingAmount}
+            sUsdAmountToTarget={Math.max(
+              debtData?.debtBalance.sub(debtData?.issuableSynths || 0)?.toNumber() || 0,
+              0
+            )}
             burnAmountSusd={burnAmountSusd}
             onBurnAmountSusdChange={(burnAmount) => {
               if (burnAmount === '') {

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -251,7 +251,7 @@ export const BurnUi = ({
             </Badge>
           </Flex>
         </Box>
-        {snxUnstakingAmount === '0.00' && (
+        {parseFloatWithCommas(snxUnstakingAmount) === 0 && (
           <Alert my={4} status="info" variant="left-accent" py={2} px={3}>
             <AlertIcon width="20px" height="20px" />
             <AlertDescription pl={2} pr={0} fontSize="sm" fontFamily="heading">

--- a/v2/components/Mint/Mint.tsx
+++ b/v2/components/Mint/Mint.tsx
@@ -263,23 +263,37 @@ export const Mint: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
             isLoading={isLoading}
             stakeAmountSNX={stakeAmountSNX}
             mintAmountsUSD={mintAmountSUSD}
-            onStakeAmountSNXChange={(val) => {
+            onStakeAmountSNXChange={(stakeAmount) => {
+              if (stakeAmount === '') {
+                setStakeAmountSNX('');
+                setMintAmountSUSD('');
+                return;
+              }
+              const parsedStakeAmount = parseFloatWithCommas(stakeAmount);
+              if (isNaN(parsedStakeAmount)) return undefined;
               const mintAmountSUSD = calculateMintAmountFromStaking(
-                val,
+                parsedStakeAmount,
                 targetCRatio?.toNumber(),
                 exchangeRateData?.SNX?.toNumber()
               );
-              setStakeAmountSNX(val);
-              setMintAmountSUSD(mintAmountSUSD);
+              setStakeAmountSNX(stakeAmount);
+              setMintAmountSUSD(mintAmountSUSD === undefined ? '' : formatNumber(mintAmountSUSD));
             }}
-            onMintAmountSUSDChange={(val) => {
+            onMintAmountSUSDChange={(mintAmount) => {
+              if (mintAmount === '') {
+                setStakeAmountSNX('');
+                setMintAmountSUSD('');
+                return;
+              }
+              const parsedMintAmount = parseFloatWithCommas(mintAmount);
+              if (isNaN(parsedMintAmount)) return undefined;
               const stakeAmountSNX = calculateStakeAmountFromMint(
-                val,
+                parsedMintAmount,
                 targetCRatio?.toNumber(),
                 exchangeRateData?.SNX?.toNumber()
               );
-              setMintAmountSUSD(val);
-              setStakeAmountSNX(stakeAmountSNX);
+              setMintAmountSUSD(mintAmount);
+              setStakeAmountSNX(stakeAmountSNX === undefined ? '' : formatNumber(stakeAmountSNX));
             }}
             unstakedSnx={unstakedSnx.toNumber()}
             susdBalance={synthsData?.balancesMap.sUSD?.balance.toNumber()}

--- a/v2/components/Mint/Mint.tsx
+++ b/v2/components/Mint/Mint.tsx
@@ -179,7 +179,7 @@ export const MintUi = ({
             </Flex>
           </Flex>
         </Box>
-        <MintOrBurnChanges collateralChange={parseFloatWithCommas(stakeAmountSNX)} action="mint" />
+        <MintOrBurnChanges debtChange={parseFloatWithCommas(mintAmountsUSD)} action="mint" />
         {gasError ? (
           <Center>
             <FailedIcon width="40px" height="40px" />

--- a/v2/components/MintOrBurnChanges/MintOrBurnChanges.tsx
+++ b/v2/components/MintOrBurnChanges/MintOrBurnChanges.tsx
@@ -134,6 +134,7 @@ export const MintOrBurnChanges: FC<{ collateralChange: number; action: 'mint' | 
   }
   const args = {
     debtBalance: debtData.debtBalance.toNumber(),
+    targetCRatio: debtData.targetCRatio.toNumber(),
     stakedSnx: stakedSnx.toNumber(),
     transferable: debtData?.transferable.toNumber(),
     sUSDBalance: sUSDBalance,
@@ -154,7 +155,6 @@ export const MintOrBurnChanges: FC<{ collateralChange: number; action: 'mint' | 
         })
       : calculateChangesFromBurn({
           ...args,
-          snxUnstakingAmount: collateralChange,
           collateral: debtData.collateral.toNumber(),
           burnAmountSusd: parseFloatWithCommas(
             calculateBurnAmountFromUnstaking(

--- a/v2/components/MintOrBurnChanges/MintOrBurnChanges.tsx
+++ b/v2/components/MintOrBurnChanges/MintOrBurnChanges.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { Box, Flex, Text, Tooltip } from '@chakra-ui/react';
-import { formatNumber, formatPercent, parseFloatWithCommas } from '@snx-v2/formatters';
+import { formatNumber, formatPercent } from '@snx-v2/formatters';
 import { ArrowRight, InfoIcon } from '@snx-v2/icons';
 import {
   calculateChangesFromBurn,
@@ -143,13 +143,12 @@ export const MintOrBurnChanges: FC<{ debtChange: number; action: 'mint' | 'burn'
     action === 'mint'
       ? calculateChangesFromMint({
           ...args,
-          stakeAmountSNX: parseFloatWithCommas(
+          stakeAmountSNX:
             calculateStakeAmountFromMint(
-              String(debtChange),
+              debtChange,
               debtData.targetCRatio.toNumber(),
-              exchangeRateData.SNX?.toNumber()
-            )
-          ),
+              exchangeRateData.SNX.toNumber()
+            ) || 0,
           mintAmountsUSD: debtChange,
         })
       : calculateChangesFromBurn({

--- a/v2/components/MintOrBurnChanges/MintOrBurnChanges.tsx
+++ b/v2/components/MintOrBurnChanges/MintOrBurnChanges.tsx
@@ -3,10 +3,9 @@ import { Box, Flex, Text, Tooltip } from '@chakra-ui/react';
 import { formatNumber, formatPercent, parseFloatWithCommas } from '@snx-v2/formatters';
 import { ArrowRight, InfoIcon } from '@snx-v2/icons';
 import {
-  calculateBurnAmountFromUnstaking,
   calculateChangesFromBurn,
   calculateChangesFromMint,
-  calculateMintAmountFromStaking,
+  calculateStakeAmountFromMint,
   calculateStakedSnx,
 } from '@snx-v2/stakingCalculations';
 import { useDebtData } from '@snx-v2/useDebtData';
@@ -112,8 +111,8 @@ export const MintOrBurnChangesUi: FC<{
     </Box>
   );
 };
-export const MintOrBurnChanges: FC<{ collateralChange: number; action: 'mint' | 'burn' }> = ({
-  collateralChange,
+export const MintOrBurnChanges: FC<{ debtChange: number; action: 'mint' | 'burn' }> = ({
+  debtChange,
   action,
 }) => {
   const { data: debtData } = useDebtData();
@@ -126,7 +125,7 @@ export const MintOrBurnChanges: FC<{ collateralChange: number; action: 'mint' | 
     !debtData ||
     !synthBalanceData ||
     !exchangeRateData ||
-    !collateralChange ||
+    !debtChange ||
     !exchangeRateData?.SNX ||
     sUSDBalance === undefined
   ) {
@@ -144,25 +143,19 @@ export const MintOrBurnChanges: FC<{ collateralChange: number; action: 'mint' | 
     action === 'mint'
       ? calculateChangesFromMint({
           ...args,
-          stakeAmountSNX: collateralChange,
-          mintAmountsUSD: parseFloatWithCommas(
-            calculateMintAmountFromStaking(
-              String(collateralChange),
+          stakeAmountSNX: parseFloatWithCommas(
+            calculateStakeAmountFromMint(
+              String(debtChange),
               debtData.targetCRatio.toNumber(),
               exchangeRateData.SNX?.toNumber()
             )
           ),
+          mintAmountsUSD: debtChange,
         })
       : calculateChangesFromBurn({
           ...args,
           collateral: debtData.collateral.toNumber(),
-          burnAmountSusd: parseFloatWithCommas(
-            calculateBurnAmountFromUnstaking(
-              String(collateralChange),
-              debtData.targetCRatio.toNumber(),
-              exchangeRateData.SNX?.toNumber()
-            )
-          ),
+          burnAmountSusd: debtChange,
         });
 
   return (

--- a/v2/lib/stakingCalculations/package.json
+++ b/v2/lib/stakingCalculations/package.json
@@ -4,7 +4,6 @@
   "main": "index.ts",
   "version": "0.0.0",
   "dependencies": {
-    "@snx-v2/formatters": "workspace:*",
     "@synthetixio/wei": "workspace:*"
   }
 }

--- a/v2/lib/stakingCalculations/stakingCalculations.test.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.test.ts
@@ -97,7 +97,7 @@ describe('stakingCalculation', () => {
     test('when target 400% (0.25%), snx price 2 and sUSD to get back to target is 0 (debtBalance-issuableSynths)', () => {
       expect(
         calculateUnstakingAmountFromBurn({
-          burnAmount: '10',
+          burnAmount: 10,
           targetCRatio: 0.25,
           collateralPrice: 2,
           debtBalance: 10,
@@ -108,7 +108,7 @@ describe('stakingCalculation', () => {
     test('when target 400% (0.25%), snx price 2 and sUSD to get back to target is $10 (debtBalance-issuableSynths)', () => {
       expect(
         calculateUnstakingAmountFromBurn({
-          burnAmount: '10',
+          burnAmount: 10,
           targetCRatio: 0.25,
           collateralPrice: 2,
           debtBalance: 20,
@@ -121,7 +121,7 @@ describe('stakingCalculation', () => {
     test('when target 400% (0.25%), snx price 2 and sUSD to get back to target is 0 (debtBalance-issuableSynths)', () => {
       expect(
         calculateBurnAmountFromUnstaking({
-          unStakingAmount: '20',
+          unStakingAmount: 20,
           targetCRatio: 0.25,
           collateralPrice: 2,
           debtBalance: 10,
@@ -132,7 +132,7 @@ describe('stakingCalculation', () => {
     test('when target 400% (0.25%),snx price 2 and sUSD to get back to target is $10 (debtBalance-issuableSynths)', () => {
       expect(
         calculateBurnAmountFromUnstaking({
-          unStakingAmount: '20',
+          unStakingAmount: 20,
           targetCRatio: 0.25,
           collateralPrice: 2,
           debtBalance: 20,
@@ -143,12 +143,12 @@ describe('stakingCalculation', () => {
   });
   describe('calculateStakeAmountFromMint', () => {
     test('when target 400% (0.25%) and snx price 2', () => {
-      expect(calculateStakeAmountFromMint('10', 0.25, 2)).toBe('20.00');
+      expect(calculateStakeAmountFromMint(10, 0.25, 2)).toBe(20);
     });
   });
   describe('calculateMintAmountFromStaking', () => {
     test('when target 400% (0.25%) and snx price 2', () => {
-      expect(calculateMintAmountFromStaking('20', 0.25, 2)).toBe('10.00');
+      expect(calculateMintAmountFromStaking(20, 0.25, 2)).toBe(10);
     });
   });
   describe('calculateChangesFromMint', () => {

--- a/v2/lib/stakingCalculations/stakingCalculations.test.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.test.ts
@@ -94,13 +94,51 @@ describe('stakingCalculation', () => {
     });
   });
   describe('calculateUnstakingAmountFromBurn', () => {
-    test('when target 400% (0.25%) and snx price 2', () => {
-      expect(calculateUnstakingAmountFromBurn('10', 0.25, 2)).toBe('20.00');
+    test('when target 400% (0.25%), snx price 2 and sUSD to get back to target is 0 (debtBalance-issuableSynths)', () => {
+      expect(
+        calculateUnstakingAmountFromBurn({
+          burnAmount: '10',
+          targetCRatio: 0.25,
+          collateralPrice: 2,
+          debtBalance: 10,
+          issuableSynths: 10,
+        })
+      ).toBe(20);
+    });
+    test('when target 400% (0.25%), snx price 2 and sUSD to get back to target is $10 (debtBalance-issuableSynths)', () => {
+      expect(
+        calculateUnstakingAmountFromBurn({
+          burnAmount: '10',
+          targetCRatio: 0.25,
+          collateralPrice: 2,
+          debtBalance: 20,
+          issuableSynths: 10,
+        })
+      ).toBe(0);
     });
   });
   describe('calculateBurnAmountFromUnstaking', () => {
-    test('when target 400% (0.25%) and snx price 2', () => {
-      expect(calculateBurnAmountFromUnstaking('20', 0.25, 2)).toBe('10.00');
+    test('when target 400% (0.25%), snx price 2 and sUSD to get back to target is 0 (debtBalance-issuableSynths)', () => {
+      expect(
+        calculateBurnAmountFromUnstaking({
+          unStakingAmount: '20',
+          targetCRatio: 0.25,
+          collateralPrice: 2,
+          debtBalance: 10,
+          issuableSynths: 10,
+        })
+      ).toBe(10);
+    });
+    test('when target 400% (0.25%),snx price 2 and sUSD to get back to target is $10 (debtBalance-issuableSynths)', () => {
+      expect(
+        calculateBurnAmountFromUnstaking({
+          unStakingAmount: '20',
+          targetCRatio: 0.25,
+          collateralPrice: 2,
+          debtBalance: 20,
+          issuableSynths: 10,
+        })
+      ).toBe(20);
     });
   });
   describe('calculateStakeAmountFromMint', () => {
@@ -171,24 +209,25 @@ describe('stakingCalculation', () => {
   });
   describe('calculateChangesFromBurn', () => {
     test('burning 10SNX', () => {
-      const snxUnstakingAmount = 10;
       const burnAmountSusd = 5;
       const stakedSnx = 20;
       const debtBalance = 10;
       const transferable = 50;
       const sUSDBalance = 10;
+      const collateral = 50;
       const collateralUsdValue = 100;
+      const targetCRatio = 0.25;
 
       expect(
         calculateChangesFromBurn({
-          snxUnstakingAmount,
           burnAmountSusd,
           stakedSnx,
           debtBalance,
           transferable,
           sUSDBalance,
           collateralUsdValue,
-          collateral: 50,
+          collateral,
+          targetCRatio,
         })
       ).toEqual({
         newCratio: 0.05,
@@ -199,7 +238,6 @@ describe('stakingCalculation', () => {
       });
     });
     test('burning more than debt balance', () => {
-      const snxUnstakingAmount = 1000;
       const burnAmountSusd = 500;
       const stakedSnx = 10;
       const debtBalance = 10;
@@ -207,10 +245,10 @@ describe('stakingCalculation', () => {
       const sUSDBalance = 10;
       const collateralUsdValue = 100;
       const collateral = 50;
+      const targetCRatio = 0.25;
 
       expect(
         calculateChangesFromBurn({
-          snxUnstakingAmount,
           burnAmountSusd,
           stakedSnx,
           debtBalance,
@@ -218,6 +256,7 @@ describe('stakingCalculation', () => {
           sUSDBalance,
           collateralUsdValue,
           collateral,
+          targetCRatio,
         })
       ).toEqual({
         newCratio: 0,

--- a/v2/lib/stakingCalculations/stakingCalculations.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.ts
@@ -85,7 +85,6 @@ export const calculateChangesFromMint = ({
 };
 
 export const calculateChangesFromBurn = ({
-  snxUnstakingAmount,
   burnAmountSusd,
   debtBalance,
   stakedSnx,
@@ -93,8 +92,8 @@ export const calculateChangesFromBurn = ({
   sUSDBalance,
   collateralUsdValue,
   collateral,
+  targetCRatio,
 }: {
-  snxUnstakingAmount: number;
   burnAmountSusd: number;
   debtBalance: number;
   stakedSnx: number;
@@ -102,13 +101,19 @@ export const calculateChangesFromBurn = ({
   sUSDBalance: number;
   collateralUsdValue: number;
   collateral: number;
+  targetCRatio: number;
 }) => {
   const newDebtBalance = Math.max(debtBalance - burnAmountSusd, 0);
-  const newStakedAmountSnx = Math.max(stakedSnx - snxUnstakingAmount, 0);
   const newCratio = newDebtBalance / collateralUsdValue || 0;
+  const newStakedAmountSnx = calculateStakedSnx({
+    currentCRatio: wei(newCratio),
+    targetCRatio: wei(targetCRatio),
+    collateral: wei(collateral),
+  }).toNumber();
+
   const escrowedSnx = collateral - stakedSnx - transferable;
-  const maxTransferable = collateral - escrowedSnx;
-  const newTransferable = Math.min(transferable + snxUnstakingAmount, maxTransferable);
+  const newTransferable = collateral - escrowedSnx - newStakedAmountSnx;
+
   const newSUSDBalance = Math.max(sUSDBalance - burnAmountSusd, 0);
   return { newDebtBalance, newStakedAmountSnx, newCratio, newTransferable, newSUSDBalance };
 };

--- a/v2/lib/stakingCalculations/stakingCalculations.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.ts
@@ -70,7 +70,7 @@ export const calculateUnstakingAmountFromBurn = ({
   const debtToGetBackToTarget = Math.max(debtBalance - issuableSynths, 0);
   const burnAmountAfterDebtIsClear = burnAmountNumber - debtToGetBackToTarget;
   if (burnAmountAfterDebtIsClear <= 0) {
-    return formatNumber(0);
+    return 0;
   }
   const newUnstakingAmount = calculateCollateralFromDebt(
     formatNumber(burnAmountAfterDebtIsClear),

--- a/v2/lib/stakingCalculations/stakingCalculations.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.ts
@@ -52,9 +52,52 @@ const calculateCollateralFromDebt = (
   return formatNumber(num / targetCRatio / collateralPrice);
 };
 
-// Even though the logic is the same for mint and burn I think it make sense to export nicer named functions
-export const calculateUnstakingAmountFromBurn = calculateCollateralFromDebt;
-export const calculateBurnAmountFromUnstaking = calculateDebtFromCollateral;
+export const calculateUnstakingAmountFromBurn = ({
+  burnAmount,
+  targetCRatio,
+  collateralPrice,
+  debtBalance,
+  issuableSynths,
+}: {
+  burnAmount: string;
+  targetCRatio: number;
+  collateralPrice: number;
+  debtBalance: number;
+  issuableSynths: number;
+}) => {
+  const burnAmountNumber = parseFloatWithCommas(burnAmount);
+
+  const debtToGetBackToTarget = Math.max(debtBalance - issuableSynths, 0);
+  const burnAmountAfterDebtIsClear = burnAmountNumber - debtToGetBackToTarget;
+  if (burnAmountAfterDebtIsClear <= 0) {
+    return formatNumber(0);
+  }
+  const newUnstakingAmount = calculateCollateralFromDebt(
+    formatNumber(burnAmountAfterDebtIsClear),
+    targetCRatio,
+    collateralPrice
+  );
+
+  return Math.max(parseFloatWithCommas(newUnstakingAmount), 0);
+};
+
+export const calculateBurnAmountFromUnstaking = ({
+  unStakingAmount,
+  targetCRatio,
+  collateralPrice,
+  debtBalance,
+  issuableSynths,
+}: {
+  unStakingAmount: string;
+  targetCRatio?: number;
+  collateralPrice?: number;
+  debtBalance: number;
+  issuableSynths: number;
+}) => {
+  const debtToGetBackToTarget = Math.max(debtBalance - issuableSynths, 0);
+  const newBurnAmount = calculateDebtFromCollateral(unStakingAmount, targetCRatio, collateralPrice);
+  return parseFloatWithCommas(newBurnAmount) + debtToGetBackToTarget;
+};
 export const calculateMintAmountFromStaking = calculateDebtFromCollateral;
 export const calculateStakeAmountFromMint = calculateCollateralFromDebt;
 

--- a/v2/lib/stakingCalculations/stakingCalculations.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.ts
@@ -29,27 +29,23 @@ export const calculateUnstakedStakedSnx = ({
     : wei(0);
 
 const calculateDebtFromCollateral = (
-  collateral: string,
+  collateral: number,
   targetCRatio?: number,
   collateralPrice?: number
 ) => {
-  const num = parseFloatWithCommas(collateral);
-  if (isNaN(num)) return '';
-  if (!targetCRatio || !collateralPrice) return '';
+  if (!targetCRatio || !collateralPrice) return undefined;
 
-  return formatNumber(num * targetCRatio * collateralPrice);
+  return collateral * targetCRatio * collateralPrice;
 };
 
 const calculateCollateralFromDebt = (
-  debtUsd: string,
+  debtUsd: number,
   targetCRatio?: number,
   collateralPrice?: number
 ) => {
-  const num = parseFloatWithCommas(debtUsd);
-  if (isNaN(num)) return '';
-  if (!targetCRatio || !collateralPrice) return '';
+  if (!targetCRatio || !collateralPrice) return undefined;
 
-  return formatNumber(num / targetCRatio / collateralPrice);
+  return debtUsd / targetCRatio / collateralPrice;
 };
 
 export const calculateUnstakingAmountFromBurn = ({
@@ -59,26 +55,25 @@ export const calculateUnstakingAmountFromBurn = ({
   debtBalance,
   issuableSynths,
 }: {
-  burnAmount: string;
+  burnAmount: number;
   targetCRatio: number;
   collateralPrice: number;
   debtBalance: number;
   issuableSynths: number;
 }) => {
-  const burnAmountNumber = parseFloatWithCommas(burnAmount);
-
   const debtToGetBackToTarget = Math.max(debtBalance - issuableSynths, 0);
-  const burnAmountAfterDebtIsClear = burnAmountNumber - debtToGetBackToTarget;
-  if (burnAmountAfterDebtIsClear <= 0) {
+  const burnAmountAfterDebtIsCleared = burnAmount - debtToGetBackToTarget;
+  if (burnAmountAfterDebtIsCleared <= 0) {
     return 0;
   }
   const newUnstakingAmount = calculateCollateralFromDebt(
-    formatNumber(burnAmountAfterDebtIsClear),
+    burnAmountAfterDebtIsCleared,
     targetCRatio,
     collateralPrice
   );
+  if (newUnstakingAmount === undefined) return undefined;
 
-  return Math.max(parseFloatWithCommas(newUnstakingAmount), 0);
+  return Math.max(newUnstakingAmount, 0);
 };
 
 export const calculateBurnAmountFromUnstaking = ({
@@ -88,7 +83,7 @@ export const calculateBurnAmountFromUnstaking = ({
   debtBalance,
   issuableSynths,
 }: {
-  unStakingAmount: string;
+  unStakingAmount: number;
   targetCRatio?: number;
   collateralPrice?: number;
   debtBalance: number;
@@ -96,7 +91,8 @@ export const calculateBurnAmountFromUnstaking = ({
 }) => {
   const debtToGetBackToTarget = Math.max(debtBalance - issuableSynths, 0);
   const newBurnAmount = calculateDebtFromCollateral(unStakingAmount, targetCRatio, collateralPrice);
-  return parseFloatWithCommas(newBurnAmount) + debtToGetBackToTarget;
+  if (newBurnAmount === undefined) return undefined;
+  return newBurnAmount + debtToGetBackToTarget;
 };
 export const calculateMintAmountFromStaking = calculateDebtFromCollateral;
 export const calculateStakeAmountFromMint = calculateCollateralFromDebt;

--- a/v2/lib/stakingCalculations/stakingCalculations.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.ts
@@ -1,4 +1,3 @@
-import { formatNumber, parseFloatWithCommas } from '@snx-v2/formatters';
 import Wei, { wei } from '@synthetixio/wei';
 
 export const calculateStakedSnx = ({

--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -110,7 +110,7 @@
       "burn-debt": "Clear Debt",
       "active-debt": "Active debt: ",
       "staked-snx": "Staked SNX: ",
-      "description-cratio": "Burn to C-Ratio - Burn sUSD required to reach target C-Ratio",
+      "unstaking-note": "When burning while under target c-ratio, you are not unstaking SNX. You need to burn {{sUsdAmountToTarget}} sUSD to have a c-ratio above target and unstake SNX.",
       "balance-error": "Not enough sUSD balance",
       "txn-modal": {
         "unstaking": "Unstaking",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7342,7 +7342,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@snx-v2/stakingCalculations@workspace:v2/lib/stakingCalculations"
   dependencies:
-    "@snx-v2/formatters": "workspace:*"
     "@synthetixio/wei": "workspace:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
The burn UI now accurately calculates unstaking amount taking your c-ratio into consideration.
If you burning to c-ratio unstaking will always be 0.

I also refactored the calculations a bit. They now just work with numbers. Input validation (NaN checks) is dont in the ui.
In general that shouldn't happen since the input field wont allow you to type non numbers.

Happy to talk through these changes if any of you wants to dive deeper.

<img width="631" alt="Screen Shot 2022-11-02 at 10 04 24 am" src="https://user-images.githubusercontent.com/5688912/199358839-032cc74c-0dc9-4797-ac5e-61d27d89333b.png">
