### PR TITLE
Burn fix

### DIFF
--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -628,7 +628,7 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
               }
 
               const snxPrice = exchangeRateData?.SNX?.toNumber();
-              if (!debtData || !susdBalance || !snxPrice) return;
+              if (!debtData || !snxPrice) return;
               const parsedBurnAmount = parseFloatWithCommas(burnAmount);
               if (isNaN(parsedBurnAmount)) return undefined;
               const snxUnstakingAmount = burnAmount

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -443,7 +443,7 @@ const getBurnAmountForCalculations = (
     case 'sUSDBalance':
       return burnAmountSusd === '' ? undefined : susdBalance;
     default:
-      return undefined;
+      return burnAmountSusd === '' ? undefined : parseFloatWithCommas(burnAmountSusd);
   }
 };
 export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAddress }) => {


### PR DESCRIPTION
Make sure we do the burn calculations even when the user doesn't have enough sUSD balance.
The button will still be disabled:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/5688912/205622328-75d96f7e-71c4-483f-abc3-93a8a4961a72.png">
