### PR TITLE
Fix display amount in unflag and self-liquidate

### DIFF
--- a/v2/components/EpochPrice/EpochPrice.tsx
+++ b/v2/components/EpochPrice/EpochPrice.tsx
@@ -43,12 +43,12 @@ export const EpochPrice = ({ epochEnd, snxPrice, isLoading = false }: EpochPrice
             ml={[0, 0, 1.5]}
             width={isLoading ? '40px' : 'unset'}
             height={isLoading ? '10px' : 'unset'}
+            mt={[1, 1, 0]}
             sx={{
               display: 'flex',
               span: {
                 fontFamily: 'mono',
                 fontSize: ['xs', 'xs', '2xs'],
-                mt: [1, 1, 0],
                 lineHeight: '10px',
                 fontWeight: 'bold',
                 color: ['whiteAlpha.900', 'whiteAlpha.900', 'white'],
@@ -59,7 +59,7 @@ export const EpochPrice = ({ epochEnd, snxPrice, isLoading = false }: EpochPrice
           </Skeleton>
         </Flex>
         <Flex
-          alignItems="center"
+          alignItems={['end', 'end', 'center']}
           flexDir={['column', 'column', 'row']}
           justify={['center', 'center', 'end']}
         >

--- a/v2/components/SelfLiquidation/SelfLiquidation.cy.tsx
+++ b/v2/components/SelfLiquidation/SelfLiquidation.cy.tsx
@@ -51,6 +51,7 @@ describe('SelfLiquidationUi', () => {
             isGasEnabledAndNotFetched={false}
             CRatioProgressBar={defaultProps.CRatioProgressBar}
             CRatioBox={defaultProps.CRatioBox}
+            isLoading={true}
           />
         </QueryClientProvider>
       </Box>
@@ -62,7 +63,7 @@ describe('SelfLiquidationUi', () => {
     cy.mount(
       <Box paddingY="7" paddingX="4" bg="navy.900" flex="1">
         <QueryClientProvider client={new QueryClient()}>
-          <SelfLiquidationUi {...defaultProps} />
+          <SelfLiquidationUi {...defaultProps} isLoading={false} />
         </QueryClientProvider>
       </Box>
     );
@@ -85,6 +86,7 @@ describe('SelfLiquidationUi', () => {
           <SelfLiquidationUi
             {...defaultProps}
             onSelfLiquidation={cy.spy().as('onSelfLiquidationMock')}
+            isLoading={false}
           />
         </QueryClientProvider>
       </Box>
@@ -104,6 +106,7 @@ describe('SelfLiquidationUi', () => {
             {...defaultProps}
             targetCRatioPercentage={300}
             currentCRatioPercentage={300}
+            isLoading={false}
           />
         </QueryClientProvider>
       </Box>
@@ -118,7 +121,7 @@ describe('SelfLiquidationUi', () => {
     cy.mount(
       <Box paddingY="7" paddingX="4" bg="navy.900" flex="1">
         <QueryClientProvider client={new QueryClient()}>
-          <SelfLiquidationUi {...defaultProps} gasError={Error('Gas Error')} />
+          <SelfLiquidationUi {...defaultProps} gasError={Error('Gas Error')} isLoading={false} />
         </QueryClientProvider>
       </Box>
     );
@@ -133,7 +136,7 @@ describe('SelfLiquidationUi', () => {
     cy.mount(
       <Box paddingY="7" paddingX="4" bg="navy.900" flex="1">
         <QueryClientProvider client={new QueryClient()}>
-          <SelfLiquidationUi {...defaultProps} isGasEnabledAndNotFetched={true} />
+          <SelfLiquidationUi {...defaultProps} isGasEnabledAndNotFetched={true} isLoading={false} />
         </QueryClientProvider>
       </Box>
     );

--- a/v2/components/UnflagOptions/UnflagOptions.tsx
+++ b/v2/components/UnflagOptions/UnflagOptions.tsx
@@ -185,21 +185,25 @@ export const UnflagOptions = () => {
   const { data: debtData } = useDebtData();
   const { data: liquidationData } = useLiquidationData();
   const { data: balanceData } = useSynthsBalances();
+
   const sUSDToGetBackToTarget = debtData
     ? debtData.debtBalance.sub(debtData.issuableSynths).toNumber()
     : undefined;
-
   const sUSDBalance = balanceData?.balancesMap.sUSD?.balance.toNumber();
+
   const selfLiquidationPenalty = liquidationData
     ? formatPercent(liquidationData.selfLiquidationPenalty.toNumber())
     : undefined;
+
   const variant = getHealthVariant({
     targetCratioPercentage: debtData?.targetCRatioPercentage.toNumber(),
     liquidationCratioPercentage: debtData?.liquidationRatioPercentage.toNumber(),
     currentCRatioPercentage: debtData?.currentCRatioPercentage.toNumber(),
     targetThreshold: debtData?.targetThreshold.toNumber(),
   });
+
   const canSelfLiquidate = variant !== 'success';
+
   return (
     <UnflagOptionsUi
       selfLiquidationPenalty={selfLiquidationPenalty}

--- a/v2/ui/Routes.tsx
+++ b/v2/ui/Routes.tsx
@@ -44,7 +44,7 @@ const Wrapper: FC<PropsWithChildren> = ({ children }) => {
   const [STAKING_V2_ENABLED] = useLocalStorage(LOCAL_STORAGE_KEYS.STAKING_V2_ENABLED, true);
   return STAKING_V2_ENABLED ? (
     <Box bg="navy.900" height="100%" className="v2">
-      <Container pt={4} pb={16} bg="navy.900" maxW="4xl">
+      <Container pt={8} pb={16} bg="navy.900" maxW="4xl">
         <HomeButton />
         {children}
       </Container>

--- a/v2/ui/content/V2Burn.tsx
+++ b/v2/ui/content/V2Burn.tsx
@@ -9,7 +9,7 @@ const V2Burn = () => {
   return (
     <>
       <Box bg="navy.900" height="100%">
-        <Container pt={4} pb={16} bg="navy.900" maxW="4xl">
+        <Container pt={8} pb={16} bg="navy.900" maxW="4xl">
           <HomeButton />
           <Burn delegateWalletAddress={delegateWallet?.address} />
         </Container>

--- a/v2/ui/content/V2Mint.tsx
+++ b/v2/ui/content/V2Mint.tsx
@@ -10,7 +10,7 @@ const V2Mint = () => {
 
   return (
     <Box bg="navy.900" height="100%">
-      <Container pt={4} pb={16} bg="navy.900" maxW="4xl">
+      <Container pt={8} pb={16} bg="navy.900" maxW="4xl">
         <HomeButton />
         <Mint delegateWalletAddress={delegateWallet?.address} />
       </Container>

--- a/v2/ui/content/V2Unflag.tsx
+++ b/v2/ui/content/V2Unflag.tsx
@@ -1,16 +1,24 @@
-import { Box, Container, Heading, Text } from '@chakra-ui/react';
+import { Box, Container, Heading, Text, SkeletonText } from '@chakra-ui/react';
 import { UnflagOptions } from '@snx-v2/UnflagOptions';
+import { useLiquidationData } from '@snx-v2/useLiquidationData';
 import { useTranslation } from 'react-i18next';
+import { formatPercent } from 'utils/formatters/number';
 
 const V2Unflag = () => {
   const { t } = useTranslation();
+  const { data: liquidationData, isLoading } = useLiquidationData();
+
   return (
     <Box bg="navy.900" height="100%">
       <Container pt={12} pb={16} bg="navy.900" maxW="4xl" height="full">
         <Heading size="md">{t('staking-v2.unflag-options.heading')}</Heading>
-        <Text mb={4} fontSize="xs" color="whiteAlpha.800">
-          {t('staking-v2.unflag-options.text')}
-        </Text>
+        <SkeletonText noOfLines={2} my={4} isLoaded={!isLoading}>
+          <Text mb={4} fontSize="xs" color="whiteAlpha.800">
+            {t('staking-v2.unflag-options.text', {
+              penalty: formatPercent(liquidationData?.selfLiquidationPenalty || 70),
+            })}
+          </Text>
+        </SkeletonText>
         <UnflagOptions />
       </Container>
     </Box>

--- a/v2/ui/content/V2Unflag.tsx
+++ b/v2/ui/content/V2Unflag.tsx
@@ -15,7 +15,9 @@ const V2Unflag = () => {
         <SkeletonText noOfLines={2} my={4} isLoaded={!isLoading}>
           <Text mb={4} fontSize="xs" color="whiteAlpha.800">
             {t('staking-v2.unflag-options.text', {
-              penalty: formatPercent(liquidationData?.selfLiquidationPenalty || 70),
+              penalty: formatPercent(liquidationData?.selfLiquidationPenalty || 70, {
+                minDecimals: 0,
+              }),
             })}
           </Text>
         </SkeletonText>

--- a/v2/ui/package.json
+++ b/v2/ui/package.json
@@ -59,6 +59,7 @@
     "@snx-v2/Welcome": "workspace:^",
     "@snx-v2/formatters": "workspace:*",
     "@snx-v2/icons": "workspace:*",
+    "@snx-v2/useLiquidationData": "workspace:*",
     "@socket.tech/plugin": "^1.0.2",
     "@synthetixio/contracts": "workspace:*",
     "@synthetixio/contracts-interface": "workspace:*",

--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -175,7 +175,7 @@
     },
     "self-liquidation": {
       "headline": "Self Liquidate",
-      "sub-headline": "If you are unable to pay down your sUSD debt, you can self liquidate your SNX collateral, with a 40% penalty. Self Liquidation is permanent, and results in the loss of some or all of your collateral. <linkTag>Read more about self liquidation</linkTag>",
+      "sub-headline": "If you are unable to pay down your sUSD debt, you can self liquidate your SNX collateral, with a {{penalty}} penalty. Self Liquidation is permanent, and results in the loss of some or all of your collateral. <linkTag>Read more about self liquidation</linkTag>",
       "amounts-headline": "Self Liquidation calculation, in SNX and USD value",
       "penalty": "Penalty {{penalty}}",
       "back-to-target": "Collateral to be liquidated",
@@ -228,7 +228,7 @@
     },
     "unflag-options": {
       "heading": "Unflag Account",
-      "text": "If you are unable to pay down your sUSD debt, you can self liquidate your SNX collateral, with a 40% penalty. Self Liquidation is permanent, and results in the loss of some or all of your collateral.",
+      "text": "If you are unable to pay down your sUSD debt, you can self liquidate your SNX collateral, with a {{penalty}} penalty. Self Liquidation is permanent, and results in the loss of some or all of your collateral.",
       "recommended": "Recommended",
       "unflag": {
         "heading": "Unflag my account by burning sUSD in order to meet target ratio",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9578,6 +9578,7 @@ __metadata:
     "@snx-v2/Welcome": "workspace:^"
     "@snx-v2/formatters": "workspace:*"
     "@snx-v2/icons": "workspace:*"
+    "@snx-v2/useLiquidationData": "workspace:*"
     "@socket.tech/plugin": ^1.0.2
     "@storybook/addon-actions": ^6.5.10
     "@storybook/addon-docs": ^6.5.10


### PR DESCRIPTION
Main thing is to use liquidation penalty data to render correct amount

<img width="930" alt="Screen Shot 2022-12-15 at 12 37 26 pm" src="https://user-images.githubusercontent.com/52280438/207752098-947ed41a-329d-48be-8047-49500ab37ad5.png">
