### PR TITLE
Handle loans disabled

### DIFF
--- a/v2/cypress/cypress/e2e/loans.e2e.js
+++ b/v2/cypress/cypress/e2e/loans.e2e.js
@@ -1,4 +1,4 @@
-it('Can borrow sUSD with ETH collateral', () => {
+it.skip('Can borrow sUSD with ETH collateral', () => {
   cy.viewport(1000, 1200);
 
   cy.task('removeEthCollateralInteractionDelay');

--- a/v2/ui/sections/loans/components/ActionBox/BorrowSynthsTab/BorrowSynthsTab.tsx
+++ b/v2/ui/sections/loans/components/ActionBox/BorrowSynthsTab/BorrowSynthsTab.tsx
@@ -56,7 +56,7 @@ const BorrowSynthsTab: FC<BorrowSynthsTabProps> = () => {
   const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
   const navigate = useNavigate();
 
-  const { minCRatio } = Loans.useContainer();
+  const { minCRatio, canOpenLoans } = Loans.useContainer();
   const { useExchangeRatesQuery, useSynthetixTxn, useTokensBalancesQuery } = useSynthetixQueries();
 
   const [gasPrice, setGasPrice] = useState<GasPrice | undefined>(undefined);
@@ -113,7 +113,8 @@ const BorrowSynthsTab: FC<BorrowSynthsTabProps> = () => {
       debtAsset &&
       !hasLowCollateralAmount &&
       !hasLowCRatio &&
-      !hasInsufficientCollateral
+      !hasInsufficientCollateral &&
+      canOpenLoans
   );
 
   const openTxn = useSynthetixTxn(
@@ -155,8 +156,13 @@ const BorrowSynthsTab: FC<BorrowSynthsTabProps> = () => {
   return (
     <>
       <FormContainer data-testid="loans form">
+        {canOpenLoans === false && (
+          <ErrorMessage>Opening of loans is currently disabled</ErrorMessage>
+        )}
         <InputsContainer>
           <AssetInput
+            selectDisabled={!canOpenLoans}
+            inputDisabled={!canOpenLoans}
             label="loans.tabs.new.debt.label"
             asset={debtAsset}
             setAsset={setDebtAsset}
@@ -167,6 +173,8 @@ const BorrowSynthsTab: FC<BorrowSynthsTabProps> = () => {
           />
           <InputsDivider />
           <AssetInput
+            selectDisabled={!canOpenLoans}
+            inputDisabled={!canOpenLoans}
             label="loans.tabs.new.collateral.label"
             asset={collateralAsset}
             setAsset={setCollateralAsset}


### PR DESCRIPTION
Handle loans being disabled.
Loans wont be enabled until v3. And in v3 it will work very differently. Maybe I should remove the test rather than skipping it?

![image](https://user-images.githubusercontent.com/5688912/212577479-07d72dbf-b5b6-41b3-ba66-3efc2e748236.png)
