### PR TITLE
Home page improvements

### DIFF
--- a/v3/ui/src/pages/Home/Home.tsx
+++ b/v3/ui/src/pages/Home/Home.tsx
@@ -88,7 +88,7 @@ export function HomeUi({
                 C-Ratio
               </Th>
               <Th color="whiteAlpha.800" pb="2">
-                Performance
+                Issuance Ratio
               </Th>
               <Th color="whiteAlpha.800" pb="2"></Th>
             </Tr>

--- a/v3/ui/src/pages/Home/Home.tsx
+++ b/v3/ui/src/pages/Home/Home.tsx
@@ -4,8 +4,10 @@ import {
   Divider,
   Flex,
   Heading,
+  Skeleton,
   Table,
   Tbody,
+  Td,
   Text,
   Th,
   Thead,
@@ -19,6 +21,26 @@ import { VaultRow } from './VaultRow';
 import { usePreferredPool } from '@snx-v3/usePreferredPool';
 import { useParams } from '@snx-v3/useParams';
 
+const LoadingRow = () => (
+  <Tr>
+    <Td>
+      <Skeleton w="full" height={8} />
+    </Td>
+    <Td>
+      <Skeleton w="full" height={8} />
+    </Td>
+    <Td>
+      <Skeleton w="full" height={8} />
+    </Td>
+    <Td>
+      <Skeleton w="full" height={8} />
+    </Td>
+    <Td>
+      <Skeleton minWidth={16} height={8} />
+    </Td>
+  </Tr>
+);
+
 export function HomeUi({
   collateralTypes,
   preferredPool,
@@ -26,8 +48,8 @@ export function HomeUi({
   VaultRow,
   navigate,
 }: {
-  collateralTypes: CollateralType[];
-  preferredPool: { name: string; id: string };
+  collateralTypes?: CollateralType[];
+  preferredPool?: { name: string; id: string };
   accountId?: string;
   VaultRow: FC<{ collateralType: CollateralType; poolId: string }>;
   navigate: NavigateFunction;
@@ -49,32 +71,40 @@ export function HomeUi({
       </Flex>
       <Divider mt={4} bg="gray.900" />
       <Box p={4} bg="navy.900" mt={8} borderWidth="1px" borderColor="gray.900" borderRadius="base">
-        <Flex justifyContent="space-between" flexWrap={{ base: 'wrap', md: 'nowrap' }}>
+        <Flex
+          justifyContent="space-between"
+          flexWrap={{ base: 'wrap', md: 'nowrap' }}
+          alignItems="center"
+        >
           <Flex
             alignItems="baseline"
             justifyContent="flex-start"
             flexDirection={{ base: 'column', md: 'row' }}
           >
-            <Heading>{preferredPool.name}</Heading>
+            {preferredPool ? <Heading>{preferredPool.name}</Heading> : <Skeleton w={16} h={8} />}
             <Text color="gray.400" ml={{ base: 0, md: 2 }}>
-              Pool #{preferredPool.id}
+              {preferredPool ? `Pool #${preferredPool.id}` : <Skeleton w={12} h={4} />}
             </Text>
           </Flex>
-          <Button
-            mt={{ base: 2, md: 0 }}
-            size="sm"
-            onClick={() =>
-              navigate({
-                pathname: generatePath('/pools/:poolId', {
-                  poolId: preferredPool.id,
-                }),
-                search: accountId ? createSearchParams({ accountId }).toString() : '',
-              })
-            }
-            variant="outline"
-          >
-            Pool Info
-          </Button>
+          {preferredPool ? (
+            <Button
+              mt={{ base: 2, md: 0 }}
+              size="sm"
+              onClick={() =>
+                navigate({
+                  pathname: generatePath('/pools/:poolId', {
+                    poolId: preferredPool.id,
+                  }),
+                  search: accountId ? createSearchParams({ accountId }).toString() : '',
+                })
+              }
+              variant="outline"
+            >
+              Pool Info
+            </Button>
+          ) : (
+            <Skeleton display="block" w={14} h={7} />
+          )}
         </Flex>
         <Text color="gray.400" mt={2}>
           The Spartan Council Pool is the primary pool of Synthetix. All collateral will be
@@ -100,9 +130,16 @@ export function HomeUi({
               </Tr>
             </Thead>
             <Tbody>
-              {collateralTypes.map((c) => (
-                <VaultRow key={c.tokenAddress} collateralType={c} poolId={preferredPool.id} />
-              ))}
+              {preferredPool && collateralTypes ? (
+                collateralTypes.map((c) => (
+                  <VaultRow key={c.tokenAddress} collateralType={c} poolId={preferredPool.id} />
+                ))
+              ) : (
+                <>
+                  <LoadingRow />
+                  <LoadingRow />
+                </>
+              )}
             </Tbody>
           </Table>
         </Box>
@@ -126,8 +163,6 @@ export function Home() {
       });
     }
   }, [navigate, accountId, params.accountId]);
-
-  if (!collateralTypes || !preferredPool) return null;
 
   return (
     <HomeUi

--- a/v3/ui/src/pages/Home/Home.tsx
+++ b/v3/ui/src/pages/Home/Home.tsx
@@ -34,7 +34,7 @@ export function HomeUi({
 }) {
   return (
     <Flex height="100%" flexDirection="column">
-      <Flex alignItems="flex-end">
+      <Flex alignItems="flex-end" flexWrap={{ base: 'wrap', md: 'nowrap' }}>
         <Box flexGrow={1} mr={12}>
           <Heading>Welcome to Synthetix V3</Heading>
           <Text>
@@ -43,20 +43,25 @@ export function HomeUi({
             quick introduction first.
           </Text>
         </Box>
-        <Button variant="outline" minW="unset" size="sm">
+        <Button variant="outline" minW="unset" size="sm" mt={{ base: 2, md: 0 }}>
           Read Introduction
         </Button>
       </Flex>
       <Divider mt={4} bg="gray.900" />
       <Box p={4} bg="navy.900" mt={8} borderWidth="1px" borderColor="gray.900" borderRadius="base">
-        <Flex justifyContent="space-between">
-          <Flex alignItems="baseline" justifyContent="flex-start">
+        <Flex justifyContent="space-between" flexWrap={{ base: 'wrap', md: 'nowrap' }}>
+          <Flex
+            alignItems="baseline"
+            justifyContent="flex-start"
+            flexDirection={{ base: 'column', md: 'row' }}
+          >
             <Heading>{preferredPool.name}</Heading>
-            <Text color="gray.400" ml={2}>
+            <Text color="gray.400" ml={{ base: 0, md: 2 }}>
               Pool #{preferredPool.id}
             </Text>
           </Flex>
           <Button
+            mt={{ base: 2, md: 0 }}
             size="sm"
             onClick={() =>
               navigate({
@@ -75,30 +80,32 @@ export function HomeUi({
           The Spartan Council Pool is the primary pool of Synthetix. All collateral will be
           deposited in this pool by default.
         </Text>
-        <Table mt={8} size="sm" variant="simple" mb="9">
-          <Thead>
-            <Tr>
-              <Th color="whiteAlpha.800" pb="2">
-                Collateral
-              </Th>
-              <Th color="whiteAlpha.800" pb="2">
-                Debt
-              </Th>
-              <Th color="whiteAlpha.800" pb="2">
-                C-Ratio
-              </Th>
-              <Th color="whiteAlpha.800" pb="2">
-                Issuance Ratio
-              </Th>
-              <Th color="whiteAlpha.800" pb="2"></Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {collateralTypes.map((c) => (
-              <VaultRow key={c.tokenAddress} collateralType={c} poolId={preferredPool.id} />
-            ))}
-          </Tbody>
-        </Table>
+        <Box overflowX="auto">
+          <Table mt={8} size="sm" variant="simple" mb="9">
+            <Thead>
+              <Tr>
+                <Th color="whiteAlpha.800" pb="2">
+                  Collateral
+                </Th>
+                <Th color="whiteAlpha.800" pb="2">
+                  Debt
+                </Th>
+                <Th color="whiteAlpha.800" pb="2">
+                  C-Ratio
+                </Th>
+                <Th color="whiteAlpha.800" pb="2">
+                  Issuance Ratio
+                </Th>
+                <Th color="whiteAlpha.800" pb="2"></Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {collateralTypes.map((c) => (
+                <VaultRow key={c.tokenAddress} collateralType={c} poolId={preferredPool.id} />
+              ))}
+            </Tbody>
+          </Table>
+        </Box>
       </Box>
     </Flex>
   );

--- a/v3/ui/src/pages/Home/VaultRow.tsx
+++ b/v3/ui/src/pages/Home/VaultRow.tsx
@@ -1,5 +1,6 @@
 import { Amount } from '@snx-v3/Amount';
-import { Button, Image, Td, Text, Tr } from '@chakra-ui/react';
+import { Button, Image, Td, Text, Tooltip, Tr } from '@chakra-ui/react';
+import { InfoOutlineIcon } from '@chakra-ui/icons';
 import { LiquidityPosition, useLiquidityPosition } from '@snx-v3/useLiquidityPosition';
 import { createSearchParams, generatePath, NavigateFunction, useNavigate } from 'react-router-dom';
 import { FC } from 'react';
@@ -48,8 +49,15 @@ function VaultRowUi({
         <Text fontSize="xs" opacity="0.66" mt="1">
           <Amount value={liquidityPosition ? collateralType.liquidationRatioD18 : '0'} suffix="%" />
         </Text>
+      <Td>
+        <Amount value={collateralType.issuanceRatioD18.mul(100)} suffix="%" />
+        <Tooltip label="Liquidation Ratio">
+          <Text fontSize="xs" opacity="0.66" mt="1">
+            <Amount value={collateralType.liquidationRatioD18.mul(100)} suffix="%" />{' '}
+            <InfoOutlineIcon ml="1" transform="translateY(-1.5px)" />
+          </Text>
+        </Tooltip>
       </Td>
-      <Td>TODO</Td>
       <Td>
         {isConnected && hasLiquidity ? (
           <Button

--- a/v3/ui/src/pages/Home/VaultRow.tsx
+++ b/v3/ui/src/pages/Home/VaultRow.tsx
@@ -33,22 +33,29 @@ function VaultRowUi({
     <Tr>
       <Td>
         <Image alt="collateral image" width="24px" height="24px" src={collateralType.logo} />
-        <Amount value={liquidityPosition ? liquidityPosition.collateralValue : '0'} prefix="$" />
+        {liquidityPosition?.collateralValue.gt(0) ? (
+          <Amount value={liquidityPosition.collateralValue} prefix="$" />
+        ) : (
+          '-'
+        )}
         <Text fontSize="xs" opacity="0.66" mt="1">
-          <Amount
-            value={liquidityPosition ? liquidityPosition.collateralAmount : '0'}
-            suffix={` ${symbol}`}
-          />
+          {liquidityPosition?.collateralValue.gt(0) ? (
+            <Amount value={liquidityPosition.collateralAmount} suffix={` ${symbol}`} />
+          ) : (
+            '-'
+          )}
         </Text>
       </Td>
       <Td>
-        <Amount value={liquidityPosition ? liquidityPosition.debt : '0'} prefix="$" />
+        {liquidityPosition?.debt.gt(0) ? <Amount value={liquidityPosition.debt} prefix="$" /> : '-'}
       </Td>
       <Td>
-        <Amount value={liquidityPosition ? liquidityPosition.cRatio : '0'} suffix="%" />
-        <Text fontSize="xs" opacity="0.66" mt="1">
-          <Amount value={liquidityPosition ? collateralType.liquidationRatioD18 : '0'} suffix="%" />
-        </Text>
+        {liquidityPosition?.cRatio.gt(0) ? (
+          <Amount value={liquidityPosition.cRatio} suffix="%" />
+        ) : (
+          '-'
+        )}
+      </Td>
       <Td>
         <Amount value={collateralType.issuanceRatioD18.mul(100)} suffix="%" />
         <Tooltip label="Liquidation Ratio">


### PR DESCRIPTION
- Show issuance ration and liquidation ratio rather than performance
- Show `-` insted of `0` when no position
- Make home page responsive. The chakra table doesn't have support for proper responsiveness so just making it scrollable for now
- Skeletons for home page

![localhost_3000__accountId=7277210567](https://user-images.githubusercontent.com/5688912/212205349-b7e62f84-c7d3-4e60-a6df-bf7256a25132.png)
![Screenshot 2023-01-13 at 10 48 08 am](https://user-images.githubusercontent.com/5688912/212205353-c983b848-4342-4918-af5d-36611847e8ac.png)
![Screenshot 2023-01-13 at 10 48 04 am](https://user-images.githubusercontent.com/5688912/212205355-9dc88e3d-1bb0-4d1a-8819-cdc655ad020b.png)
![Screenshot 2023-01-13 at 12 45 21 pm](https://user-images.githubusercontent.com/5688912/212218187-18519e98-386b-4e9c-bf97-78d40eaea79e.png)
