### PR TITLE
Target threshold

### DIFF
--- a/v2/components/Burn/BurnHeader.tsx
+++ b/v2/components/Burn/BurnHeader.tsx
@@ -64,7 +64,7 @@ export const BurnHeaderUi: FC<{
             fadeDuration={1}
           >
             <CRatioProgressBar
-              targetThreshold={targetThreshold || 0.01}
+              targetThreshold={targetThreshold || 0}
               liquidationCratioPercentage={liquidationRatioPercentage || 0}
               currentCRatioPercentage={currentCRatioPercentage || 0}
               targetCratioPercentage={targetCRatioPercentage || 0}

--- a/v2/components/Burn/BurnHeader.tsx
+++ b/v2/components/Burn/BurnHeader.tsx
@@ -12,12 +12,14 @@ export const BurnHeaderUi: FC<{
   liquidationRatioPercentage?: number;
   targetCRatioPercentage?: number;
   currentCRatioPercentage?: number;
+  targetThreshold?: number;
   isDebtDataLoading?: boolean;
 }> = ({
   burnAmountSusd,
   liquidationRatioPercentage,
   targetCRatioPercentage,
   currentCRatioPercentage,
+  targetThreshold,
   isDebtDataLoading,
 }) => {
   const { t } = useTranslation();
@@ -62,6 +64,7 @@ export const BurnHeaderUi: FC<{
             fadeDuration={1}
           >
             <CRatioProgressBar
+              targetThreshold={targetThreshold || 0.01}
               liquidationCratioPercentage={liquidationRatioPercentage || 0}
               currentCRatioPercentage={currentCRatioPercentage || 0}
               targetCratioPercentage={targetCRatioPercentage || 0}
@@ -97,6 +100,7 @@ export const BurnHeader: FC<{ burnAmountSusd: number }> = ({ burnAmountSusd }) =
       liquidationRatioPercentage={debtData?.liquidationRatioPercentage.toNumber()}
       targetCRatioPercentage={debtData?.targetCRatioPercentage.toNumber()}
       currentCRatioPercentage={debtData?.currentCRatioPercentage.toNumber()}
+      targetThreshold={debtData?.targetThreshold.toNumber()}
       isDebtDataLoading={isDebtDataLoading}
     />
   );

--- a/v2/components/CRatioBanner/CRatioBanner.tsx
+++ b/v2/components/CRatioBanner/CRatioBanner.tsx
@@ -80,6 +80,7 @@ export const CRatioBanner: React.FC = () => {
     currentCRatioPercentage: debtData.currentCRatioPercentage.toNumber(),
     targetCratioPercentage: debtData.targetCRatioPercentage.toNumber(),
     liquidationCratioPercentage: debtData.liquidationRatioPercentage.toNumber(),
+    targetThreshold: debtData.targetThreshold.toNumber(),
   });
 
   const isFlagged = debtData.liquidationDeadlineForAccount.gt(0);

--- a/v2/components/CRatioBox/CRatioBox.tsx
+++ b/v2/components/CRatioBox/CRatioBox.tsx
@@ -36,6 +36,7 @@ export const CRatioBoxUi: FC<{
   collateral?: number;
   debtBalance?: number;
   SNXRate?: number;
+  targetThreshold?: number;
 }> = ({
   currentCRatioPercentage,
   targetCRatioPercentage,
@@ -45,6 +46,7 @@ export const CRatioBoxUi: FC<{
   SNXRate,
   amount,
   actionType,
+  targetThreshold,
 }) => {
   const { t } = useTranslation();
 
@@ -52,6 +54,7 @@ export const CRatioBoxUi: FC<{
     currentCRatioPercentage,
     targetCratioPercentage: targetCRatioPercentage,
     liquidationCratioPercentage: liquidationRatioPercentage,
+    targetThreshold,
   });
   const newDebtBalance = calculateNewDebtBalance(actionType, debtBalance, amount);
   const newCratioPercentage = calcNewCratioPercentage(collateral, SNXRate, newDebtBalance);
@@ -62,6 +65,7 @@ export const CRatioBoxUi: FC<{
         : currentCRatioPercentage,
     targetCratioPercentage: targetCRatioPercentage,
     liquidationCratioPercentage: liquidationRatioPercentage,
+    targetThreshold,
   });
 
   const cRatioHealth = t(`staking-v2.cratio-box.${badgeHealthVariant}`);
@@ -104,6 +108,7 @@ export const CRatioBoxUi: FC<{
                         targetCratioPercentage: targetCRatioPercentage,
                         liquidationCratioPercentage: liquidationRatioPercentage,
                         currentCRatioPercentage: newCratioPercentage * 100,
+                        targetThreshold,
                       })
                     ).color
                   }
