### PR TITLE
Fix abi import from json

### DIFF
--- a/v2/ui/sections/pool/GUniAPRCalcualation.ts
+++ b/v2/ui/sections/pool/GUniAPRCalcualation.ts
@@ -1,9 +1,10 @@
 import axios from 'axios';
 import { ethers, BigNumber, providers, Contract } from 'ethers';
-import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json';
+import IUniswapV3Pool from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json';
 import { GELATO_POOL_ABI } from './useGetUniswapStakingRewardsAPY';
 import { gelatoGraphURL, UNISWAP_HELPERS_ADDRESS } from 'constants/gelato';
 
+const IUniswapV3PoolABI = IUniswapV3Pool.abi;
 const X96 = BigNumber.from(2).pow(BigNumber.from(96));
 const BLOCKS_PER_YEAR = 537542;
 


### PR DESCRIPTION
Fixes the build warning:
```
WARNING in ./sections/pool/GUniAPRCalcualation.ts 155:93-110
Should not import the named export 'abi' (imported as 'IUniswapV3PoolABI') from default-exporting module (only default export is available soon)
```