### PR TITLE
Cross network burn

### DIFF
--- a/v2/components/BurnStats/BurnStats.tsx
+++ b/v2/components/BurnStats/BurnStats.tsx
@@ -3,7 +3,7 @@ import { Flex } from '@chakra-ui/react';
 import { StatBox } from '@snx-v2/StatBox';
 import { formatNumberToUsd, formatPercent } from '@snx-v2/formatters';
 import { useApr } from '@snx-v2/useApr';
-import { useFeePoolData } from '@snx-v2/useFeePoolData';
+import { useFeesBurnedInPeriod } from '@snx-v2/useFeesBurnedInPeriod';
 
 export const BurnStatsUi: FC<{
   lastEpochBurned: string;
@@ -48,15 +48,15 @@ export const BurnStatsUi: FC<{
 
 export const BurnStats = () => {
   const { data: earning, isLoading: isAprLoading } = useApr();
-  const { data: fees, isLoading: isFeesLoading } = useFeePoolData();
+  const { data: feesBurned, isLoading: isFeesLoading } = useFeesBurnedInPeriod();
 
   const isLoading = isAprLoading || isFeesLoading;
 
   return (
     <BurnStatsUi
       isLoading={isLoading}
-      lifetimeBurned={'coming soon'}
-      lastEpochBurned={formatNumberToUsd(fees?.feesBurned.toNumber() || 0)}
+      lifetimeBurned="coming soon"
+      lastEpochBurned={formatNumberToUsd(feesBurned?.toNumber() || 0)}
       burningAPR={formatPercent(earning?.feesApr?.toNumber() || 0)}
     />
   );

--- a/v2/components/BurnStats/package.json
+++ b/v2/components/BurnStats/package.json
@@ -8,7 +8,7 @@
     "@snx-v2/StatBox": "workspace:*",
     "@snx-v2/formatters": "workspace:*",
     "@snx-v2/useApr": "workspace:*",
-    "@snx-v2/useFeePoolData": "workspace:*",
+    "@snx-v2/useFeesBurnedInPeriod": "workspace:*",
     "react": "^18.2.0"
   }
 }

--- a/v2/components/RewardsItem/Fees.tsx
+++ b/v2/components/RewardsItem/Fees.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from 'react-i18next';
 import { InfoOutline, DollarIcon } from '@snx-v2/icons';
 import { useDebtData } from '@snx-v2/useDebtData';
 import { formatNumber, formatPercent } from '@snx-v2/formatters';
-import { useFeePoolData } from '@snx-v2/useFeePoolData';
 import { useApr } from '@snx-v2/useApr';
 import { TradingFeesModal } from './TradingFeesModal';
 import { RewardsItemUI } from './RewardsItem';
 import { useSynthsBalances } from '@snx-v2/useSynthsBalances';
 import { useExchangeRatesData } from '@snx-v2/useExchangeRatesData';
+import { useFeesBurnedInPeriod } from '@snx-v2/useFeesBurnedInPeriod';
 
 export const Fees = () => {
   const { t } = useTranslation();
@@ -18,16 +18,16 @@ export const Fees = () => {
   const { data: debtData, isLoading: isDebtLoading } = useDebtData();
   const { data: synthsBalances, isLoading: isSynthsLoading } = useSynthsBalances();
   const { data: exchangeRates, isLoading: isExchangeRatesLoading } = useExchangeRatesData();
-  const { data: feePoolData, isLoading: isFeePoolDataLoading } = useFeePoolData();
+  const { data: feesBurned, isLoading: isFeesBurnedLoading } = useFeesBurnedInPeriod();
   const { data: aprData } = useApr();
 
   const isLoading =
-    isDebtLoading || isFeePoolDataLoading || isSynthsLoading || isExchangeRatesLoading;
+    isDebtLoading || isFeesBurnedLoading || isSynthsLoading || isExchangeRatesLoading;
 
   return (
     <>
       <TradingFeesModal
-        feesBurned={feePoolData?.feesBurned.toNumber() || 0}
+        feesBurned={feesBurned?.toNumber() || 0}
         isOpen={isFeesModalOpen}
         onClose={() => setFeesModalOpen(false)}
         sUSDBalance={formatNumber(synthsBalances?.balancesMap['sUSD']?.balance.toNumber() || 0)}
@@ -63,7 +63,7 @@ export const Fees = () => {
               <Flex flexDirection="column">
                 <Text fontFamily="heading" fontSize="sm" color="white" fontWeight="900">
                   {/* Fee amount here */}
-                  {`${formatNumber(feePoolData?.feesBurned.toNumber() || 0)} sUSD`}
+                  {`${formatNumber(feesBurned?.toNumber() || 0)} sUSD`}
                 </Text>
               </Flex>
             );

--- a/v2/components/RewardsItem/package.json
+++ b/v2/components/RewardsItem/package.json
@@ -19,6 +19,7 @@
     "@snx-v2/useDebtData": "workspace:*",
     "@snx-v2/useExchangeRatesData": "workspace:*",
     "@snx-v2/useFeePoolData": "workspace:*",
+    "@snx-v2/useFeesBurnedInPeriod": "workspace:*",
     "@snx-v2/useGetLiquidationRewards": "workspace:*",
     "@snx-v2/useRewardsAvailable": "workspace:*",
     "@snx-v2/useSynthsBalances": "workspace:*",

--- a/v2/lib/useFeePoolData/useFeePoolData.ts
+++ b/v2/lib/useFeePoolData/useFeePoolData.ts
@@ -6,18 +6,17 @@ import add from 'date-fns/add';
 import { wei } from '@synthetixio/wei';
 
 export const useFeePoolData = (period = 0) => {
-  const { walletAddress, networkId } = useContext(ContractContext);
+  const { networkId } = useContext(ContractContext);
   const { data: FeePool } = useFeePool();
 
   return useQuery(
-    ['stakingV2', 'feePool', networkId, period, walletAddress],
+    ['stakingV2', 'feePool', networkId, period],
     async () => {
       if (!FeePool) throw Error('Query should not be enabled if contracts are missing');
 
-      const [feePeriod, feePeriodDurationBn, feesBurned] = await Promise.all([
+      const [feePeriod, feePeriodDurationBn] = await Promise.all([
         FeePool.recentFeePeriods(period),
         FeePool.feePeriodDuration(),
-        walletAddress ? FeePool.feesBurned(walletAddress) : wei(0),
       ]);
 
       const startTime = Number(feePeriod.startTime);
@@ -29,7 +28,6 @@ export const useFeePoolData = (period = 0) => {
         nextFeePeriodStartDate: add(new Date(startTime * 1000), { seconds: feePeriodDuration }),
         feesToDistribute: wei(feePeriod.feesToDistribute),
         rewardsToDistribute: wei(feePeriod.rewardsToDistribute),
-        feesBurned: wei(feesBurned),
       };
     },
     {

--- a/v2/lib/useFeesBurnedInPeriod/index.ts
+++ b/v2/lib/useFeesBurnedInPeriod/index.ts
@@ -1,0 +1,1 @@
+export * from './useFeesBurnedInPeriod';

--- a/v2/lib/useFeesBurnedInPeriod/package.json
+++ b/v2/lib/useFeesBurnedInPeriod/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@snx-v2/useFeesBurnedInPeriod",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.5",
+  "dependencies": {
+    "@snx-v2/ContractContext": "workspace:*",
+    "@snx-v2/useSynthetixContracts": "workspace:*",
+    "@synthetixio/contracts-interface": "workspace:*",
+    "@synthetixio/wei": "workspace:*",
+    "@tanstack/react-query": "^4.3.4",
+    "ethers": "^5.7.2",
+    "react": "^18.2.0"
+  }
+}

--- a/v2/lib/useFeesBurnedInPeriod/useFeesBurnedInPeriod.test.ts
+++ b/v2/lib/useFeesBurnedInPeriod/useFeesBurnedInPeriod.test.ts
@@ -1,0 +1,25 @@
+import { wei } from '@synthetixio/wei';
+import { calculateTotalBurn } from './useFeesBurnedInPeriod';
+describe('calculateTotalBurn', () => {
+  test('handles user not staking', () => {
+    const burnedDebt = calculateTotalBurn({
+      userDebtShareSupplyCurrentNetwork: wei(0),
+      totalDebtShareSupplyMainnet: wei(100),
+      totalDebtShareSupplyOptimism: wei(100),
+      totalBurnMainnet: wei(10),
+      totalBurnOptimism: wei(10),
+    });
+    expect(burnedDebt).toEqual(wei(0));
+  });
+  test('calculates burned debt correctly', () => {
+    const burnedDebt = calculateTotalBurn({
+      userDebtShareSupplyCurrentNetwork: wei(20),
+      totalDebtShareSupplyMainnet: wei(100),
+      totalDebtShareSupplyOptimism: wei(100),
+      totalBurnMainnet: wei(10),
+      totalBurnOptimism: wei(10),
+    });
+
+    expect(burnedDebt).toEqual(wei(2)); // total_burn * user_SDS / total_SDS =  20 * (20 / 200) = 2
+  });
+});

--- a/v2/lib/useFeesBurnedInPeriod/useFeesBurnedInPeriod.ts
+++ b/v2/lib/useFeesBurnedInPeriod/useFeesBurnedInPeriod.ts
@@ -1,0 +1,86 @@
+import { useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { providers } from 'ethers';
+import { ContractContext } from '@snx-v2/ContractContext';
+import Wei, { wei } from '@synthetixio/wei';
+import { useFeePool, useSynthetixDebtShare } from '@snx-v2/useSynthetixContracts/';
+import { NetworkIdByName } from '@synthetixio/contracts-interface';
+
+// exported for tests
+export const calculateTotalBurn = ({
+  userDebtShareSupplyCurrentNetwork,
+  totalDebtShareSupplyOptimism,
+  totalDebtShareSupplyMainnet,
+  totalBurnMainnet,
+  totalBurnOptimism,
+}: {
+  userDebtShareSupplyCurrentNetwork: Wei;
+  totalDebtShareSupplyOptimism: Wei;
+  totalDebtShareSupplyMainnet: Wei;
+  totalBurnMainnet: Wei;
+  totalBurnOptimism: Wei;
+}) => {
+  const totalDebtShareSupply = totalDebtShareSupplyMainnet.add(totalDebtShareSupplyOptimism);
+
+  if (!userDebtShareSupplyCurrentNetwork) return wei(0);
+
+  const totalBurn = totalBurnMainnet.add(totalBurnOptimism);
+  return totalBurn.mul(userDebtShareSupplyCurrentNetwork.div(totalDebtShareSupply));
+};
+
+export const useFeesBurnedInPeriod = (period = 1) => {
+  const { walletAddress, networkId } = useContext(ContractContext);
+  const { data: DebtShare } = useSynthetixDebtShare();
+  const { data: FeePool } = useFeePool();
+
+  return useQuery({
+    queryKey: ['stakingV2', 'useFeesBurnedInPeriod', networkId, walletAddress],
+    queryFn: async () => {
+      if (!DebtShare || !FeePool || !walletAddress) throw Error('Query should not be enabled');
+
+      const optimismProvider = new providers.InfuraProvider(
+        NetworkIdByName['mainnet-ovm'],
+        process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
+      );
+      const mainnetProvider = new providers.InfuraProvider(
+        NetworkIdByName.mainnet,
+        process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
+      );
+
+      const DebtShareOptimism = DebtShare.connect(optimismProvider);
+      const DebtShareMainnet = DebtShare.connect(mainnetProvider);
+      const FeePoolOptimism = FeePool.connect(optimismProvider);
+      const FeePoolMainnet = FeePool.connect(mainnetProvider);
+
+      const [prevFeePeriodOptimism, prevFeePeriodMainnet] = await Promise.all([
+        FeePoolOptimism.recentFeePeriods(period),
+        FeePoolMainnet.recentFeePeriods(period),
+      ]);
+
+      const periodIdForCurrentNetwork =
+        networkId === NetworkIdByName['mainnet-ovm']
+          ? prevFeePeriodOptimism.feePeriodId
+          : prevFeePeriodMainnet.feePeriodId;
+      const [
+        userDebtShareSupplyCurrentNetwork,
+        totalDebtShareSupplyOptimism,
+        totalDebtShareSupplyMainnet,
+      ] = await Promise.all([
+        DebtShare.balanceOfOnPeriod(walletAddress, periodIdForCurrentNetwork),
+        DebtShareOptimism.totalSupplyOnPeriod(prevFeePeriodOptimism.feePeriodId),
+        DebtShareMainnet.totalSupplyOnPeriod(prevFeePeriodMainnet.feePeriodId),
+      ]);
+
+      return calculateTotalBurn({
+        userDebtShareSupplyCurrentNetwork: wei(userDebtShareSupplyCurrentNetwork),
+        totalDebtShareSupplyOptimism: wei(totalDebtShareSupplyOptimism),
+        totalDebtShareSupplyMainnet: wei(totalDebtShareSupplyMainnet),
+        totalBurnOptimism: wei(prevFeePeriodOptimism.feesToDistribute),
+        totalBurnMainnet: wei(prevFeePeriodOptimism.feesToDistribute),
+      });
+    },
+
+    enabled: Boolean(FeePool && walletAddress && DebtShare),
+    staleTime: 1000,
+  });
+};

--- a/v2/lib/useSynthetixContracts/index.ts
+++ b/v2/lib/useSynthetixContracts/index.ts
@@ -7,4 +7,5 @@ export * from './useSynthUtil';
 export * from './useProxyERC20sUSD';
 export * from './useRewardEscrowV2';
 export * from './useLiquidatorRewards';
+export * from './useSynthetixDebtShare';
 export * from './common';

--- a/v2/lib/useSynthetixContracts/useSynthetixDebtShare.ts
+++ b/v2/lib/useSynthetixContracts/useSynthetixDebtShare.ts
@@ -1,0 +1,62 @@
+import { useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ethers, providers } from 'ethers';
+import { isSupportedNetworkId, NetworkNameById } from './common';
+import { ContractContext } from '@snx-v2/ContractContext';
+
+import type { SynthetixDebtShare } from '@synthetixio/contracts/build/mainnet/deployment/SynthetixDebtShare';
+import type { SynthetixDebtShare as SynthetixDebtShareOvm } from '@synthetixio/contracts/build/mainnet-ovm/deployment/SynthetixDebtShare';
+import { SynthetixProvider } from '@synthetixio/providers';
+import { SignerContext } from '@snx-v2/SignerContext';
+
+const contracts = {
+  mainnet: () => import('@synthetixio/contracts/build/mainnet/deployment/SynthetixDebtShare'),
+  'mainnet-ovm': () =>
+    import('@synthetixio/contracts/build/mainnet-ovm/deployment/SynthetixDebtShare'),
+  goerli: () => import('@synthetixio/contracts/build/goerli/deployment/SynthetixDebtShare'),
+  'goerli-ovm': () =>
+    import('@synthetixio/contracts/build/goerli-ovm/deployment/SynthetixDebtShare'),
+};
+
+export const getSynthetixDebtShare = async ({
+  networkId,
+  signer,
+  provider,
+}: {
+  networkId: number;
+  signer: ethers.Signer | null;
+  provider: SynthetixProvider;
+}) => {
+  const signerOrProvider = signer || provider;
+
+  const supportedNetworkId = isSupportedNetworkId(networkId);
+  if (!supportedNetworkId) {
+    throw Error(`${networkId} is not supported`);
+  }
+  const networkName = NetworkNameById[networkId];
+  const { address, abi } = await contracts[networkName]();
+  const contract = new ethers.Contract(address, abi, signerOrProvider) as
+    | SynthetixDebtShare
+    | SynthetixDebtShareOvm;
+  return contract;
+};
+export const useSynthetixDebtShare = () => {
+  const { networkId, walletAddress } = useContext(ContractContext);
+  const signer = useContext(SignerContext);
+
+  return useQuery(
+    // We add walletAddress as a query key to make sure the signer is up to date, we cant use signer directly since it cant be stringified
+    [networkId, 'useSynthetixDebtShare', walletAddress],
+    async () => {
+      if (!networkId) throw Error('Network id required');
+
+      const provider = new providers.InfuraProvider(
+        networkId,
+        process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
+      );
+
+      return getSynthetixDebtShare({ networkId, signer, provider });
+    },
+    { staleTime: Infinity, enabled: Boolean(networkId) }
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7258,6 +7258,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@snx-v2/useFeesBurnedInPeriod@workspace:v2/lib/useFeesBurnedInPeriod":
+  version: 0.0.0-use.local
+  resolution: "@snx-v2/useFeesBurnedInPeriod@workspace:v2/lib/useFeesBurnedInPeriod"
+  dependencies:
+    "@snx-v2/ContractContext": "workspace:*"
+    "@snx-v2/useSynthetixContracts": "workspace:*"
+    "@synthetixio/contracts-interface": "workspace:*"
+    "@synthetixio/wei": "workspace:*"
+    "@tanstack/react-query": ^4.3.4
+    ethers: ^5.7.2
+    react: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@snx-v2/useFeesClaimed@workspace:v2/lib/useFeesClaimed":
   version: 0.0.0-use.local
   resolution: "@snx-v2/useFeesClaimed@workspace:v2/lib/useFeesClaimed"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6509,7 +6509,7 @@ __metadata:
     "@snx-v2/StatBox": "workspace:*"
     "@snx-v2/formatters": "workspace:*"
     "@snx-v2/useApr": "workspace:*"
-    "@snx-v2/useFeePoolData": "workspace:*"
+    "@snx-v2/useFeesBurnedInPeriod": "workspace:*"
     react: ^18.2.0
   languageName: unknown
   linkType: soft
@@ -6797,6 +6797,7 @@ __metadata:
     "@snx-v2/useDebtData": "workspace:*"
     "@snx-v2/useExchangeRatesData": "workspace:*"
     "@snx-v2/useFeePoolData": "workspace:*"
+    "@snx-v2/useFeesBurnedInPeriod": "workspace:*"
     "@snx-v2/useGetLiquidationRewards": "workspace:*"
     "@snx-v2/useRewardsAvailable": "workspace:*"
     "@snx-v2/useSynthsBalances": "workspace:*"
@@ -7258,7 +7259,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v2/useFeesBurnedInPeriod@workspace:v2/lib/useFeesBurnedInPeriod":
+"@snx-v2/useFeesBurnedInPeriod@workspace:*, @snx-v2/useFeesBurnedInPeriod@workspace:v2/lib/useFeesBurnedInPeriod":
   version: 0.0.0-use.local
   resolution: "@snx-v2/useFeesBurnedInPeriod@workspace:v2/lib/useFeesBurnedInPeriod"
   dependencies:


### PR DESCRIPTION
This fixes the burn amount. Still needs another PR for the APR calculation. 

The reason why this is needed is due to the global debt is shared between the networks. 
So we cant just check what was burned on the network you stake on. There's a burn on the other network too and that will affect the global debt.
See convo in staking-team for more context