@@ -180,6 +185,7 @@ export const CRatioBox: FC<{ actionType: 'mint' | 'burn'; amount?: number }> = (
       collateral={debtData?.collateral.toNumber()}
       debtBalance={debtData?.debtBalance.toNumber()}
       SNXRate={exchangeRateData?.SNX?.toNumber()}
+      targetThreshold={debtData?.targetThreshold.toNumber()}
     />
   );
 };

--- a/v2/components/CRatioHealthCard/CRatioHealthCard.tsx
+++ b/v2/components/CRatioHealthCard/CRatioHealthCard.tsx
@@ -10,6 +10,7 @@ type UiProps = {
   liquidationCratioPercentage?: number;
   targetCratioPercentage?: number;
   currentCRatioPercentage?: number;
+  targetThreshold?: number;
   isLoading: boolean;
 };
 
@@ -17,6 +18,7 @@ export const CRatioHealthCardUi: React.FC<UiProps> = ({
   targetCratioPercentage,
   liquidationCratioPercentage,
   currentCRatioPercentage,
+  targetThreshold,
   isLoading,
 }) => {
   const { t } = useTranslation();
@@ -25,6 +27,7 @@ export const CRatioHealthCardUi: React.FC<UiProps> = ({
     targetCratioPercentage,
     liquidationCratioPercentage,
     currentCRatioPercentage,
+    targetThreshold,
   });
 
   return (
@@ -45,6 +48,7 @@ export const CRatioHealthCardUi: React.FC<UiProps> = ({
         />
       </Flex>
       <CRatioProgressBar
+        targetThreshold={targetThreshold || 0.01}
         targetCratioPercentage={targetCratioPercentage || 0}
         liquidationCratioPercentage={liquidationCratioPercentage || 0}
         currentCRatioPercentage={currentCRatioPercentage || 0}
@@ -62,6 +66,7 @@ export const CRatioHealthCard: React.FC = () => {
       currentCRatioPercentage={debtData?.currentCRatioPercentage.toNumber()}
       targetCratioPercentage={debtData?.targetCRatioPercentage.toNumber()}
       liquidationCratioPercentage={debtData?.liquidationRatioPercentage.toNumber()}
+      targetThreshold={debtData?.targetThreshold.toNumber()}
       isLoading={isLoading}
     />
   );

--- a/v2/components/CRatioHealthCard/CRatioHealthCard.tsx
+++ b/v2/components/CRatioHealthCard/CRatioHealthCard.tsx
@@ -48,7 +48,7 @@ export const CRatioHealthCardUi: React.FC<UiProps> = ({
         />
       </Flex>
       <CRatioProgressBar
-        targetThreshold={targetThreshold || 0.01}
+        targetThreshold={targetThreshold || 0}
         targetCratioPercentage={targetCratioPercentage || 0}
         liquidationCratioPercentage={liquidationCratioPercentage || 0}
         currentCRatioPercentage={currentCRatioPercentage || 0}

--- a/v2/components/CRatioHealthCard/CRatioProgressBar.tsx
+++ b/v2/components/CRatioHealthCard/CRatioProgressBar.tsx
@@ -51,11 +51,13 @@ export const CRatioProgressBar: FC<{
   liquidationCratioPercentage: number;
   targetCratioPercentage: number;
   currentCRatioPercentage: number;
+  targetThreshold: number;
   isLoading: boolean;
 }> = ({
   targetCratioPercentage,
   liquidationCratioPercentage,
   currentCRatioPercentage,
+  targetThreshold,
   isLoading,
 }) => {
   const maxRatioShown = Math.min(
@@ -70,6 +72,7 @@ export const CRatioProgressBar: FC<{
     targetCratioPercentage,
     liquidationCratioPercentage,
     currentCRatioPercentage,
+    targetThreshold,
   });
 
   return (

--- a/v2/components/MainActionCards/MainActionCards.tsx
+++ b/v2/components/MainActionCards/MainActionCards.tsx
@@ -171,12 +171,14 @@ const MaintainActionCard: React.FC<{
   liquidationCratioPercentage?: number;
   targetCratioPercentage?: number;
   currentCRatioPercentage?: number;
+  targetThreshold?: number;
   isFlagged?: boolean;
 }> = ({
   isLoading,
   liquidationCratioPercentage,
   targetCratioPercentage,
   currentCRatioPercentage,
+  targetThreshold,
   isFlagged,
 }) => {
   const navigate = useNavigate();
@@ -186,6 +188,7 @@ const MaintainActionCard: React.FC<{
     liquidationCratioPercentage,
     targetCratioPercentage,
     currentCRatioPercentage,
+    targetThreshold,
   });
 
   const isStaking = currentCRatioPercentage && currentCRatioPercentage > 0;
@@ -264,6 +267,7 @@ const CollectActionCard: React.FC<{
   nextEpochStartDate?: Date;
   hasClaimed?: boolean;
   snxPrice?: string;
+  targetThreshold?: number;
 }> = ({
   isLoading,
   liquidationCratioPercentage,
@@ -272,6 +276,7 @@ const CollectActionCard: React.FC<{
   nextEpochStartDate,
   hasClaimed,
   snxPrice,
+  targetThreshold,
 }) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -280,6 +285,7 @@ const CollectActionCard: React.FC<{
     liquidationCratioPercentage,
     targetCratioPercentage,
     currentCRatioPercentage,
+    targetThreshold,
   });
 
   const isStaking = currentCRatioPercentage && currentCRatioPercentage > 0;
@@ -364,6 +370,7 @@ type UiProps = {
   snxPrice?: string;
   connectWallet: (chainId?: NetworkId | undefined) => Promise<void>;
   walletAddress: string | null;
+  targetThreshold?: number;
 };
 
 export const MainActionCardsUi: React.FC<UiProps> = ({
@@ -377,6 +384,7 @@ export const MainActionCardsUi: React.FC<UiProps> = ({
   snxPrice,
   connectWallet,
   walletAddress,
+  targetThreshold,
 }) => {
   return (
     <Stack direction={['column', 'column', 'row']} align="center" spacing="14px">
@@ -393,6 +401,7 @@ export const MainActionCardsUi: React.FC<UiProps> = ({
         targetCratioPercentage={targetCratioPercentage}
         currentCRatioPercentage={currentCRatioPercentage}
         isFlagged={isFlagged}
+        targetThreshold={targetThreshold}
       />
       <CollectActionCard
         isLoading={isLoading}
@@ -402,6 +411,7 @@ export const MainActionCardsUi: React.FC<UiProps> = ({
         hasClaimed={hasClaimed}
         nextEpochStartDate={nextEpochStartDate}
         snxPrice={snxPrice}
+        targetThreshold={targetThreshold}
       />
     </Stack>
   );

--- a/v2/components/MainActionCards/MainActionCardsList.tsx
+++ b/v2/components/MainActionCards/MainActionCardsList.tsx
@@ -33,6 +33,7 @@ export const MainActionCardsList = ({ connectWallet }: MainActionsCardsListProps
       nextEpochStartDate={feePoolData?.nextFeePeriodStartDate}
       snxPrice={exchangeRateData?.SNX?.toString()}
       walletAddress={walletAddress}
+      targetThreshold={debtData?.targetThreshold.toNumber()}
     />
   );
 };

--- a/v2/components/Mint/MintHeader.tsx
+++ b/v2/components/Mint/MintHeader.tsx
@@ -69,6 +69,7 @@ export const MintHeaderUi: FC<{
   liquidationRatioPercentage?: number;
   targetCRatioPercentage?: number;
   currentCRatioPercentage?: number;
+  targetThreshold?: number;
   collateral?: number;
   debtBalance?: number;
   SNXRate?: number;
@@ -80,6 +81,7 @@ export const MintHeaderUi: FC<{
   liquidationRatioPercentage,
   targetCRatioPercentage,
   currentCRatioPercentage,
+  targetThreshold,
   SNXRate,
   isDebtDataLoading,
   isExchangeRateLoading,
@@ -162,6 +164,7 @@ export const MintHeaderUi: FC<{
                   liquidationCratioPercentage={liquidationRatioPercentage || 0}
                   currentCRatioPercentage={currentCRatioPercentage || 0}
                   targetCratioPercentage={targetCRatioPercentage || 0}
+                  targetThreshold={targetThreshold || 0.01}
                   isLoading={false}
                 />
               </Flex>
@@ -197,6 +200,7 @@ export const MintHeader: FC<{ mintAmountSUSD?: number }> = ({ mintAmountSUSD }) 
       liquidationRatioPercentage={debtData?.liquidationRatioPercentage.toNumber()}
       targetCRatioPercentage={debtData?.targetCRatioPercentage.toNumber()}
       currentCRatioPercentage={debtData?.currentCRatioPercentage.toNumber()}
+      targetThreshold={debtData?.targetThreshold.toNumber()}
       SNXRate={exchangeRateData?.SNX?.toNumber()}
       isDebtDataLoading={isDebtDataLoading}
       isExchangeRateLoading={isExchangeRateLoading}

--- a/v2/components/Mint/MintHeader.tsx
+++ b/v2/components/Mint/MintHeader.tsx
@@ -164,7 +164,7 @@ export const MintHeaderUi: FC<{
                   liquidationCratioPercentage={liquidationRatioPercentage || 0}
                   currentCRatioPercentage={currentCRatioPercentage || 0}
                   targetCratioPercentage={targetCRatioPercentage || 0}
-                  targetThreshold={targetThreshold || 0.01}
+                  targetThreshold={targetThreshold || 0}
                   isLoading={false}
                 />
               </Flex>

--- a/v2/components/SelfLiquidation/SelfLiquidation.tsx
+++ b/v2/components/SelfLiquidation/SelfLiquidation.tsx
@@ -76,7 +76,7 @@ export const SelfLiquidationUi: FC<{
           borderColor="gray.900"
         >
           <CRatioProgressBar
-            targetThreshold={targetThreshold || 0.01}
+            targetThreshold={targetThreshold || 0}
             liquidationCratioPercentage={liquidationRatioPercentage || 0}
             currentCRatioPercentage={currentCRatioPercentage || 0}
             targetCratioPercentage={targetCRatioPercentage || 0}

--- a/v2/components/SelfLiquidation/SelfLiquidation.tsx
+++ b/v2/components/SelfLiquidation/SelfLiquidation.tsx
@@ -20,6 +20,7 @@ export const SelfLiquidationUi: FC<{
   targetCRatioPercentage?: number;
   liquidationRatioPercentage?: number;
   currentCRatioPercentage?: number;
+  targetThreshold?: number;
   onSelfLiquidation: () => void;
   transactionFee?: Wei | null;
   isGasEnabledAndNotFetched: boolean;
@@ -31,6 +32,7 @@ export const SelfLiquidationUi: FC<{
   targetCRatioPercentage,
   liquidationRatioPercentage,
   currentCRatioPercentage,
+  targetThreshold,
   onSelfLiquidation,
   transactionFee,
   gasError,
@@ -74,6 +76,7 @@ export const SelfLiquidationUi: FC<{
           borderColor="gray.900"
         >
           <CRatioProgressBar
+            targetThreshold={targetThreshold || 0.01}
             liquidationCratioPercentage={liquidationRatioPercentage || 0}
             currentCRatioPercentage={currentCRatioPercentage || 0}
             targetCratioPercentage={targetCRatioPercentage || 0}
@@ -178,6 +181,7 @@ export const SelfLiquidation = () => {
         targetCRatioPercentage={debtData?.targetCRatioPercentage.toNumber()}
         liquidationRatioPercentage={debtData?.liquidationRatioPercentage.toNumber()}
         currentCRatioPercentage={debtData?.currentCRatioPercentage.toNumber()}
+        targetThreshold={debtData?.targetThreshold.toNumber()}
       />
       <SelfLiquidationTransactionModal
         txnHash={txnHash}

--- a/v2/lib/getHealthVariant/getHealthVariant.test.ts
+++ b/v2/lib/getHealthVariant/getHealthVariant.test.ts
@@ -6,6 +6,7 @@ describe('getVariant', () => {
       liquidationCratioPercentage: 130,
       targetCratioPercentage: 400,
       currentCRatioPercentage: 0,
+      targetThreshold: 0.01,
     };
     const result = getHealthVariant(arg);
     expect(result).toBe('success');
@@ -14,7 +15,18 @@ describe('getVariant', () => {
     const arg = {
       liquidationCratioPercentage: 130,
       targetCratioPercentage: 400,
-      currentCRatioPercentage: 401,
+      currentCRatioPercentage: 405,
+      targetThreshold: 0.01,
+    };
+    const result = getHealthVariant(arg);
+    expect(result).toBe('success');
+  });
+  test('success with threshold', () => {
+    const arg = {
+      liquidationCratioPercentage: 130,
+      targetCratioPercentage: 400,
+      currentCRatioPercentage: 397, // below target but within the threshold
+      targetThreshold: 0.01,
     };
     const result = getHealthVariant(arg);
     expect(result).toBe('success');
@@ -23,16 +35,29 @@ describe('getVariant', () => {
     const arg = {
       liquidationCratioPercentage: 130,
       targetCratioPercentage: 400,
-      currentCRatioPercentage: 399,
+      currentCRatioPercentage: 395,
+      targetThreshold: 0.01,
     };
     const result = getHealthVariant(arg);
     expect(result).toBe('warning');
   });
+  test('threshold doesnt apply to liquidationRatio', () => {
+    const arg = {
+      liquidationCratioPercentage: 130,
+      targetCratioPercentage: 400,
+      currentCRatioPercentage: 129, // would be ok if threshold was applied between warning and error
+      targetThreshold: 0.01,
+    };
+    const result = getHealthVariant(arg);
+    expect(result).toBe('error');
+  });
+
   test('error', () => {
     const arg = {
       liquidationCratioPercentage: 130,
       targetCratioPercentage: 400,
-      currentCRatioPercentage: 129,
+      currentCRatioPercentage: 125,
+      targetThreshold: 0.01,
     };
     const result = getHealthVariant(arg);
     expect(result).toBe('error');

--- a/v2/lib/getHealthVariant/getHealthVariant.ts
+++ b/v2/lib/getHealthVariant/getHealthVariant.ts
@@ -2,16 +2,20 @@ export const getHealthVariant = ({
   targetCratioPercentage,
   liquidationCratioPercentage,
   currentCRatioPercentage,
+  targetThreshold = 0.01,
 }: {
   liquidationCratioPercentage: number | undefined;
   targetCratioPercentage: number | undefined;
   currentCRatioPercentage: number | undefined;
+  targetThreshold: number | undefined;
 }) => {
   if (!liquidationCratioPercentage || !targetCratioPercentage || !currentCRatioPercentage)
     return 'success';
   if (currentCRatioPercentage === 0) return 'success';
+  const currentCRatioPercentageWithThresHold = currentCRatioPercentage * (1 + targetThreshold);
+  // You can claim rewards when you below target but within the targetThreshold, the threshold does NOT apply to the liquidationRatio
   if (currentCRatioPercentage < liquidationCratioPercentage) return 'error';
-  if (currentCRatioPercentage < targetCratioPercentage) return 'warning';
+  if (currentCRatioPercentageWithThresHold < targetCratioPercentage) return 'warning';
   return 'success';
 };
 

--- a/v2/lib/useSelfLiquidationData/useSelfLiquidationData.ts
+++ b/v2/lib/useSelfLiquidationData/useSelfLiquidationData.ts
@@ -22,6 +22,7 @@ export const useSelfLiquidationData = () => {
     targetCRatioPercentage,
     currentCRatioPercentage,
     liquidationRatioPercentage,
+    targetThreshold,
   } = debtData || {};
   const { SNX: SNXRate } = exchangeRateData || {};
   const { selfLiquidationPenalty } = liquidationData || {};
@@ -30,6 +31,7 @@ export const useSelfLiquidationData = () => {
     targetCratioPercentage: targetCRatioPercentage?.toNumber(),
     currentCRatioPercentage: currentCRatioPercentage?.toNumber(),
     liquidationCratioPercentage: liquidationRatioPercentage?.toNumber(),
+    targetThreshold: targetThreshold?.toNumber(),
   });
   const enabled = Boolean(
     collateralInUsd && debtBalance && selfLiquidationPenalty && SNXRate && Liquidator && health


### PR DESCRIPTION
The FeePool contract (where we claim) takes a threshold ( called `targetThreshold` on the `SystemSettings` contract) into account. If your c-ratio is below target but within the threshold you can claim. There's no threshold for liquidations.

We already fetched `targetThreshold` in the debtData hook. So this PR just make sure we take it into account in `getHealthVariant`
