### PR TITLE
Account navigation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,7 +69,7 @@ module.exports = {
       rules: {
         quotes: 'off',
         'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
-
+        'react/prop-types': 'off', // use ts
         // react-hooks
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'error',

--- a/v3/ui/src/App.tsx
+++ b/v3/ui/src/App.tsx
@@ -16,7 +16,7 @@ import { Market } from './pages/markets/Market';
 import { Pool } from './pages/pools/pool';
 import { Teleporter } from './pages/teleporter/Teleporter';
 import { NotFoundPage } from './pages/404';
-import RequireAccount from './components/accounts/RequireAccount';
+import { RequireAccount } from './components/accounts/RequireAccount';
 
 export const Synthetix: React.FC = () => {
   const { colorMode, toggleColorMode } = useColorMode();

--- a/v3/ui/src/App.tsx
+++ b/v3/ui/src/App.tsx
@@ -16,6 +16,7 @@ import { Market } from './pages/markets/Market';
 import { Pool } from './pages/pools/pool';
 import { Teleporter } from './pages/teleporter/Teleporter';
 import { NotFoundPage } from './pages/404';
+import RequireAccount from './components/accounts/RequireAccount';
 
 export const Synthetix: React.FC = () => {
   const { colorMode, toggleColorMode } = useColorMode();
@@ -30,11 +31,46 @@ export const Synthetix: React.FC = () => {
     <Suspense fallback={<Spinner />}>
       <Routes>
         <Route element={<DefaultLayout />}>
-          <Route path="/accounts/:id/positions/:collateral/:poolId" element={<StakingPosition />} />
-          <Route path="/accounts/:id/collateral" element={<Collateral />} />
-          <Route path="/accounts/:id/accept-nomination" element={<AcceptNomination />} />
-          <Route path="/accounts/:id/settings" element={<Settings />} />
-          <Route path="/accounts/:id" element={<Account />} />
+          <Route
+            path="/accounts/:id/positions/:collateral/:poolId"
+            element={
+              <RequireAccount>
+                <StakingPosition />
+              </RequireAccount>
+            }
+          />
+          <Route
+            path="/accounts/:id/collateral"
+            element={
+              <RequireAccount>
+                <Collateral />
+              </RequireAccount>
+            }
+          />
+          <Route
+            path="/accounts/:id/accept-nomination"
+            element={
+              <RequireAccount>
+                <AcceptNomination />
+              </RequireAccount>
+            }
+          />
+          <Route
+            path="/accounts/:id/settings"
+            element={
+              <RequireAccount>
+                <Settings />
+              </RequireAccount>
+            }
+          />
+          <Route
+            path="/accounts/:id"
+            element={
+              <RequireAccount>
+                <Account />
+              </RequireAccount>
+            }
+          />
           <Route path="/accounts/create" element={<CreateAccount />} />
           <Route path="/markets/create" element={<CreateMarket />} />
           <Route path="/markets/:address" element={<Market />} />

--- a/v3/ui/src/components/accounts/RequireAccount.tsx
+++ b/v3/ui/src/components/accounts/RequireAccount.tsx
@@ -3,7 +3,7 @@ import { useRecoilState } from 'recoil';
 import { useNavigateWithChain } from '../../hooks';
 import { accountsState } from '../../utils/state';
 
-const RequireAccount: React.FC<PropsWithChildren> = ({ children }) => {
+export const RequireAccount: React.FC<PropsWithChildren> = ({ children }) => {
   const navigate = useNavigateWithChain();
   const [{ accounts }] = useRecoilState(accountsState);
   const numOfAccount = accounts.length;
@@ -11,7 +11,6 @@ const RequireAccount: React.FC<PropsWithChildren> = ({ children }) => {
     if (numOfAccount === 0) {
       navigate({ pathname: `/` }, { replace: true });
     }
-  }, [numOfAccount]);
+  }, [numOfAccount, navigate]);
   return <>{children}</>;
 };
-export default RequireAccount;

--- a/v3/ui/src/components/accounts/RequireAccount.tsx
+++ b/v3/ui/src/components/accounts/RequireAccount.tsx
@@ -1,0 +1,17 @@
+import { PropsWithChildren, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { useNavigateWithChain } from '../../hooks';
+import { accountsState } from '../../utils/state';
+
+const RequireAccount: React.FC<PropsWithChildren> = ({ children }) => {
+  const navigate = useNavigateWithChain();
+  const [{ accounts }] = useRecoilState(accountsState);
+  const numOfAccount = accounts.length;
+  useEffect(() => {
+    if (numOfAccount === 0) {
+      navigate({ pathname: `/` }, { replace: true });
+    }
+  }, [numOfAccount]);
+  return <>{children}</>;
+};
+export default RequireAccount;

--- a/v3/ui/src/hooks/useNavigateWithChain.ts
+++ b/v3/ui/src/hooks/useNavigateWithChain.ts
@@ -2,6 +2,7 @@ import { useRecoilState } from 'recoil';
 import { chainIdState } from '../utils/state';
 import { useNavigate, NavigateOptions, Path, createSearchParams } from 'react-router-dom';
 import { getChainNameById } from '../utils/constants';
+import { useCallback } from 'react';
 
 /**
  * Overloads navigate function to navigate user to a specific route WITH
@@ -12,12 +13,15 @@ export const useNavigateWithChain = () => {
   const [localChainId] = useRecoilState(chainIdState);
   const chainName = getChainNameById(localChainId);
   const navigate = useNavigate();
-  return (to: Partial<Path>, options?: NavigateOptions) =>
-    navigate(
-      {
-        ...to,
-        search: `?${createSearchParams({ chain: chainName })}`,
-      },
-      options
-    );
+  return useCallback(
+    (to: Partial<Path>, options?: NavigateOptions) =>
+      navigate(
+        {
+          ...to,
+          search: `?${createSearchParams({ chain: chainName || 'goerli' })}`,
+        },
+        options
+      ),
+    [chainName, navigate]
+  );
 };

--- a/v3/ui/src/pages/index.tsx
+++ b/v3/ui/src/pages/index.tsx
@@ -8,12 +8,12 @@ import { accountsState } from '../utils/state';
 export function Home() {
   const navigate = useNavigateWithChain();
   const [{ accounts }] = useRecoilState(accountsState);
-  const numOfAccount = accounts.length;
+  const firstAccount = accounts.length ? accounts[0] : undefined;
   useEffect(() => {
-    if (numOfAccount > 0) {
-      navigate({ pathname: `/accounts/${accounts[0]}` }, { replace: true });
+    if (firstAccount) {
+      navigate({ pathname: `/accounts/${firstAccount}` }, { replace: true });
     }
-  }, [numOfAccount]);
+  }, [firstAccount, navigate]);
 
   return (
     <Flex

--- a/v3/ui/src/pages/index.tsx
+++ b/v3/ui/src/pages/index.tsx
@@ -8,13 +8,12 @@ import { accountsState } from '../utils/state';
 export function Home() {
   const navigate = useNavigateWithChain();
   const [{ accounts }] = useRecoilState(accountsState);
-
+  const numOfAccount = accounts.length;
   useEffect(() => {
-    if (accounts.length) {
-      navigate({ pathname: `/accounts/${accounts[0]}` });
+    if (numOfAccount > 0) {
+      navigate({ pathname: `/accounts/${accounts[0]}` }, { replace: true });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [numOfAccount]);
 
   return (
     <Flex


### PR DESCRIPTION
- If your on the home page and switch to an address with accounts -> navigate to account page. Previously it only worked on reload.
- If you're on a page that requires account and switch to a wallet without accounts -> navigate to home