### PR TITLE
update kwenta to official url

### DIFF
--- a/v2/components/UtilityCard/UtilityCard.stories.tsx
+++ b/v2/components/UtilityCard/UtilityCard.stories.tsx
@@ -22,7 +22,7 @@ Primary.args = {
   description:
     'Trade commodities, forex, crypto, and more with up to 25x leverage and deep liquidity.',
   Icon: KwentaIcon,
-  link: 'https://kwenta.io',
+  link: 'https://kwenta.eth.limo',
 };
 
 Secondary.args = {

--- a/v2/lib/Constants/links.ts
+++ b/v2/lib/Constants/links.ts
@@ -2,8 +2,8 @@ export const PROD_HOSTNAME = 'staking.synthetix.io';
 
 export const EXTERNAL_LINKS = {
   Trading: {
-    Kwenta: 'https://kwenta.io',
-    KwentaTrading: 'https://kwenta.io/exchange',
+    Kwenta: 'https://kwenta.eth.limo',
+    KwentaTrading: 'https://kwenta.eth.limo/exchange',
     DexAG: 'https://dex.ag/',
     Uniswap: 'https://uniswap.exchange/',
     OneInchLink: (from: string, to: string) => `https://1inch.exchange/#/1/swap/${from}/${to}`,

--- a/v2/ui/constants/links.ts
+++ b/v2/ui/constants/links.ts
@@ -4,8 +4,8 @@ export const PROD_HOSTNAME = 'staking.synthetix.io';
 
 export const EXTERNAL_LINKS = {
   Trading: {
-    Kwenta: 'https://kwenta.io',
-    KwentaTrading: 'https://kwenta.io/exchange',
+    Kwenta: 'https://kwenta.eth.limo',
+    KwentaTrading: 'https://kwenta.eth.limo/exchange',
     KwentaToken: 'https://mirror.xyz/kwenta.eth/bM-hUzw9fzxTom3k8Is_HbkVJ4My3XzamHthA0Lp7KI',
     DexAG: 'https://dex.ag/',
     Uniswap: 'https://uniswap.exchange/',

--- a/v2/ui/content/V2Home.tsx
+++ b/v2/ui/content/V2Home.tsx
@@ -136,7 +136,7 @@ const V2Home = () => {
               mr={4}
               title="Kwenta"
               description={t('staking-v2.home.utilities.kwentaDescription')}
-              link="https://kwenta.io"
+              link="https://kwenta.eth.limo"
               Icon={KwentaIcon}
             />
             <UtilityCard

--- a/v3/ui/src/layouts/Default/Header.tsx
+++ b/v3/ui/src/layouts/Default/Header.tsx
@@ -32,7 +32,7 @@ import { useEffect } from 'react';
 const tradeContent = () => {
   return (
     <>
-      <a href="https://kwenta.io" target="_blank" rel="noreferrer">
+      <a href="https://kwenta.eth.limo" target="_blank" rel="noreferrer">
         <Flex mb="3" cursor="pointer" alignItems="center">
           <Image src={kwenta} alt="Kwenta" width="28px" height="28px" />
           <Box pl="3">


### PR DESCRIPTION
This PR updates any mentions of `https://kwenta.io` to the official, Kwenta endorsed URL `https://kwenta.eth.limo` URL, which hosts the decentralized Kwenta deployment.

`https://kwenta.io` is on its way to be deprecated, hence should be avoided if possible. For more information, see [KIP-22](https://kips.kwenta.io/kips/kip-22/).

### Other notes

Note that below file lines 44 resp. 47 add links to the long deprecated `shorting` page on Kwenta, which should probably be removed from the repository. These have not been touched by this commit.

https://github.com/Synthetixio/js-monorepo/blob/bc4a61b92d09bc01e03750a649989485ba05d7bb/v2/ui/constants/routes.ts#L44-L46

