### PR TITLE
V2 burn fixes

### DIFF
--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -522,10 +522,10 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
         }
         setActivePreset('max');
 
-        const burnAmountString = formatNumber(
+        const burnAmountString = numberWithCommas(
           debtData.debtBalance.gt(sUSDBalanceWithDefault)
-            ? sUSDBalanceWithDefault
-            : debtData.debtBalance.toNumber()
+            ? sUSDBalanceWithDefault.toString()
+            : debtData.debtBalance.toString()
         );
         const snxUnstakingAmount = formatNumber(stakedSnx.toNumber());
         setBurnAmountSusd(burnAmountString);
@@ -542,7 +542,7 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
         }
         setActivePreset('sUSDBalance');
 
-        const burnAmountString = formatNumber(sUSDBalanceWithDefault);
+        const burnAmountString = numberWithCommas(sUSDBalanceWithDefault.toString());
         const snxUnstakingAmount = calculateUnstakingAmountFromBurn({
           burnAmount: sUSDBalanceWithDefault,
           targetCRatio: debtData.targetCRatio.toNumber(),
@@ -565,9 +565,9 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
           return;
         }
         setActivePreset('debtBalance');
-        const burnAmountString = formatNumber(debtData.debtBalance.toNumber());
+        const burnAmountString = numberWithCommas(debtData.debtBalance.toString());
         const snxUnstakingAmount = calculateUnstakingAmountFromBurn({
-          burnAmount: sUSDBalanceWithDefault,
+          burnAmount: debtData.debtBalance.toNumber(),
           targetCRatio: debtData.targetCRatio.toNumber(),
           collateralPrice: snxPrice,
           debtBalance: debtData.debtBalance.toNumber(),

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -107,7 +107,7 @@ export const BurnUi = ({
   const onChange = (currency: 'susd' | 'snx') => (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replaceAll(',', '');
     onPresetClick(null);
-    if (/^[0-9]*(\.[0-9]{0,2})?$/.test(value)) {
+    if (/^[0-9]*(\.[0-9]{0,18})?$/.test(value)) {
       return currency === 'susd' ? onBurnAmountSusdChange(value) : onUnstakeAmountChange(value);
     }
   };

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -477,7 +477,10 @@ export const Burn: FC<{ delegateWalletAddress?: string }> = ({ delegateWalletAdd
     // Even if the sUSD balance might be bigger than the users debt we still send the complete balance to the contract
     // We do this to avoid users having sUSD dust incase the debt fluctuates.
     // The contract will only burn whats needed to clear the debt.
-    amount: activePreset === 'max' ? wei(susdBalance || 0).toBN() : wei(burnAmountSusd || 0).toBN(),
+    amount:
+      activePreset === 'max' || activePreset === 'debtBalance'
+        ? wei(susdBalance || 0).toBN()
+        : wei(burnAmountSusd || 0).toBN(),
     delegateAddress: delegateWalletAddress,
     toTarget: activePreset === 'toTarget',
   });


### PR DESCRIPTION
- Dont round numbers for preset.
- Send whole usd balance when `debtBalance` preset is active (see comment)
- Allow 18 dp in input field
![image](https://user-images.githubusercontent.com/5688912/213084876-9e50626c-9e67-48b6-9444-0a62b665acf5.png)
