### PR TITLE
Wallet fixes

### DIFF
--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -277,7 +277,7 @@ export const NavigationUI = ({
                 <Text ml={2}>{t('common.wallet.menu.settings')}</Text>
               </Center>
             </MenuItem> */}
-            <MenuItem onClick={() => navigate('/')}>
+            <MenuItem onClick={() => window.open('https://synthetix.io/guides', '_newtab')}>
               <GuideIcon />
               <Text ml={2}>{t('common.wallet.menu.guide')}</Text>
             </MenuItem>

--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -265,12 +265,14 @@ export const NavigationUI = ({
                 <Text ml={2}>{t('common.wallet.menu.gov')}</Text>
               </Center>
             </MenuItem>
-            <MenuItem onClick={onOpen}>
-              <Center>
-                <WalletIcon color="white" />
-                <Text ml={2}>{t('common.wallet.menu.wallet')}</Text>
-              </Center>
-            </MenuItem>
+            {isWalletConnected && (
+              <MenuItem onClick={onOpen}>
+                <Center>
+                  <WalletIcon color="white" />
+                  <Text ml={2}>{t('common.wallet.menu.wallet')}</Text>
+                </Center>
+              </MenuItem>
+            )}
             {/* <MenuItem onClick={() => navigate('/')}>
               <Center>
                 <SettingsIcon color="white" />

--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -27,7 +27,7 @@ import {
   StakingIcon,
   WalletIcon,
   StakingLogo,
-  InfoOutline,
+  // InfoOutline,
 } from '@snx-v2/icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -247,12 +247,12 @@ export const NavigationUI = ({
             </MenuButton>
           </Center>
           <MenuList>
-            <MenuItem onClick={() => navigate('/')}>
+            {/* <MenuItem onClick={() => navigate('/')}>
               <Center>
                 <InfoOutline />
                 <Text ml={2}>{t('common.wallet.menu.help')}</Text>
               </Center>
-            </MenuItem>
+            </MenuItem> */}
             <MenuItem onClick={() => navigate('/loans')}>
               <Center>
                 <LoansIcon />

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -141,14 +141,24 @@ export const WalletModalUi: FC<{
             <Button
               display="block"
               variant="ghost"
-              onClick={() => navigate('/synths')}
+              onClick={() => {
+                onClose();
+                navigate('/synths');
+              }}
               margin="0 auto"
             >
               {t('staking-v2.wallet-modal.view-all')}
             </Button>
           </Box>
           <Divider my={4} />
-          <Button onClick={() => navigate('/escrow')} margin="0 auto" display="block">
+          <Button
+            onClick={() => {
+              onClose();
+              navigate('/escrow');
+            }}
+            margin="0 auto"
+            display="block"
+          >
             {t('staking-v2.wallet-modal.escrow')}
           </Button>
         </ModalBody>

--- a/v2/components/WalletModal/WalletModal.tsx
+++ b/v2/components/WalletModal/WalletModal.tsx
@@ -78,7 +78,15 @@ export const WalletModalUi: FC<{
               <Text fontSize="sm" color="gray.800">
                 {t('staking-v2.wallet-modal.connected-with', { walletType })}
               </Text>
-              <Button size="xs" onClick={() => disconnectWallet()} variant="ghost">
+              <Button
+                size="xs"
+                onClick={() => {
+                  onClose();
+                  disconnectWallet();
+                  navigate('/');
+                }}
+                variant="ghost"
+              >
                 {t('staking-v2.wallet-modal.disconnect')}
               </Button>
             </Flex>


### PR DESCRIPTION
- Navigate to home when disconnecting wallet
- Close modal when navigating to new page
- Dont display help menu item
- Link to guide
- Only display account when wallet is connected