### PR TITLE
Manage borrow, repay & withdraw

### DIFF
--- a/v3/components/NumberInput/NumberInput.tsx
+++ b/v3/components/NumberInput/NumberInput.tsx
@@ -18,6 +18,7 @@ export function NumberInput({
   const onInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       setInputValue(e.target.value);
+      e.target.setCustomValidity('');
       if (!onChange) {
         // Could be a read-only input
         return;
@@ -31,8 +32,6 @@ export function NumberInput({
 
       if (max?.gte(0) && nextValue.gt(max)) {
         e.target.setCustomValidity('Value greater than max');
-      } else {
-        e.target.setCustomValidity('');
       }
 
       if (!value.eq(nextValue)) {

--- a/v3/lib/ManagePositionContext/ManagePositionContext.tsx
+++ b/v3/lib/ManagePositionContext/ManagePositionContext.tsx
@@ -1,0 +1,28 @@
+import Wei, { wei } from '@synthetixio/wei';
+import React, { createContext, useState, PropsWithChildren, Dispatch, SetStateAction } from 'react';
+
+export const ManagePositionContext = createContext<{
+  collateralChange: Wei;
+  debtChange: Wei;
+  setDebtChange: Dispatch<SetStateAction<Wei>>;
+  setCollateralChange: Dispatch<SetStateAction<Wei>>;
+}>({
+  collateralChange: wei(0),
+  debtChange: wei(0),
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setDebtChange: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setCollateralChange: () => {},
+});
+
+export const ManagePositionProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [debtChange, setDebtChange] = useState(wei(0));
+  const [collateralChange, setCollateralChange] = useState(wei(0));
+  return (
+    <ManagePositionContext.Provider
+      value={{ debtChange, setDebtChange, collateralChange, setCollateralChange }}
+    >
+      {children}
+    </ManagePositionContext.Provider>
+  );
+};

--- a/v3/lib/ManagePositionContext/index.ts
+++ b/v3/lib/ManagePositionContext/index.ts
@@ -1,0 +1,1 @@
+export * from './ManagePositionContext';

--- a/v3/lib/ManagePositionContext/package.json
+++ b/v3/lib/ManagePositionContext/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@snx-v3/ManagePositionContext",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.1",
+  "dependencies": {
+    "@synthetixio/wei": "workspace:*",
+    "react": "^18.2.0"
+  }
+}

--- a/v3/lib/useUSDProxy/index.ts
+++ b/v3/lib/useUSDProxy/index.ts
@@ -1,0 +1,1 @@
+export * from './useUSDProxy';

--- a/v3/lib/useUSDProxy/package.json
+++ b/v3/lib/useUSDProxy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@snx-v3/useUSDProxy",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.1",
+  "dependencies": {
+    "@ethersproject/contracts": "^5.7.0",
+    "@snx-v3/useBlockchain": "workspace:*",
+    "@synthetixio/v3-contracts": "workspace:*",
+    "@tanstack/react-query": "^4.3.4"
+  }
+}

--- a/v3/lib/useUSDProxy/useUSDProxy.ts
+++ b/v3/lib/useUSDProxy/useUSDProxy.ts
@@ -1,0 +1,36 @@
+import { Contract } from '@ethersproject/contracts';
+import { useQuery } from '@tanstack/react-query';
+import type { USDProxy as USDProxyGoerli } from '@synthetixio/v3-contracts/build/goerli/USDProxy';
+import type { USDProxy as USDProxyOptimismGoerli } from '@synthetixio/v3-contracts/build/optimism-goerli/USDProxy';
+import { useNetwork, useProvider, useSigner } from '@snx-v3/useBlockchain';
+
+export async function importUSDProxy(chainName: string) {
+  switch (chainName) {
+    case 'goerli':
+      return import('@synthetixio/v3-contracts/build/goerli/USDProxy');
+    case 'optimism-goerli':
+      return import('@synthetixio/v3-contracts/build/optimism-goerli/USDProxy');
+    default:
+      throw new Error(`Unsupported chain ${chainName}`);
+  }
+}
+export const useUSDProxy = () => {
+  const network = useNetwork();
+  const provider = useProvider();
+  const signer = useSigner();
+  const signerOrProvider = signer || provider;
+
+  return useQuery({
+    queryKey: [network.name, { withSigner: Boolean(signer) }, 'USDProxy'],
+    queryFn: async function () {
+      const USDProxy = await importUSDProxy(network.name);
+      return new Contract(USDProxy.address, USDProxy.abi, signerOrProvider) as
+        | USDProxyGoerli
+        | USDProxyOptimismGoerli;
+    },
+    enabled: Boolean(network.name && signerOrProvider),
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
+};
+export type USDProxyContractType = USDProxyGoerli | USDProxyOptimismGoerli;

--- a/v3/ui/package.json
+++ b/v3/ui/package.json
@@ -28,6 +28,7 @@
     "@snx-v3/BorderBox": "workspace:*",
     "@snx-v3/CollateralTypeSelector": "workspace:*",
     "@snx-v3/Constants": "workspace:*",
+    "@snx-v3/ManagePositionContext": "workspace:*",
     "@snx-v3/Multistep": "workspace:*",
     "@snx-v3/NumberInput": "workspace:*",
     "@snx-v3/PoolBox": "workspace:*",

--- a/v3/ui/package.json
+++ b/v3/ui/package.json
@@ -53,6 +53,7 @@
     "@snx-v3/usePreferredPool": "workspace:*",
     "@snx-v3/useTokenBalance": "workspace:*",
     "@snx-v3/useTransactionState": "workspace:*",
+    "@snx-v3/useUSDProxy": "workspace:*",
     "@snx-v3/useVaultsData": "workspace:*",
     "@snx-v3/validatePosition": "workspace:*",
     "@synthetixio/v3-contracts": "workspace:*",

--- a/v3/ui/src/App.tsx
+++ b/v3/ui/src/App.tsx
@@ -31,7 +31,7 @@ export const Synthetix: FC = () => {
             element={<AccountPositionPage />}
           />
           <Route
-            path="new/accounts/:accountId/positions/:collateral/:poolId"
+            path="new/accounts/:accountId/positions/:collateralSymbol/:poolId"
             element={<Manage />}
           />
           <Route path="/deposit/:collateralSymbol/:poolId" element={<Deposit />} />

--- a/v3/ui/src/pages/AccountPositionPage/useManagePosition.ts
+++ b/v3/ui/src/pages/AccountPositionPage/useManagePosition.ts
@@ -136,9 +136,9 @@ export const useManagePosition = ({
     }
 
     if (debtChange.gt(0)) {
-      title.push('Mint snxUSD');
+      title.push('Borrow snxUSD');
     } else if (debtChange.lt(0)) {
-      title.push('Burn snxUSD');
+      title.push('Repay snxUSD');
     }
 
     return title;

--- a/v3/ui/src/pages/Manage/Borrow.tsx
+++ b/v3/ui/src/pages/Manage/Borrow.tsx
@@ -49,7 +49,7 @@ const BorrowUi: FC<{
           </Flex>
         </Flex>
       </BorderBox>
-      <Button>Borrow snxUSD</Button>
+      <Button type="submit">Borrow snxUSD</Button>
     </Flex>
   );
 };

--- a/v3/ui/src/pages/Manage/Borrow.tsx
+++ b/v3/ui/src/pages/Manage/Borrow.tsx
@@ -31,7 +31,12 @@ const BorrowUi: FC<{
           snxUSD
         </Text>
         <Flex flexDirection="column" justifyContent="flex-end" flexGrow={1}>
-          <NumberInput value={debtChange} onChange={(val) => setDebtChange(val)} max={maxDebt} />
+          <NumberInput
+            InputProps={{ isRequired: true }}
+            value={debtChange}
+            onChange={(val) => setDebtChange(val)}
+            max={maxDebt}
+          />
           <Flex flexDirection="column" alignItems="flex-end" fontSize="xs" color="whiteAlpha.700">
             <Flex
               gap="1"

--- a/v3/ui/src/pages/Manage/Borrow.tsx
+++ b/v3/ui/src/pages/Manage/Borrow.tsx
@@ -1,0 +1,75 @@
+import { Button, Flex, Text } from '@chakra-ui/react';
+import { Amount } from '@snx-v3/Amount';
+import { BorderBox } from '@snx-v3/BorderBox';
+import { DollarCircle } from '@snx-v3/icons';
+import { NumberInput } from '@snx-v3/NumberInput';
+import { ManagePositionContext } from '@snx-v3/ManagePositionContext';
+import { FC, useContext } from 'react';
+import { validatePosition } from '@snx-v3/validatePosition';
+import { useCollateralType } from '@snx-v3/useCollateralTypes';
+import { useParams } from '@snx-v3/useParams';
+import { useLiquidityPosition } from '@snx-v3/useLiquidityPosition';
+import Wei from '@synthetixio/wei';
+
+const BorrowUi: FC<{
+  debtChange: Wei;
+  maxDebt: Wei;
+  setDebtChange: (val: Wei) => void;
+}> = ({ debtChange, setDebtChange, maxDebt }) => {
+  return (
+    <Flex flexDirection="column" gap={2}>
+      <Text fontSize="md" fontWeight="700">
+        Borrow snxUSD
+      </Text>
+      <Text fontSize="sm" color="gray.400">
+        Take an interest-free loan against your collateral. This increases your debt and decreases
+        your C-Ratio.
+      </Text>
+      <BorderBox display="flex" py={1} px={2}>
+        <Text display="flex" gap={2} alignItems="center" fontWeight="600" mx="2">
+          <DollarCircle />
+          snxUSD
+        </Text>
+        <Flex flexDirection="column" justifyContent="flex-end" flexGrow={1}>
+          <NumberInput value={debtChange} onChange={(val) => setDebtChange(val)} max={maxDebt} />
+          <Flex flexDirection="column" alignItems="flex-end" fontSize="xs" color="whiteAlpha.700">
+            <Flex
+              gap="1"
+              cursor="pointer"
+              onClick={() => {
+                if (!maxDebt) {
+                  return;
+                }
+                setDebtChange(maxDebt);
+              }}
+            >
+              <Text>Max Borrow:</Text>
+              <Amount value={maxDebt} />
+            </Flex>
+          </Flex>
+        </Flex>
+      </BorderBox>
+      <Button>Borrow snxUSD</Button>
+    </Flex>
+  );
+};
+
+export const Borrow = () => {
+  const { debtChange, collateralChange, setDebtChange } = useContext(ManagePositionContext);
+  const params = useParams();
+  const collateralType = useCollateralType(params.collateralType);
+  const { data: liquidityPosition } = useLiquidityPosition({
+    tokenAddress: collateralType?.tokenAddress,
+    accountId: params.accountId,
+    poolId: params.poolId,
+  });
+  const { maxDebt } = validatePosition({
+    issuanceRatioD18: collateralType?.issuanceRatioD18,
+    collateralAmount: liquidityPosition?.collateralAmount,
+    collateralValue: liquidityPosition?.collateralValue,
+    debt: liquidityPosition?.debt,
+    collateralChange: collateralChange,
+    debtChange: debtChange,
+  });
+  return <BorrowUi setDebtChange={setDebtChange} debtChange={debtChange} maxDebt={maxDebt} />;
+};

--- a/v3/ui/src/pages/Manage/Manage.tsx
+++ b/v3/ui/src/pages/Manage/Manage.tsx
@@ -11,6 +11,7 @@ import { CollateralIcon } from '@snx-v3/icons';
 import { currency } from '@snx-v3/format';
 import { PoolBox } from '@snx-v3/PoolBox';
 import { ManageAction } from './ManageActions';
+import { ManagePositionProvider } from '@snx-v3/ManagePositionContext';
 
 export const ManageUi: FC<{
   liquidityPosition: LiquidityPosition;
@@ -115,5 +116,9 @@ export const Manage = () => {
   if (!collateralType || !liquidityPosition) {
     return <Spinner />; // TODO skeleton
   }
-  return <ManageUi liquidityPosition={liquidityPosition} collateralType={collateralType} />;
+  return (
+    <ManagePositionProvider>
+      <ManageUi liquidityPosition={liquidityPosition} collateralType={collateralType} />
+    </ManagePositionProvider>
+  );
 };

--- a/v3/ui/src/pages/Manage/ManageActions.tsx
+++ b/v3/ui/src/pages/Manage/ManageActions.tsx
@@ -1,5 +1,5 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons';
-import { Box, Button, Flex } from '@chakra-ui/react';
+import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import { BorderBox } from '@snx-v3/BorderBox';
 import { BorrowIcon, DollarCircle } from '@snx-v3/icons';
 import { useParams } from '@snx-v3/useParams';
@@ -21,6 +21,9 @@ const ActionButton: FC<
     _hover={{
       bg: 'whiteAlpha.100',
     }}
+    _active={{
+      bg: 'whiteAlpha.100',
+    }}
     cursor="pointer"
     bg={activeAction === action ? 'whiteAlpha.100' : 'none'}
     onClick={() => onClick(action)}
@@ -32,14 +35,30 @@ const ActionButton: FC<
   </BorderBox>
 );
 
-const ManageActionUi: FC<{ setActiveAction: (action: string) => void; manageAction?: string }> = ({
-  setActiveAction,
-  manageAction,
-}) => {
+const Action: FC<{ manageAction: string }> = ({ manageAction }) => {
+  switch (manageAction) {
+    case 'borrow':
+      return <Text>Borrow</Text>;
+    case 'deposit':
+      return <Text>Deposit</Text>;
+    case 'repay':
+      return <Text>Repay</Text>;
+    case 'withdraw':
+      return <Text>Withdraw</Text>;
+
+    default:
+      return null;
+  }
+};
+
+const ManageActionUi: FC<{
+  setActiveAction: (action: string) => void;
+  manageAction?: string;
+}> = ({ setActiveAction, manageAction }) => {
   return (
     <Box>
       <Flex mt={2} gap={2}>
-        <ActionButton onClick={setActiveAction} action="collateral" activeAction={manageAction}>
+        <ActionButton onClick={setActiveAction} action="deposit" activeAction={manageAction}>
           <ArrowDownIcon w="15px" h="15px" mr={1} /> Deposit Collateral
         </ActionButton>
         <ActionButton onClick={setActiveAction} action="repay" activeAction={manageAction}>
@@ -48,12 +67,17 @@ const ManageActionUi: FC<{ setActiveAction: (action: string) => void; manageActi
       </Flex>
       <Flex mt={2} gap={2}>
         <ActionButton onClick={setActiveAction} action="withdraw" activeAction={manageAction}>
-          <ArrowUpIcon w="15px" h="15px" mr={1} /> Deposit Collateral
+          <ArrowUpIcon w="15px" h="15px" mr={1} /> Withdraw Collateral
         </ActionButton>
         <ActionButton onClick={setActiveAction} action="borrow" activeAction={manageAction}>
           <BorrowIcon mr={1} /> Borrow snxUSD
         </ActionButton>
       </Flex>
+      {manageAction ? (
+        <Flex direction="column" mt={4}>
+          <Action manageAction={manageAction} />
+        </Flex>
+      ) : null}
     </Box>
   );
 };

--- a/v3/ui/src/pages/Manage/ManageActions.tsx
+++ b/v3/ui/src/pages/Manage/ManageActions.tsx
@@ -5,6 +5,7 @@ import { BorrowIcon, DollarCircle } from '@snx-v3/icons';
 import { useParams } from '@snx-v3/useParams';
 import { FC, PropsWithChildren } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { Borrow } from './Borrow';
 
 const ActionButton: FC<
   PropsWithChildren<{
@@ -38,7 +39,7 @@ const ActionButton: FC<
 const Action: FC<{ manageAction: string }> = ({ manageAction }) => {
   switch (manageAction) {
     case 'borrow':
-      return <Text>Borrow</Text>;
+      return <Borrow />;
     case 'deposit':
       return <Text>Deposit</Text>;
     case 'repay':

--- a/v3/ui/src/pages/Manage/ManageActions.tsx
+++ b/v3/ui/src/pages/Manage/ManageActions.tsx
@@ -12,6 +12,8 @@ import { FC, FormEvent, PropsWithChildren, useCallback, useContext } from 'react
 import { useSearchParams } from 'react-router-dom';
 import { Borrow } from './Borrow';
 import { useManagePosition } from '../AccountPositionPage/useManagePosition';
+import { Repay } from './Repay';
+import { Withdraw } from './Withdraw';
 
 const ActionButton: FC<
   PropsWithChildren<{
@@ -49,9 +51,9 @@ const Action: FC<{ manageAction: string }> = ({ manageAction }) => {
     case 'deposit':
       return <Text>Deposit</Text>;
     case 'repay':
-      return <Text>Repay</Text>;
+      return <Repay />;
     case 'withdraw':
-      return <Text>Withdraw</Text>;
+      return <Withdraw />;
 
     default:
       return null;
@@ -137,7 +139,11 @@ export const ManageAction = () => {
   return (
     <ManageActionUi
       onSubmit={onSubmit}
-      setActiveAction={(action) => setQueryParam({ manageAction: action })}
+      setActiveAction={(action) => {
+        setCollateralChange(wei(0));
+        setDebtChange(wei(0));
+        setQueryParam({ manageAction: action });
+      }}
       manageAction={params.manageAction}
     />
   );

--- a/v3/ui/src/pages/Manage/Repay.tsx
+++ b/v3/ui/src/pages/Manage/Repay.tsx
@@ -1,0 +1,81 @@
+import { Button, Flex, Text } from '@chakra-ui/react';
+import { Amount } from '@snx-v3/Amount';
+import { BorderBox } from '@snx-v3/BorderBox';
+import { DollarCircle } from '@snx-v3/icons';
+import { ManagePositionContext } from '@snx-v3/ManagePositionContext';
+import { NumberInput } from '@snx-v3/NumberInput';
+import { useCollateralType } from '@snx-v3/useCollateralTypes';
+import { useUSDProxy } from '@snx-v3/useUSDProxy';
+import { useLiquidityPosition } from '@snx-v3/useLiquidityPosition';
+import { useTokenBalance } from '@snx-v3/useTokenBalance';
+import Wei, { wei } from '@synthetixio/wei';
+import { FC, useContext } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const RepayUi: FC<{
+  debtChange: Wei;
+  max?: Wei;
+  setDebtChange: (val: Wei) => void;
+}> = ({ debtChange, setDebtChange, max }) => {
+  return (
+    <Flex flexDirection="column" gap={2}>
+      <Text fontSize="md" fontWeight="700">
+        Repay snxUSD
+      </Text>
+      <Text fontSize="sm" color="gray.400">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Totam consectetur dignissimos velit
+        odio cum vitae facilis?
+      </Text>
+      <BorderBox display="flex" py={1} px={2}>
+        <Text display="flex" gap={2} alignItems="center" fontWeight="600" mx="2">
+          <DollarCircle />
+          snxUSD
+        </Text>
+        <Flex flexDirection="column" justifyContent="flex-end" flexGrow={1}>
+          <NumberInput
+            InputProps={{ isRequired: true }}
+            value={debtChange.abs()}
+            onChange={(val) => setDebtChange(val.mul(-1))}
+            max={max}
+          />
+          <Flex flexDirection="column" alignItems="flex-end" fontSize="xs" color="whiteAlpha.700">
+            <Flex
+              gap="1"
+              cursor="pointer"
+              onClick={() => {
+                if (!max) {
+                  return;
+                }
+                setDebtChange(max.mul(-1));
+              }}
+            >
+              <Text>Debt:</Text>
+              <Amount value={max} />
+            </Flex>
+          </Flex>
+        </Flex>
+      </BorderBox>
+      <Button type="submit">Repay snxUSD</Button>
+    </Flex>
+  );
+};
+export const Repay = () => {
+  const { debtChange, setDebtChange } = useContext(ManagePositionContext);
+  const { data: USDProxy } = useUSDProxy();
+  const params = useParams();
+  const collateralType = useCollateralType(params.collateralType);
+  const { data: liquidityPosition } = useLiquidityPosition({
+    tokenAddress: collateralType?.tokenAddress,
+    accountId: params.accountId,
+    poolId: params.poolId,
+  });
+  const { data: balance } = useTokenBalance(USDProxy?.address);
+
+  return (
+    <RepayUi
+      setDebtChange={setDebtChange}
+      debtChange={debtChange}
+      max={Wei.min(liquidityPosition?.debt || wei(0), balance || wei(0))}
+    />
+  );
+};

--- a/v3/ui/src/pages/Manage/Withdraw.tsx
+++ b/v3/ui/src/pages/Manage/Withdraw.tsx
@@ -1,0 +1,111 @@
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import { Button, Flex, Text, Tooltip } from '@chakra-ui/react';
+import { Amount } from '@snx-v3/Amount';
+import { BorderBox } from '@snx-v3/BorderBox';
+import { currency } from '@snx-v3/format';
+import { CollateralIcon } from '@snx-v3/icons';
+import { ManagePositionContext } from '@snx-v3/ManagePositionContext';
+import { NumberInput } from '@snx-v3/NumberInput';
+import { useCollateralType } from '@snx-v3/useCollateralTypes';
+import { useLiquidityPosition } from '@snx-v3/useLiquidityPosition';
+import { validatePosition } from '@snx-v3/validatePosition';
+import Wei, { wei } from '@synthetixio/wei';
+import { FC, useContext } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const WithdrawUi: FC<{
+  collateralChange: Wei;
+  currentCollateral?: Wei;
+  max?: Wei;
+  displaySymbol: string;
+  symbol: string;
+  setCollateralChange: (val: Wei) => void;
+}> = ({ collateralChange, setCollateralChange, max, displaySymbol, symbol, currentCollateral }) => {
+  return (
+    <Flex flexDirection="column" gap={2}>
+      <Text fontSize="md" fontWeight="700">
+        Withdraw {displaySymbol}
+      </Text>
+      <Text fontSize="sm" color="gray.400">
+        Withdraw collateral. The max amount you can withdraw is based on your debt and the issuance
+        ratio. To be able to withdraw all collateral you need to repay your debt first
+      </Text>
+      <BorderBox display="flex" py={1} px={2}>
+        <Text display="flex" gap={2} alignItems="center" fontWeight="600" mx="2">
+          <CollateralIcon symbol={symbol} />
+          {displaySymbol}
+        </Text>
+        <Flex flexDirection="column" justifyContent="flex-end" flexGrow={1}>
+          <NumberInput
+            InputProps={{ isRequired: true }}
+            value={collateralChange.abs()}
+            onChange={(val) => setCollateralChange(val.mul(-1))}
+            max={max}
+          />
+          <Flex flexDirection="column" alignItems="flex-end" fontSize="xs" color="whiteAlpha.700">
+            <Flex
+              gap="1"
+              cursor="pointer"
+              onClick={() => {
+                if (!max) {
+                  return;
+                }
+                setCollateralChange(max.mul(-1));
+              }}
+            >
+              <Tooltip
+                label={`Your total collateral balance is: ${currency(
+                  currentCollateral || wei(0)
+                )}. To be able to withdraw all you need to repay all your debt`}
+              >
+                <Text display="flex" alignItems="center" gap={1}>
+                  <InfoOutlineIcon /> Max Withdrawable {displaySymbol}:
+                </Text>
+              </Tooltip>
+
+              <Amount value={max} />
+            </Flex>
+          </Flex>
+        </Flex>
+      </BorderBox>
+      <Button type="submit">Withdraw {displaySymbol}</Button>
+    </Flex>
+  );
+};
+export const Withdraw = () => {
+  const { collateralChange, debtChange, setCollateralChange } = useContext(ManagePositionContext);
+  const params = useParams();
+  const collateralType = useCollateralType(params.collateralType);
+  const { data: liquidityPosition } = useLiquidityPosition({
+    tokenAddress: collateralType?.tokenAddress,
+    accountId: params.accountId,
+    poolId: params.poolId,
+  });
+  if (!collateralType) return null;
+  const { newDebt } = validatePosition({
+    issuanceRatioD18: collateralType.issuanceRatioD18,
+    collateralAmount: liquidityPosition?.collateralAmount,
+    collateralValue: liquidityPosition?.collateralValue,
+    debt: liquidityPosition?.debt,
+    collateralChange: collateralChange,
+    debtChange: debtChange,
+  });
+  // To get the max withdrawable collateral we look at the new debt and the issuance ratio.
+  // This gives us the amount in dollar. We then divide by the collateral price.
+  // To avoid the transaction failing due to small price deviations, we also apply a 2% buffer by multiplying with 0.98
+  const maxCollateral = newDebt
+    .mul(collateralType.issuanceRatioD18)
+    .div(collateralType.price)
+    .mul(0.98);
+
+  return (
+    <WithdrawUi
+      displaySymbol={collateralType.displaySymbol}
+      symbol={collateralType.symbol}
+      setCollateralChange={setCollateralChange}
+      collateralChange={collateralChange}
+      currentCollateral={liquidityPosition?.collateralAmount}
+      max={maxCollateral}
+    />
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7739,6 +7739,7 @@ __metadata:
     "@snx-v3/usePreferredPool": "workspace:*"
     "@snx-v3/useTokenBalance": "workspace:*"
     "@snx-v3/useTransactionState": "workspace:*"
+    "@snx-v3/useUSDProxy": "workspace:*"
     "@snx-v3/useVaultsData": "workspace:*"
     "@snx-v3/validatePosition": "workspace:*"
     "@storybook/addon-essentials": ^6.5.15
@@ -8052,6 +8053,17 @@ __metadata:
     "@tanstack/react-query": ^4.3.4
     react: ^18.2.0
     zod: ^3.20.2
+  languageName: unknown
+  linkType: soft
+
+"@snx-v3/useUSDProxy@workspace:*, @snx-v3/useUSDProxy@workspace:v3/lib/useUSDProxy":
+  version: 0.0.0-use.local
+  resolution: "@snx-v3/useUSDProxy@workspace:v3/lib/useUSDProxy"
+  dependencies:
+    "@ethersproject/contracts": ^5.7.0
+    "@snx-v3/useBlockchain": "workspace:*"
+    "@synthetixio/v3-contracts": "workspace:*"
+    "@tanstack/react-query": ^4.3.4
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7548,6 +7548,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@snx-v3/ManagePositionContext@workspace:*, @snx-v3/ManagePositionContext@workspace:v3/lib/ManagePositionContext":
+  version: 0.0.0-use.local
+  resolution: "@snx-v3/ManagePositionContext@workspace:v3/lib/ManagePositionContext"
+  dependencies:
+    "@synthetixio/wei": "workspace:*"
+    react: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@snx-v3/Multistep@workspace:*, @snx-v3/Multistep@workspace:v3/components/Multistep":
   version: 0.0.0-use.local
   resolution: "@snx-v3/Multistep@workspace:v3/components/Multistep"
@@ -7705,6 +7714,7 @@ __metadata:
     "@snx-v3/BorderBox": "workspace:*"
     "@snx-v3/CollateralTypeSelector": "workspace:*"
     "@snx-v3/Constants": "workspace:*"
+    "@snx-v3/ManagePositionContext": "workspace:*"
     "@snx-v3/Multistep": "workspace:*"
     "@snx-v3/NumberInput": "workspace:*"
     "@snx-v3/PoolBox": "workspace:*"


### PR DESCRIPTION
This adds Borrow action for manage screen, it's fully working.  Deposit, Withdraw and Repay should be easy to add if we're happy with the structure.

I tried to minimize prop drilling, since it would be quite deep. I do this by relying on query hooks like usual but I also opted to create a `ManagePositionContext`. This context hold state for `debtChange` and `collateralChange`. The 
`useManagePosition` hook is called quite high up in the tree, but since it's reads debtChange and collateralChange from context, it should be easy to add the "Additional Action" ui.

This will also make it easy to create the "changes in debt, collateral and c-ratio" boxes. 

```ts
  const { debtChange, collateralChange } = useContext(ManagePositionContext);
  const collateralType = useCollateralType(params.collateralType);
  const { data: liquidityPosition } = useLiquidityPosition({
    tokenAddress: collateralType?.tokenAddress,
    accountId: params.accountId,
    poolId: params.poolId,
  });
  const { newCRatio,newDebt,newCollateralAmount } = validatePosition({
    issuanceRatioD18: collateralType?.issuanceRatioD18,
    collateralAmount: liquidityPosition?.collateralAmount,
    collateralValue: liquidityPosition?.collateralValue,
    debt: liquidityPosition?.debt,
    collateralChange,
    debtChange,
  });
```