### PR TITLE
Fix pool configuration

### DIFF
--- a/v3/subgraphs/goerli/generated/schema.ts
+++ b/v3/subgraphs/goerli/generated/schema.ts
@@ -154,6 +154,23 @@ export class Pool extends Entity {
     }
   }
 
+  get market_ids(): Array<string> | null {
+    let value = this.get('market_ids');
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toStringArray();
+    }
+  }
+
+  set market_ids(value: Array<string> | null) {
+    if (!value) {
+      this.unset('market_ids');
+    } else {
+      this.set('market_ids', Value.fromStringArray(<Array<string>>value));
+    }
+  }
+
   get configurations(): Array<string> | null {
     let value = this.get('configurations');
     if (!value || value.kind == ValueKind.NULL) {

--- a/v3/subgraphs/goerli/schema.graphql
+++ b/v3/subgraphs/goerli/schema.graphql
@@ -10,6 +10,8 @@ type Pool @entity {
   "Only set when name of the pool got updated"
   name: String
   total_weight: BigInt
+  "This is an internal field, needed to keep configurations in sync. The reason for this is due to derived fields are no readable from event handlers. Consumers should look up markets by the configurations field"
+  market_ids: [String!]
   configurations: [MarketConfiguration!] @derivedFrom(field: "pool")
 }
 

--- a/v3/subgraphs/goerli/src/core.ts
+++ b/v3/subgraphs/goerli/src/core.ts
@@ -6,7 +6,6 @@ import {
   Liquidation,
   PermissionGranted,
   PermissionRevoked,
-  PoolConfigurationSet,
   PoolCreated,
   PoolNameUpdated,
   PoolNominationRenounced,
@@ -27,7 +26,6 @@ import {
   AccountRewardsDistributor,
   CollateralType,
   Liquidation as LiquidationEntity,
-  MarketConfiguration,
   Pool,
   Position,
   RewardsClaimed,
@@ -47,6 +45,7 @@ import { BigDecimal, BigInt, Bytes, log, store } from '@graphprotocol/graph-ts';
 /////////////
 
 export * from './market';
+export * from './marketConfigurations';
 
 ///////////
 // Pool //
@@ -111,150 +110,6 @@ export function handleNewPoolOwner(event: PoolOwnershipAccepted): void {
     pool.nominated_owner = Bytes.empty();
     pool.save();
   }
-}
-
-const getMarketConfigurationForPoolByMarketId = (pool: Pool): Map<string, MarketConfiguration> => {
-  //  This would be great but we cant read derived fields
-  const poolMarketIds = pool.market_ids;
-
-  let marketConfigurationsByMarketId = new Map<string, MarketConfiguration>();
-  if (poolMarketIds === null) return marketConfigurationsByMarketId;
-  for (let i = 0; i < poolMarketIds.length; ++i) {
-    const marketId = poolMarketIds.at(i);
-    const marketConfigurationId = pool.id.toString().concat('-').concat(marketId);
-    const marketConfigForPool = MarketConfiguration.load(marketConfigurationId);
-    if (marketConfigForPool) {
-      marketConfigurationsByMarketId.set(marketConfigForPool.market, marketConfigForPool);
-    }
-  }
-  return marketConfigurationsByMarketId;
-};
-const deleteRemovedMarketConfigurations = (
-  event: PoolConfigurationSet,
-  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
-): void => {
-  if (currentMarketConfigurationsInPoolByMarketId.size === 0) {
-    // no current market set on pool, so nothing to remove
-    return;
-  }
-  const marketsFromEventExistsById = new Map<string, boolean>();
-  for (let i = 0; i < event.params.markets.length; ++i) {
-    const market = event.params.markets.at(i);
-    marketsFromEventExistsById.set(market.marketId.toString(), true);
-  }
-
-  const currentMarketConfigs = currentMarketConfigurationsInPoolByMarketId.values();
-
-  // The event.markets is the source of truth of what markets is connected to the pool
-  // If we currently have a market configuration that shouldn't be there, remove that entity.
-  for (let i = 0; i < currentMarketConfigs.length; ++i) {
-    const marketId = currentMarketConfigs.at(i).market.toString();
-    const marketConfigShouldBeRemoved = !marketsFromEventExistsById.has(marketId);
-    if (marketConfigShouldBeRemoved) {
-      const marketConfigurationId = event.params.poolId.toString().concat('-').concat(marketId);
-      store.remove('MarketConfiguration', marketConfigurationId);
-    }
-  }
-};
-
-const updateMarketConfiguration = (
-  marketConfig: MarketConfiguration,
-  newWeight: BigInt,
-  newMaxDebtShareValue: BigDecimal,
-  blockTimestamp: BigInt,
-  blockNumber: BigInt
-): void => {
-  const oldWeight = marketConfig.weight;
-  const oldMaxDebtShareValue = marketConfig.max_debt_share_value;
-  if (oldWeight === newWeight && oldMaxDebtShareValue === newMaxDebtShareValue) {
-    // No values need to be updated
-    return;
-  }
-  marketConfig.weight = newWeight;
-  marketConfig.max_debt_share_value = newMaxDebtShareValue;
-  marketConfig.updated_at = blockTimestamp;
-  marketConfig.updated_at_block = blockNumber;
-  marketConfig.save();
-};
-const updateExistingMarketConfigurations = (
-  event: PoolConfigurationSet,
-  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
-): void => {
-  if (currentMarketConfigurationsInPoolByMarketId.size === 0) {
-    // no current market set on pool, so nothing to update
-    return;
-  }
-
-  for (let i = 0; i < event.params.markets.length; ++i) {
-    const newMaxDebtShareValue = event.params.markets.at(i).maxDebtShareValueD18.toBigDecimal();
-    const marketId = event.params.markets.at(i).marketId.toString();
-    if (currentMarketConfigurationsInPoolByMarketId.has(marketId)) {
-      const marketConfig = currentMarketConfigurationsInPoolByMarketId.get(marketId);
-      const newWeight = event.params.markets.at(i).weightD18;
-      const blockTimestamp = event.block.timestamp;
-      const blockNumber = event.block.number;
-      updateMarketConfiguration(
-        marketConfig,
-        newWeight,
-        newMaxDebtShareValue,
-        blockTimestamp,
-        blockNumber
-      );
-    }
-  }
-};
-
-const createNewMarketConfigurations = (
-  event: PoolConfigurationSet,
-  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
-): void => {
-  const poolId = event.params.poolId.toString();
-  for (let i = 0; i < event.params.markets.length; ++i) {
-    const marketId = event.params.markets.at(i).marketId.toString();
-    if (!currentMarketConfigurationsInPoolByMarketId.has(marketId)) {
-      const marketConfiguration = new MarketConfiguration(poolId.concat('-').concat(marketId));
-      marketConfiguration.market = marketId;
-      marketConfiguration.pool = poolId;
-      marketConfiguration.created_at = event.block.timestamp;
-      marketConfiguration.created_at_block = event.block.number;
-      marketConfiguration.updated_at = event.block.timestamp;
-      marketConfiguration.updated_at_block = event.block.number;
-      marketConfiguration.weight = event.params.markets.at(i).weightD18;
-      marketConfiguration.max_debt_share_value = event.params.markets
-        .at(i)
-        .maxDebtShareValueD18.toBigDecimal();
-
-      marketConfiguration.save();
-    }
-  }
-};
-
-const updatePoolFields = (event: PoolConfigurationSet, pool: Pool): void => {
-  const newTotalWeight = event.params.markets.reduce((sum, x) => {
-    return sum.plus(x.weightD18);
-  }, new BigInt(0));
-  const marketIds = event.params.markets.map<string>((x) => x.marketId.toString());
-  pool.total_weight = newTotalWeight;
-  pool.updated_at = event.block.timestamp;
-  pool.updated_at_block = event.block.number;
-  pool.market_ids = marketIds;
-  pool.save();
-};
-
-export function handlePoolConfigurationSet(event: PoolConfigurationSet): void {
-  const poolId = event.params.poolId.toString();
-  const pool = Pool.load(poolId);
-  // Pool will be never undefined, though for safety reasons we are checking for that
-  if (pool === null) {
-    log.error('Pool id: ' + poolId + ' does not exist', []);
-    return;
-  }
-  const currentMarketConfigsInPoolByMarketId = getMarketConfigurationForPoolByMarketId(pool);
-  // Mutative
-  deleteRemovedMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
-  updateExistingMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
-  createNewMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
-  updatePoolFields(event, pool);
 }
 
 //////////////

--- a/v3/subgraphs/goerli/src/core.ts
+++ b/v3/subgraphs/goerli/src/core.ts
@@ -34,7 +34,7 @@ import {
   Vault,
   VaultLiquidation as VaultLiquidationEntity,
 } from '../generated/schema';
-import { BigDecimal, BigInt, Bytes, log, store } from '@graphprotocol/graph-ts';
+import { BigDecimal, BigInt, Bytes, store } from '@graphprotocol/graph-ts';
 
 ////////////////////
 // Event handlers //

--- a/v3/subgraphs/goerli/src/marketConfigurations.ts
+++ b/v3/subgraphs/goerli/src/marketConfigurations.ts
@@ -1,0 +1,147 @@
+import { PoolConfigurationSet } from '../generated/CoreProxy/CoreProxy';
+import { MarketConfiguration, Pool } from '../generated/schema';
+import { BigDecimal, BigInt, log, store } from '@graphprotocol/graph-ts';
+
+const getMarketConfigurationForPoolByMarketId = (pool: Pool): Map<string, MarketConfiguration> => {
+  //  This would be great but we cant read derived fields
+  const poolMarketIds = pool.market_ids;
+
+  let marketConfigurationsByMarketId = new Map<string, MarketConfiguration>();
+  if (poolMarketIds === null) return marketConfigurationsByMarketId;
+  for (let i = 0; i < poolMarketIds.length; ++i) {
+    const marketId = poolMarketIds.at(i);
+    const marketConfigurationId = pool.id.toString().concat('-').concat(marketId);
+    const marketConfigForPool = MarketConfiguration.load(marketConfigurationId);
+    if (marketConfigForPool) {
+      marketConfigurationsByMarketId.set(marketConfigForPool.market, marketConfigForPool);
+    }
+  }
+  return marketConfigurationsByMarketId;
+};
+const deleteRemovedMarketConfigurations = (
+  event: PoolConfigurationSet,
+  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
+): void => {
+  if (currentMarketConfigurationsInPoolByMarketId.size === 0) {
+    // no current market set on pool, so nothing to remove
+    return;
+  }
+  const marketsFromEventExistsById = new Map<string, boolean>();
+  for (let i = 0; i < event.params.markets.length; ++i) {
+    const market = event.params.markets.at(i);
+    marketsFromEventExistsById.set(market.marketId.toString(), true);
+  }
+
+  const currentMarketConfigs = currentMarketConfigurationsInPoolByMarketId.values();
+
+  // The event.markets is the source of truth of what markets is connected to the pool
+  // If we currently have a market configuration that shouldn't be there, remove that entity.
+  for (let i = 0; i < currentMarketConfigs.length; ++i) {
+    const marketId = currentMarketConfigs.at(i).market.toString();
+    const marketConfigShouldBeRemoved = !marketsFromEventExistsById.has(marketId);
+    if (marketConfigShouldBeRemoved) {
+      const marketConfigurationId = event.params.poolId.toString().concat('-').concat(marketId);
+      store.remove('MarketConfiguration', marketConfigurationId);
+    }
+  }
+};
+
+const updateMarketConfiguration = (
+  marketConfig: MarketConfiguration,
+  newWeight: BigInt,
+  newMaxDebtShareValue: BigDecimal,
+  blockTimestamp: BigInt,
+  blockNumber: BigInt
+): void => {
+  const oldWeight = marketConfig.weight;
+  const oldMaxDebtShareValue = marketConfig.max_debt_share_value;
+  if (oldWeight === newWeight && oldMaxDebtShareValue === newMaxDebtShareValue) {
+    // No values need to be updated
+    return;
+  }
+  marketConfig.weight = newWeight;
+  marketConfig.max_debt_share_value = newMaxDebtShareValue;
+  marketConfig.updated_at = blockTimestamp;
+  marketConfig.updated_at_block = blockNumber;
+  marketConfig.save();
+};
+const updateExistingMarketConfigurations = (
+  event: PoolConfigurationSet,
+  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
+): void => {
+  if (currentMarketConfigurationsInPoolByMarketId.size === 0) {
+    // no current market set on pool, so nothing to update
+    return;
+  }
+
+  for (let i = 0; i < event.params.markets.length; ++i) {
+    const newMaxDebtShareValue = event.params.markets.at(i).maxDebtShareValueD18.toBigDecimal();
+    const marketId = event.params.markets.at(i).marketId.toString();
+    if (currentMarketConfigurationsInPoolByMarketId.has(marketId)) {
+      const marketConfig = currentMarketConfigurationsInPoolByMarketId.get(marketId);
+      const newWeight = event.params.markets.at(i).weightD18;
+      const blockTimestamp = event.block.timestamp;
+      const blockNumber = event.block.number;
+      updateMarketConfiguration(
+        marketConfig,
+        newWeight,
+        newMaxDebtShareValue,
+        blockTimestamp,
+        blockNumber
+      );
+    }
+  }
+};
+
+const createNewMarketConfigurations = (
+  event: PoolConfigurationSet,
+  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
+): void => {
+  const poolId = event.params.poolId.toString();
+  for (let i = 0; i < event.params.markets.length; ++i) {
+    const marketId = event.params.markets.at(i).marketId.toString();
+    if (!currentMarketConfigurationsInPoolByMarketId.has(marketId)) {
+      const marketConfiguration = new MarketConfiguration(poolId.concat('-').concat(marketId));
+      marketConfiguration.market = marketId;
+      marketConfiguration.pool = poolId;
+      marketConfiguration.created_at = event.block.timestamp;
+      marketConfiguration.created_at_block = event.block.number;
+      marketConfiguration.updated_at = event.block.timestamp;
+      marketConfiguration.updated_at_block = event.block.number;
+      marketConfiguration.weight = event.params.markets.at(i).weightD18;
+      marketConfiguration.max_debt_share_value = event.params.markets
+        .at(i)
+        .maxDebtShareValueD18.toBigDecimal();
+
+      marketConfiguration.save();
+    }
+  }
+};
+
+const updatePoolFields = (event: PoolConfigurationSet, pool: Pool): void => {
+  const newTotalWeight = event.params.markets.reduce((sum, x) => {
+    return sum.plus(x.weightD18);
+  }, new BigInt(0));
+  const marketIds = event.params.markets.map<string>((x) => x.marketId.toString());
+  pool.total_weight = newTotalWeight;
+  pool.updated_at = event.block.timestamp;
+  pool.updated_at_block = event.block.number;
+  pool.market_ids = marketIds;
+  pool.save();
+};
+
+export function handlePoolConfigurationSet(event: PoolConfigurationSet): void {
+  const poolId = event.params.poolId.toString();
+  const pool = Pool.load(poolId);
+  // Pool will be never undefined, though for safety reasons we are checking for that
+  if (pool === null) {
+    log.error('Pool id: ' + poolId + ' does not exist', []);
+    return;
+  }
+  const currentMarketConfigsInPoolByMarketId = getMarketConfigurationForPoolByMarketId(pool);
+  // Mutative
+  deleteRemovedMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
+  updateExistingMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
+  createNewMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
+  updatePoolFields(event, pool);
+}

--- a/v3/subgraphs/goerli/src/marketConfigurations.ts
+++ b/v3/subgraphs/goerli/src/marketConfigurations.ts
@@ -3,7 +3,6 @@ import { MarketConfiguration, Pool } from '../generated/schema';
 import { BigDecimal, BigInt, log, store } from '@graphprotocol/graph-ts';
 
 const getMarketConfigurationForPoolByMarketId = (pool: Pool): Map<string, string> => {
-  //  This would be great but we cant read derived fields
   const poolMarketIds = pool.market_ids;
 
   let marketIdByMarketId = new Map<string, string>();

--- a/v3/subgraphs/goerli/src/marketConfigurations.ts
+++ b/v3/subgraphs/goerli/src/marketConfigurations.ts
@@ -2,27 +2,23 @@ import { PoolConfigurationSet } from '../generated/CoreProxy/CoreProxy';
 import { MarketConfiguration, Pool } from '../generated/schema';
 import { BigDecimal, BigInt, log, store } from '@graphprotocol/graph-ts';
 
-const getMarketConfigurationForPoolByMarketId = (pool: Pool): Map<string, MarketConfiguration> => {
+const getMarketConfigurationForPoolByMarketId = (pool: Pool): Map<string, string> => {
   //  This would be great but we cant read derived fields
   const poolMarketIds = pool.market_ids;
 
-  let marketConfigurationsByMarketId = new Map<string, MarketConfiguration>();
-  if (poolMarketIds === null) return marketConfigurationsByMarketId;
+  let marketIdByMarketId = new Map<string, string>();
+  if (poolMarketIds === null) return marketIdByMarketId;
   for (let i = 0; i < poolMarketIds.length; ++i) {
     const marketId = poolMarketIds.at(i);
-    const marketConfigurationId = pool.id.toString().concat('-').concat(marketId);
-    const marketConfigForPool = MarketConfiguration.load(marketConfigurationId);
-    if (marketConfigForPool) {
-      marketConfigurationsByMarketId.set(marketConfigForPool.market, marketConfigForPool);
-    }
+    marketIdByMarketId.set(marketId, marketId);
   }
-  return marketConfigurationsByMarketId;
+  return marketIdByMarketId;
 };
 const deleteRemovedMarketConfigurations = (
   event: PoolConfigurationSet,
-  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
+  currentMarketIdsInPoolByMarketId: Map<string, string>
 ): void => {
-  if (currentMarketConfigurationsInPoolByMarketId.size === 0) {
+  if (currentMarketIdsInPoolByMarketId.size === 0) {
     // no current market set on pool, so nothing to remove
     return;
   }
@@ -32,12 +28,12 @@ const deleteRemovedMarketConfigurations = (
     marketsFromEventExistsById.set(market.marketId.toString(), true);
   }
 
-  const currentMarketConfigs = currentMarketConfigurationsInPoolByMarketId.values();
+  const currentMarketConfigs = currentMarketIdsInPoolByMarketId.values();
 
   // The event.markets is the source of truth of what markets is connected to the pool
   // If we currently have a market configuration that shouldn't be there, remove that entity.
   for (let i = 0; i < currentMarketConfigs.length; ++i) {
-    const marketId = currentMarketConfigs.at(i).market.toString();
+    const marketId = currentMarketConfigs.at(i);
     const marketConfigShouldBeRemoved = !marketsFromEventExistsById.has(marketId);
     if (marketConfigShouldBeRemoved) {
       const marketConfigurationId = event.params.poolId.toString().concat('-').concat(marketId);
@@ -47,12 +43,17 @@ const deleteRemovedMarketConfigurations = (
 };
 
 const updateMarketConfiguration = (
-  marketConfig: MarketConfiguration,
+  marketConfigId: string,
   newWeight: BigInt,
   newMaxDebtShareValue: BigDecimal,
   blockTimestamp: BigInt,
   blockNumber: BigInt
 ): void => {
+  const marketConfig = MarketConfiguration.load(marketConfigId);
+  if (!marketConfig) {
+    log.error('Expected market id to exists', []);
+    return;
+  }
   const oldWeight = marketConfig.weight;
   const oldMaxDebtShareValue = marketConfig.max_debt_share_value;
   if (oldWeight === newWeight && oldMaxDebtShareValue === newMaxDebtShareValue) {
@@ -67,9 +68,9 @@ const updateMarketConfiguration = (
 };
 const updateExistingMarketConfigurations = (
   event: PoolConfigurationSet,
-  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
+  currentMarketIdsInPoolByMarketId: Map<string, string>
 ): void => {
-  if (currentMarketConfigurationsInPoolByMarketId.size === 0) {
+  if (currentMarketIdsInPoolByMarketId.size === 0) {
     // no current market set on pool, so nothing to update
     return;
   }
@@ -77,13 +78,13 @@ const updateExistingMarketConfigurations = (
   for (let i = 0; i < event.params.markets.length; ++i) {
     const newMaxDebtShareValue = event.params.markets.at(i).maxDebtShareValueD18.toBigDecimal();
     const marketId = event.params.markets.at(i).marketId.toString();
-    if (currentMarketConfigurationsInPoolByMarketId.has(marketId)) {
-      const marketConfig = currentMarketConfigurationsInPoolByMarketId.get(marketId);
+    if (currentMarketIdsInPoolByMarketId.has(marketId)) {
       const newWeight = event.params.markets.at(i).weightD18;
       const blockTimestamp = event.block.timestamp;
       const blockNumber = event.block.number;
+      const marketConfigId = event.params.poolId.toString().concat('-').concat(marketId);
       updateMarketConfiguration(
-        marketConfig,
+        marketConfigId,
         newWeight,
         newMaxDebtShareValue,
         blockTimestamp,
@@ -95,12 +96,12 @@ const updateExistingMarketConfigurations = (
 
 const createNewMarketConfigurations = (
   event: PoolConfigurationSet,
-  currentMarketConfigurationsInPoolByMarketId: Map<string, MarketConfiguration>
+  currentMarketIdsInPoolByMarketId: Map<string, string>
 ): void => {
   const poolId = event.params.poolId.toString();
   for (let i = 0; i < event.params.markets.length; ++i) {
     const marketId = event.params.markets.at(i).marketId.toString();
-    if (!currentMarketConfigurationsInPoolByMarketId.has(marketId)) {
+    if (!currentMarketIdsInPoolByMarketId.has(marketId)) {
       const marketConfiguration = new MarketConfiguration(poolId.concat('-').concat(marketId));
       marketConfiguration.market = marketId;
       marketConfiguration.pool = poolId;
@@ -138,10 +139,10 @@ export function handlePoolConfigurationSet(event: PoolConfigurationSet): void {
     log.error('Pool id: ' + poolId + ' does not exist', []);
     return;
   }
-  const currentMarketConfigsInPoolByMarketId = getMarketConfigurationForPoolByMarketId(pool);
+  const currentMarketIdsInPoolByMarketId = getMarketConfigurationForPoolByMarketId(pool);
   // Mutative
-  deleteRemovedMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
-  updateExistingMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
-  createNewMarketConfigurations(event, currentMarketConfigsInPoolByMarketId);
+  deleteRemovedMarketConfigurations(event, currentMarketIdsInPoolByMarketId);
+  updateExistingMarketConfigurations(event, currentMarketIdsInPoolByMarketId);
+  createNewMarketConfigurations(event, currentMarketIdsInPoolByMarketId);
   updatePoolFields(event, pool);
 }

--- a/v3/subgraphs/goerli/tests/core.test.ts
+++ b/v3/subgraphs/goerli/tests/core.test.ts
@@ -266,27 +266,32 @@ describe('core tests', () => {
     handleMarketCreated(newMarketRegisteredEvent);
     handleMarketCreated(newMarketRegisteredEvent2);
     handlePoolConfigurationSet(newPoolConfigurationSetEvent);
+
     assert.fieldEquals('Pool', '1', 'id', '1');
     assert.fieldEquals('Pool', '1', 'total_weight', '75');
     assert.fieldEquals('Pool', '1', 'updated_at', (now + 3000).toString());
     assert.fieldEquals('Pool', '1', 'updated_at_block', (now + 2000).toString());
-    assert.fieldEquals('Pool', '1', 'configurations', '[1-1, 1-2]');
+    assert.fieldEquals('Pool', '1', 'market_ids', '[1, 2]');
     assert.fieldEquals('Pool', '1', 'total_weight', '75');
     assert.assertNull(store.get('Pool', '1')!.get('name'));
     assert.notInStore('Pool', '2');
     assert.fieldEquals('Market', '1', 'id', '1');
-    assert.fieldEquals('Market', '1', 'configurations', '[1-1]');
+    assert.fieldEquals('Pool', '1', 'market_ids', '[1, 2]');
+
+    // Assert market doesn't get updated by configuration event
     assert.fieldEquals('Market', '1', 'created_at', (now + 1000).toString());
     assert.fieldEquals('Market', '1', 'created_at_block', now.toString());
-    assert.fieldEquals('Market', '1', 'updated_at', (now + 3000).toString());
-    assert.fieldEquals('Market', '1', 'updated_at_block', (now + 2000).toString());
+    // The market itself will not receive any updates, only the MarketConfiguration and the Pool
+    assert.fieldEquals('Market', '1', 'updated_at', (now + 1000).toString());
+    assert.fieldEquals('Market', '1', 'updated_at_block', now.toString());
     assert.fieldEquals('Market', '2', 'id', '2');
-    assert.fieldEquals('Market', '2', 'configurations', '[1-2]');
     assert.fieldEquals('Market', '2', 'created_at', (now + 2000).toString());
     assert.fieldEquals('Market', '2', 'created_at_block', (now + 1000).toString());
-    assert.fieldEquals('Market', '2', 'updated_at', (now + 3000).toString());
-    assert.fieldEquals('Market', '2', 'updated_at_block', (now + 2000).toString());
+    assert.fieldEquals('Market', '2', 'updated_at', (now + 2000).toString());
+    assert.fieldEquals('Market', '2', 'updated_at_block', (now + 1000).toString());
     assert.notInStore('Market', '3');
+
+    // Assert market configuration
     assert.fieldEquals('MarketConfiguration', '1-1', 'id', '1-1');
     assert.fieldEquals('MarketConfiguration', '1-1', 'pool', '1');
     assert.fieldEquals('MarketConfiguration', '1-1', 'max_debt_share_value', '812739821');
@@ -303,9 +308,10 @@ describe('core tests', () => {
     assert.fieldEquals('MarketConfiguration', '1-2', 'created_at_block', (now + 2000).toString());
     assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at', (now + 3000).toString());
     assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at_block', (now + 2000).toString());
-    // Fire second event that should update all entities + remove the MarketConfigurations entities that
-    // are not used anymore from the store
+
+    // Fire second event that should update Pool and MarketConfiguration.  Removed MarketConfigurations should also be deleted
     handlePoolConfigurationSet(secondNewPoolConfigurationSetEvent);
+
     assert.notInStore('MarketConfiguration', '1-1');
     assert.fieldEquals('Pool', '1', 'total_weight', '32');
     assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at', (now + 4000).toString());

--- a/v3/subgraphs/goerli/tests/core.test.ts
+++ b/v3/subgraphs/goerli/tests/core.test.ts
@@ -71,7 +71,6 @@ describe('core tests', () => {
     assert.assertNull(store.get('Pool', '1')!.get('nominated_owner'));
     assert.assertNull(store.get('Pool', '1')!.get('name'));
     assert.assertNull(store.get('Pool', '1')!.get('total_weight'));
-    assert.assertNull(store.get('Pool', '1')!.get('configurations'));
     assert.notInStore('Pool', '2');
   });
 
@@ -97,7 +96,6 @@ describe('core tests', () => {
     assert.fieldEquals('Pool', '1', 'updated_at_block', now.toString());
     assert.assertNull(store.get('Pool', '1')!.get('name'));
     assert.assertNull(store.get('Pool', '1')!.get('total_weight'));
-    assert.assertNull(store.get('Pool', '1')!.get('configurations'));
     assert.notInStore('Pool', '2');
   });
 
@@ -116,7 +114,6 @@ describe('core tests', () => {
     assert.fieldEquals('Pool', '1', 'updated_at_block', now.toString());
     assert.assertNull(store.get('Pool', '1')!.get('nominated_owner'));
     assert.assertNull(store.get('Pool', '1')!.get('total_weight'));
-    assert.assertNull(store.get('Pool', '1')!.get('configurations'));
     assert.notInStore('Pool', '2');
   });
 
@@ -145,7 +142,6 @@ describe('core tests', () => {
     assert.fieldEquals('Pool', '1', 'updated_at_block', now.toString());
     assert.assertNull(store.get('Pool', '1')!.get('name'));
     assert.assertNull(store.get('Pool', '1')!.get('total_weight'));
-    assert.assertNull(store.get('Pool', '1')!.get('configurations'));
     assert.notInStore('Pool', '2');
   });
 
@@ -173,7 +169,6 @@ describe('core tests', () => {
     assert.fieldEquals('Pool', '1', 'updated_at_block', now.toString());
     assert.assertNull(store.get('Pool', '1')!.get('name'));
     assert.assertNull(store.get('Pool', '1')!.get('total_weight'));
-    assert.assertNull(store.get('Pool', '1')!.get('configurations'));
     assert.notInStore('Pool', '2');
   });
 
@@ -201,7 +196,6 @@ describe('core tests', () => {
     assert.fieldEquals('Pool', '1', 'updated_at_block', now.toString());
     assert.assertNull(store.get('Pool', '1')!.get('name'));
     assert.assertNull(store.get('Pool', '1')!.get('total_weight'));
-    assert.assertNull(store.get('Pool', '1')!.get('configurations'));
     assert.notInStore('Pool', '2');
   });
 

--- a/v3/subgraphs/goerli/tests/core.test.ts
+++ b/v3/subgraphs/goerli/tests/core.test.ts
@@ -17,7 +17,6 @@ import {
   handlePoolOwnerNominated,
   handlePermissionGranted,
   handlePermissionRevoked,
-  handlePoolConfigurationSet,
   handlePoolCreated,
   handlePoolNameUpdated,
   handlePoolNominationRenounced,
@@ -37,11 +36,9 @@ import {
   createDelegationUpdateEvent,
   createDepositEvent,
   createLiquidationEvent,
-  createMarketCreatedEvent,
   createPoolOwnerNominatedEvent,
   createPermissionGrantedEvent,
   createPermissionRevokedEvent,
-  createPoolConfigurationSetEvent,
   createPoolCreatedEvent,
   createPoolNameUpdatedEvent,
   createPoolNominationRevokedEvent,
@@ -55,7 +52,6 @@ import {
   createVaultLiquidationEvent,
   createWithdrawnEvent,
 } from './event-factories';
-import { handleMarketCreated } from '../src/market';
 
 describe('core tests', () => {
   beforeEach(() => {
@@ -222,101 +218,6 @@ describe('core tests', () => {
     assert.fieldEquals('Account', '1', 'updated_at_block', (now - 1000).toString());
     assert.fieldEquals('Account', '1', 'permissions', '[]');
     assert.notInStore('Account', '2');
-  });
-
-  test('handlePoolConfigurationSet', () => {
-    // Needs to be here because of Closures
-    const now = new Date(1668448739566).getTime();
-    const newPoolEvent = createPoolCreatedEvent(1, address, now, now - 1000);
-    const newMarketRegisteredEvent = createMarketCreatedEvent(1, address, now + 1000, now);
-    const newMarketRegisteredEvent2 = createMarketCreatedEvent(2, address2, now + 2000, now + 1000);
-    const markets = changetype<Array<ethereum.Tuple>>([
-      changetype<Array<ethereum.Tuple>>([
-        ethereum.Value.fromI32(1),
-        ethereum.Value.fromI32(32),
-        ethereum.Value.fromI32(812739821),
-      ]),
-      changetype<Array<ethereum.Tuple>>([
-        ethereum.Value.fromI32(2),
-        ethereum.Value.fromI32(43),
-        ethereum.Value.fromI32(892379812),
-      ]),
-    ]);
-
-    const newPoolConfigurationSetEvent = createPoolConfigurationSetEvent(
-      1,
-      markets,
-      now + 3000,
-      now + 2000
-    );
-    const secondMarkets = changetype<Array<ethereum.Tuple>>([
-      changetype<Array<ethereum.Tuple>>([
-        ethereum.Value.fromI32(2),
-        ethereum.Value.fromI32(32),
-        ethereum.Value.fromI32(812739821),
-      ]),
-    ]);
-    const secondNewPoolConfigurationSetEvent = createPoolConfigurationSetEvent(
-      1,
-      secondMarkets,
-      now + 4000,
-      now + 3000
-    );
-    handlePoolCreated(newPoolEvent);
-    handleMarketCreated(newMarketRegisteredEvent);
-    handleMarketCreated(newMarketRegisteredEvent2);
-    handlePoolConfigurationSet(newPoolConfigurationSetEvent);
-
-    assert.fieldEquals('Pool', '1', 'id', '1');
-    assert.fieldEquals('Pool', '1', 'total_weight', '75');
-    assert.fieldEquals('Pool', '1', 'updated_at', (now + 3000).toString());
-    assert.fieldEquals('Pool', '1', 'updated_at_block', (now + 2000).toString());
-    assert.fieldEquals('Pool', '1', 'market_ids', '[1, 2]');
-    assert.fieldEquals('Pool', '1', 'total_weight', '75');
-    assert.assertNull(store.get('Pool', '1')!.get('name'));
-    assert.notInStore('Pool', '2');
-    assert.fieldEquals('Market', '1', 'id', '1');
-    assert.fieldEquals('Pool', '1', 'market_ids', '[1, 2]');
-
-    // Assert market doesn't get updated by configuration event
-    assert.fieldEquals('Market', '1', 'created_at', (now + 1000).toString());
-    assert.fieldEquals('Market', '1', 'created_at_block', now.toString());
-    // The market itself will not receive any updates, only the MarketConfiguration and the Pool
-    assert.fieldEquals('Market', '1', 'updated_at', (now + 1000).toString());
-    assert.fieldEquals('Market', '1', 'updated_at_block', now.toString());
-    assert.fieldEquals('Market', '2', 'id', '2');
-    assert.fieldEquals('Market', '2', 'created_at', (now + 2000).toString());
-    assert.fieldEquals('Market', '2', 'created_at_block', (now + 1000).toString());
-    assert.fieldEquals('Market', '2', 'updated_at', (now + 2000).toString());
-    assert.fieldEquals('Market', '2', 'updated_at_block', (now + 1000).toString());
-    assert.notInStore('Market', '3');
-
-    // Assert market configuration
-    assert.fieldEquals('MarketConfiguration', '1-1', 'id', '1-1');
-    assert.fieldEquals('MarketConfiguration', '1-1', 'pool', '1');
-    assert.fieldEquals('MarketConfiguration', '1-1', 'max_debt_share_value', '812739821');
-    assert.fieldEquals('MarketConfiguration', '1-1', 'updated_at_block', (now + 2000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-1', 'updated_at', (now + 3000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-1', 'created_at', (now + 3000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-1', 'created_at_block', (now + 2000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-1', 'market', '1');
-    assert.fieldEquals('MarketConfiguration', '1-2', 'id', '1-2');
-    assert.fieldEquals('MarketConfiguration', '1-2', 'market', '2');
-    assert.fieldEquals('MarketConfiguration', '1-2', 'pool', '1');
-    assert.fieldEquals('MarketConfiguration', '1-2', 'max_debt_share_value', '892379812');
-    assert.fieldEquals('MarketConfiguration', '1-2', 'created_at', (now + 3000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-2', 'created_at_block', (now + 2000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at', (now + 3000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at_block', (now + 2000).toString());
-
-    // Fire second event that should update Pool and MarketConfiguration.  Removed MarketConfigurations should also be deleted
-    handlePoolConfigurationSet(secondNewPoolConfigurationSetEvent);
-
-    assert.notInStore('MarketConfiguration', '1-1');
-    assert.fieldEquals('Pool', '1', 'total_weight', '32');
-    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at', (now + 4000).toString());
-    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at_block', (now + 3000).toString());
-    assert.notInStore('Pool', '2');
   });
 
   test('handleCollateralConfigured', () => {

--- a/v3/subgraphs/goerli/tests/market.test.ts
+++ b/v3/subgraphs/goerli/tests/market.test.ts
@@ -39,7 +39,6 @@ describe('Market tests', () => {
     assert.fieldEquals('Market', '1', 'usd_withdrawn', '0');
     assert.fieldEquals('Market', '1', 'net_issuance', '0');
     assert.fieldEquals('Market', '1', 'reported_debt', '0');
-    assert.assertNull(store.get('Market', '1')!.get('configurations'));
     assert.notInStore('Market', '2');
   });
 
@@ -124,7 +123,6 @@ describe('Market tests', () => {
 
     /* Assert that the market has the most recent values */
     assert.fieldEquals('Market', '1', 'address', address);
-    assert.assertNull(store.get('Market', '1')!.get('configurations'));
     assert.fieldEquals('Market', '1', 'reported_debt', '23');
     assert.fieldEquals('Market', '1', 'usd_deposited', '400');
     assert.fieldEquals('Market', '1', 'usd_withdrawn', '400');

--- a/v3/subgraphs/goerli/tests/marketConfiguration.test.ts
+++ b/v3/subgraphs/goerli/tests/marketConfiguration.test.ts
@@ -1,0 +1,110 @@
+import { test, assert, clearStore, describe, beforeEach } from 'matchstick-as/assembly/index';
+import { ethereum, store } from '@graphprotocol/graph-ts';
+import { address, address2 } from './constants';
+import { handlePoolConfigurationSet, handlePoolCreated } from '../src/core';
+import {
+  createMarketCreatedEvent,
+  createPoolConfigurationSetEvent,
+  createPoolCreatedEvent,
+} from './event-factories';
+import { handleMarketCreated } from '../src/market';
+
+describe('MarketConfiguration', () => {
+  beforeEach(() => {
+    clearStore();
+  });
+  test('handlePoolConfigurationSet', () => {
+    // Needs to be here because of Closures
+    const now = new Date(1668448739566).getTime();
+    const newPoolEvent = createPoolCreatedEvent(1, address, now, now - 1000);
+    const newMarketRegisteredEvent = createMarketCreatedEvent(1, address, now + 1000, now);
+    const newMarketRegisteredEvent2 = createMarketCreatedEvent(2, address2, now + 2000, now + 1000);
+    const markets = changetype<Array<ethereum.Tuple>>([
+      changetype<Array<ethereum.Tuple>>([
+        ethereum.Value.fromI32(1),
+        ethereum.Value.fromI32(32),
+        ethereum.Value.fromI32(812739821),
+      ]),
+      changetype<Array<ethereum.Tuple>>([
+        ethereum.Value.fromI32(2),
+        ethereum.Value.fromI32(43),
+        ethereum.Value.fromI32(892379812),
+      ]),
+    ]);
+
+    const newPoolConfigurationSetEvent = createPoolConfigurationSetEvent(
+      1,
+      markets,
+      now + 3000,
+      now + 2000
+    );
+    const secondMarkets = changetype<Array<ethereum.Tuple>>([
+      changetype<Array<ethereum.Tuple>>([
+        ethereum.Value.fromI32(2),
+        ethereum.Value.fromI32(32),
+        ethereum.Value.fromI32(812739821),
+      ]),
+    ]);
+    const secondNewPoolConfigurationSetEvent = createPoolConfigurationSetEvent(
+      1,
+      secondMarkets,
+      now + 4000,
+      now + 3000
+    );
+    handlePoolCreated(newPoolEvent);
+    handleMarketCreated(newMarketRegisteredEvent);
+    handleMarketCreated(newMarketRegisteredEvent2);
+    handlePoolConfigurationSet(newPoolConfigurationSetEvent);
+
+    assert.fieldEquals('Pool', '1', 'id', '1');
+    assert.fieldEquals('Pool', '1', 'total_weight', '75');
+    assert.fieldEquals('Pool', '1', 'updated_at', (now + 3000).toString());
+    assert.fieldEquals('Pool', '1', 'updated_at_block', (now + 2000).toString());
+    assert.fieldEquals('Pool', '1', 'market_ids', '[1, 2]');
+    assert.fieldEquals('Pool', '1', 'total_weight', '75');
+    assert.assertNull(store.get('Pool', '1')!.get('name'));
+    assert.notInStore('Pool', '2');
+    assert.fieldEquals('Market', '1', 'id', '1');
+    assert.fieldEquals('Pool', '1', 'market_ids', '[1, 2]');
+
+    // Assert market doesn't get updated by configuration event
+    assert.fieldEquals('Market', '1', 'created_at', (now + 1000).toString());
+    assert.fieldEquals('Market', '1', 'created_at_block', now.toString());
+    // The market itself will not receive any updates, only the MarketConfiguration and the Pool
+    assert.fieldEquals('Market', '1', 'updated_at', (now + 1000).toString());
+    assert.fieldEquals('Market', '1', 'updated_at_block', now.toString());
+    assert.fieldEquals('Market', '2', 'id', '2');
+    assert.fieldEquals('Market', '2', 'created_at', (now + 2000).toString());
+    assert.fieldEquals('Market', '2', 'created_at_block', (now + 1000).toString());
+    assert.fieldEquals('Market', '2', 'updated_at', (now + 2000).toString());
+    assert.fieldEquals('Market', '2', 'updated_at_block', (now + 1000).toString());
+    assert.notInStore('Market', '3');
+
+    // Assert market configuration
+    assert.fieldEquals('MarketConfiguration', '1-1', 'id', '1-1');
+    assert.fieldEquals('MarketConfiguration', '1-1', 'pool', '1');
+    assert.fieldEquals('MarketConfiguration', '1-1', 'max_debt_share_value', '812739821');
+    assert.fieldEquals('MarketConfiguration', '1-1', 'updated_at_block', (now + 2000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-1', 'updated_at', (now + 3000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-1', 'created_at', (now + 3000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-1', 'created_at_block', (now + 2000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-1', 'market', '1');
+    assert.fieldEquals('MarketConfiguration', '1-2', 'id', '1-2');
+    assert.fieldEquals('MarketConfiguration', '1-2', 'market', '2');
+    assert.fieldEquals('MarketConfiguration', '1-2', 'pool', '1');
+    assert.fieldEquals('MarketConfiguration', '1-2', 'max_debt_share_value', '892379812');
+    assert.fieldEquals('MarketConfiguration', '1-2', 'created_at', (now + 3000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-2', 'created_at_block', (now + 2000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at', (now + 3000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at_block', (now + 2000).toString());
+
+    // Fire second event that should update Pool and MarketConfiguration.  Removed MarketConfigurations should also be deleted
+    handlePoolConfigurationSet(secondNewPoolConfigurationSetEvent);
+
+    assert.notInStore('MarketConfiguration', '1-1');
+    assert.fieldEquals('Pool', '1', 'total_weight', '32');
+    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at', (now + 4000).toString());
+    assert.fieldEquals('MarketConfiguration', '1-2', 'updated_at_block', (now + 3000).toString());
+    assert.notInStore('Pool', '2');
+  });
+});


### PR DESCRIPTION
I started digging into an sync error on the subgraph that surfaced now when we have some more data added to the contracts:
![image](https://user-images.githubusercontent.com/5688912/207773704-a10a2d68-986e-4b0d-bc65-b7ad724abedc.png)

This turned out to require a few more changes than expected.
Some key learning:
1. We should never (or rather **CANT**) set derived fields, the compiler **wont** catch this but it fails when live
2. It's not possible to read derived fields from events handlers.

Give this sorta annoying findings this PR is suppose to fix the `PoolConfigurationSet` event by:
- Making sure we dont set configurations on the `Pool` or the `Market`
- Add a new field, `market_ids` on the `Pool`, this is needed so we know what `MarketConfiguration`s to remove when the `PoolConfigurationSet` is triggered
(This is the recommended architecture when you need to read derived fields: https://github.com/graphprotocol/graph-tooling/issues/1093)
I also made some fairly large refactor breaking things into functions and putting them in its own module. So now it's quite clear to see what mutative operations is done on a  `PoolConfigurationSet` event. That is:
1. `deleteRemovedMarketConfigurations`
2. `updateExistingMarketConfigurations`
3. `createNewMarketConfigurations`
4. `updatePoolFields`