### PR TITLE
Add useAllowance hook

### DIFF
--- a/v3/lib/useAllowance/index.ts
+++ b/v3/lib/useAllowance/index.ts
@@ -1,0 +1,1 @@
+export * from './useAllowance';

--- a/v3/lib/useAllowance/package.json
+++ b/v3/lib/useAllowance/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@snx-v3/useAllowance",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.2",
+  "dependencies": {
+    "@snx-v3/useBlockchain": "workspace:*",
+    "@snx-v3/zod": "workspace:*",
+    "@synthetixio/wei": "workspace:*",
+    "@tanstack/react-query": "^4.3.4",
+    "ethers": "^5.7.2"
+  }
+}

--- a/v3/lib/useAllowance/useAllowance.ts
+++ b/v3/lib/useAllowance/useAllowance.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAccount, useProvider } from '@snx-v3/useBlockchain';
+import { Contract } from 'ethers';
+import { ZodBigNumber } from '@snx-v3/zod';
+import { wei } from '@synthetixio/wei';
+
+const AllowanceSchema = ZodBigNumber.transform((x) => wei(x));
+const abi = 'function allowance(address, address) view returns (uint256)';
+export const useAllowance = ({
+  contractAddress,
+  spender,
+}: {
+  contractAddress: string;
+  spender: string;
+}) => {
+  const { address: accountAddress } = useAccount();
+  const provider = useProvider();
+
+  return useQuery({
+    queryKey: [
+      { accountAddress, contractAddress, spender, network: provider.network.name },
+      'allowance',
+    ],
+    queryFn: async () => {
+      const contract = new Contract(contractAddress, abi, provider);
+      const allowance = await contract.allowance(accountAddress, spender);
+      return AllowanceSchema.parse(allowance);
+    },
+    enabled: Boolean(accountAddress && contractAddress && spender && provider),
+  });
+};

--- a/v3/ui/package.json
+++ b/v3/ui/package.json
@@ -23,6 +23,7 @@
     "@snx-v3/etherscanLink": "workspace:*",
     "@snx-v3/format": "workspace:*",
     "@snx-v3/useAccounts": "workspace:*",
+    "@snx-v3/useAllowance": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useCollateralTypes": "workspace:*",
     "@snx-v3/useCoreProxy": "workspace:*",

--- a/v3/ui/src/components/accounts/Position/useManagePosition.ts
+++ b/v3/ui/src/components/accounts/Position/useManagePosition.ts
@@ -10,6 +10,7 @@ import { useContract } from '../../../hooks/useContract';
 import { MulticallCall, useMulticall } from '../../../hooks/useMulticall';
 import { useUnWrapEth, useWrapEth } from '../../../hooks/useWrapEth';
 import { useEthCollateralType } from '@snx-v3/useCollateralTypes';
+import { BigNumber } from 'ethers';
 
 export const useManagePosition = ({
   accountId,
@@ -121,7 +122,7 @@ export const useManagePosition = ({
   const multiTxn = useMulticall(calls);
   const { approve, requireApproval } = useApprove(
     collateral.tokenAddress,
-    collateralChange > 0 ? collateralChangeBN : 0,
+    collateralChange > 0 ? collateralChangeBN : BigNumber.from(0),
     snxProxy?.address
   );
 

--- a/v3/ui/src/hooks/useApproveCall.ts
+++ b/v3/ui/src/hooks/useApproveCall.ts
@@ -1,11 +1,11 @@
-import { BigNumberish } from 'ethers';
+import { BigNumber } from 'ethers';
 import { useCallback } from 'react';
 import { useApprove } from './useApprove';
 import { TxConfig } from './useMulticall';
 
 export const useApproveCall = (
   contractAddress: string,
-  amount: BigNumberish,
+  amount: BigNumber,
   spender: string,
   call: () => Promise<void>,
   config?: Partial<TxConfig>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7776,6 +7776,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@snx-v3/useAllowance@workspace:*, @snx-v3/useAllowance@workspace:v3/lib/useAllowance":
+  version: 0.0.0-use.local
+  resolution: "@snx-v3/useAllowance@workspace:v3/lib/useAllowance"
+  dependencies:
+    "@snx-v3/useBlockchain": "workspace:*"
+    "@snx-v3/zod": "workspace:*"
+    "@synthetixio/wei": "workspace:*"
+    "@tanstack/react-query": ^4.3.4
+    ethers: ^5.7.2
+  languageName: unknown
+  linkType: soft
+
 "@snx-v3/useBlockchain@workspace:*, @snx-v3/useBlockchain@workspace:v3/lib/useBlockchain":
   version: 0.0.0-use.local
   resolution: "@snx-v3/useBlockchain@workspace:v3/lib/useBlockchain"
@@ -9994,6 +10006,7 @@ __metadata:
     "@snx-v3/etherscanLink": "workspace:*"
     "@snx-v3/format": "workspace:*"
     "@snx-v3/useAccounts": "workspace:*"
+    "@snx-v3/useAllowance": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useCollateralTypes": "workspace:*"
     "@snx-v3/useCoreProxy": "workspace:*"


### PR DESCRIPTION
- Add useAllowance hook
- Fix types in useApprove

A first step to replacing wagmi in useApprove. We haven't done any mutation queries without wagmi so yet, so a little bit of work required.