### PR TITLE
Clean up old pages

### DIFF
--- a/v2/lib/useFeesClaimed/package.json
+++ b/v2/lib/useFeesClaimed/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@snx-v2/Constants": "workspace:*",
     "@snx-v2/ContractContext": "workspace:*",
+    "@synthetixio/wei": "workspace:*",
     "@tanstack/react-query": "^4.24.6",
     "react": "^18.2.0"
   }

--- a/v2/lib/useFeesClaimed/useFeesClaimed.tsx
+++ b/v2/lib/useFeesClaimed/useFeesClaimed.tsx
@@ -2,10 +2,17 @@ import { useContext } from 'react';
 import { ContractContext } from '@snx-v2/ContractContext';
 import { useQuery } from '@tanstack/react-query';
 import { MAINNET_URL, OPTIMISM_URL } from '@snx-v2/Constants';
+import { wei } from '@synthetixio/wei';
 
 type FeesClaimedQueryResult = {
   __typename?: 'Query';
-  feesClaimeds: Array<{ account: string; value: string; rewards?: string; timestamp: string }>;
+  feesClaimeds: Array<{
+    id: string;
+    account: string;
+    value: string;
+    rewards?: string;
+    timestamp: string;
+  }>;
 };
 
 const gql = (data: TemplateStringsArray) => data[0];
@@ -17,6 +24,7 @@ const FeesClaimedDocument = gql`
       orderDirection: desc
       first: 1000
     ) {
+      id
       rewards
       value
       timestamp
@@ -41,12 +49,17 @@ export const useFeesClaimed = () => {
         const { message } = json.errors[0];
         throw new Error(message);
       }
-      return json.data.feesClaimeds.map((x) => ({
-        ...x,
-        value: parseFloat(x.value),
-        rewards: parseFloat(x.rewards || '0'),
-        timestamp: parseFloat(x.timestamp),
-      }));
+      const schedarReleaseDate = Math.floor(new Date('2023-02-15T09:29:25.000Z').getTime() / 1000);
+
+      return json.data.feesClaimeds.map((x) => {
+        const value = parseFloat(x.timestamp) < schedarReleaseDate ? x.value : '0';
+        return {
+          ...x,
+          value: wei(value),
+          rewards: wei(x.rewards || '0'),
+          timestamp: wei(x.timestamp),
+        };
+      });
     },
     { enabled: Boolean(networkId && walletAddress), staleTime: 10000 }
   );

--- a/v2/lib/useGetLifetimeRewards/package.json
+++ b/v2/lib/useGetLifetimeRewards/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@snx-v2/useExchangeRatesData": "workspace:*",
     "@tanstack/react-query": "^4.24.6",
-    "date-fns": "^2.29.3",
     "react": "^18.2.0"
   }
 }

--- a/v2/ui/content/DelegatePage.tsx
+++ b/v2/ui/content/DelegatePage.tsx
@@ -1,69 +1,18 @@
 import { FC } from 'react';
 import Head from 'react-helmet';
-import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
-import Connector from 'containers/Connector';
-
-import StatBox from 'components/StatBox';
-import { LineSpacer } from '@snx-v1/styles';
-import useUserStakingData from 'hooks/useUserStakingData';
 import Main from 'sections/delegate/index';
-import StatsSection from 'components/StatsSection';
-import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
-import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import { formatFiatCurrency, formatPercent } from 'utils/formatters/number';
-import StakedValue from 'sections/shared/modals/StakedValueModal/StakedValueBox';
-import ActiveDebt from 'sections/shared/modals/DebtValueModal/DebtValueBox';
 
 const DelegatePage: FC = () => {
   const { t } = useTranslation();
-
-  const { walletAddress } = Connector.useContainer();
-
-  const { stakedCollateralValue, debtBalance } = useStakingCalculations();
-  const { selectedPriceCurrency, getPriceAtCurrentRate } = useSelectedPriceCurrency();
-  const { stakingAPR } = useUserStakingData(walletAddress);
-
   return (
     <>
       <Head>
         <title>{t('delegate.page-title')}</title>
       </Head>
-      <StatsSection>
-        <StakedValue
-          title={t('common.stat-box.staked-value')}
-          value={formatFiatCurrency(getPriceAtCurrentRate(stakedCollateralValue), {
-            sign: selectedPriceCurrency.sign,
-          })}
-          isGreen
-        />
-        <Earning
-          title={t('common.stat-box.earning')}
-          value={formatPercent(stakingAPR ? stakingAPR : 0)}
-          size="lg"
-        />
-        <ActiveDebt
-          title={t('common.stat-box.active-debt')}
-          value={formatFiatCurrency(getPriceAtCurrentRate(debtBalance), {
-            sign: selectedPriceCurrency.sign,
-          })}
-          isGreen
-        />
-      </StatsSection>
-      <LineSpacer />
       <Main />
     </>
   );
 };
-
-const Earning = styled(StatBox)`
-  .title {
-    color: ${(props) => props.theme.colors.green};
-  }
-  .value {
-    text-shadow: ${(props) => props.theme.colors.greenTextShadow};
-    color: #073124;
-  }
-`;
 
 export default DelegatePage;

--- a/v2/ui/content/HistoryPage.tsx
+++ b/v2/ui/content/HistoryPage.tsx
@@ -13,6 +13,7 @@ import sortBy from 'lodash/sortBy';
 
 import useSynthetixQueries from '@synthetixio/queries';
 import Connector from 'containers/Connector';
+import { useFeesClaimed } from '@snx-v2/useFeesClaimed';
 
 const HistoryPage: FC = () => {
   const { t } = useTranslation();
@@ -38,15 +39,7 @@ const HistoryPage: FC = () => {
     },
     { id: true, timestamp: true, value: true }
   );
-  const feeClaims = subgraph.useGetFeesClaimeds(
-    {
-      first: 1000,
-      orderBy: 'timestamp',
-      orderDirection: 'desc',
-      where: { account: walletAddress?.toLowerCase() },
-    },
-    { id: true, timestamp: true, rewards: true, value: true }
-  );
+  const feeClaims = useFeesClaimed();
 
   const isLoaded = issues.isSuccess && burns.isSuccess && feeClaims.isSuccess;
 

--- a/v2/ui/content/MergeAccountsPage.tsx
+++ b/v2/ui/content/MergeAccountsPage.tsx
@@ -1,69 +1,20 @@
 import { FC } from 'react';
 import Head from 'react-helmet';
-import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
-import Connector from 'containers/Connector';
-
-import StatBox from 'components/StatBox';
-import { LineSpacer } from '@snx-v1/styles';
-import StatsSection from 'components/StatsSection';
-import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
-import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import useUserStakingData from 'hooks/useUserStakingData';
-import { formatFiatCurrency, formatPercent } from 'utils/formatters/number';
-import StakedValue from 'sections/shared/modals/StakedValueModal/StakedValueBox';
-import ActiveDebt from 'sections/shared/modals/DebtValueModal/DebtValueBox';
-
 import Main from 'sections/merge-accounts';
 
 const MergeAccountsPage: FC = () => {
   const { t } = useTranslation();
-  const { walletAddress } = Connector.useContainer();
-
-  const { stakedCollateralValue, debtBalance } = useStakingCalculations();
-  const { selectedPriceCurrency, getPriceAtCurrentRate } = useSelectedPriceCurrency();
-  const { stakingAPR } = useUserStakingData(walletAddress);
 
   return (
     <>
       <Head>
         <title>{t('merge-accounts.page-title')}</title>
       </Head>
-      <StatsSection>
-        <StakedValue
-          title={t('common.stat-box.staked-value')}
-          value={formatFiatCurrency(getPriceAtCurrentRate(stakedCollateralValue), {
-            sign: selectedPriceCurrency.sign,
-          })}
-          isGreen
-        />
-        <Earning
-          title={t('common.stat-box.earning')}
-          value={formatPercent(stakingAPR ? stakingAPR : 0)}
-          size="lg"
-        />
-        <ActiveDebt
-          title={t('common.stat-box.active-debt')}
-          value={formatFiatCurrency(getPriceAtCurrentRate(debtBalance), {
-            sign: selectedPriceCurrency.sign,
-          })}
-          isGreen
-        />
-      </StatsSection>
-      <LineSpacer />
+
       <Main />
     </>
   );
 };
-
-const Earning = styled(StatBox)`
-  .title {
-    color: ${(props) => props.theme.colors.green};
-  }
-  .value {
-    text-shadow: ${(props) => props.theme.colors.greenTextShadow};
-    color: #073124;
-  }
-`;
 
 export default MergeAccountsPage;

--- a/v2/ui/package.json
+++ b/v2/ui/package.json
@@ -61,6 +61,7 @@
     "@snx-v2/Welcome": "workspace:^",
     "@snx-v2/formatters": "workspace:*",
     "@snx-v2/icons": "workspace:*",
+    "@snx-v2/useFeesClaimed": "workspace:*",
     "@snx-v2/useLiquidationData": "workspace:*",
     "@socket.tech/plugin": "^1.0.3",
     "@synthetixio/contracts": "workspace:*",

--- a/v2/ui/sections/delegate/index.tsx
+++ b/v2/ui/sections/delegate/index.tsx
@@ -24,6 +24,7 @@ const Index: FC = () => {
 };
 
 const Container = styled.div`
+  margin-top: 36px;
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-gap: 1rem;

--- a/v2/ui/sections/history/Transactions/Transactions.tsx
+++ b/v2/ui/sections/history/Transactions/Transactions.tsx
@@ -54,22 +54,25 @@ const Transactions: FC<TransactionsProps> = ({ transactions, isLoaded, noResults
         accessor: 'value',
         Cell: (
           cellProps: CellProps<HistoricalStakingTransaction, HistoricalStakingTransaction['value']>
-        ) => (
-          <div>
-            {formatCurrency(Synths.sUSD, cellProps.value, {
-              currencyKey: Synths.sUSD,
-            })}
-            {cellProps.row.original.type === StakingTransactionType.FeesClaimed &&
-              cellProps.row.original.rewards != null && (
+        ) => {
+          const { value, rewards } = cellProps.row.original;
+          const isClaim = cellProps.row.original.type === StakingTransactionType.FeesClaimed;
+          return (
+            <div>
+              {isClaim && value.eq(0)
+                ? null
+                : formatCurrency(Synths.sUSD, cellProps.value, { currencyKey: Synths.sUSD })}
+              {!!rewards && (
                 <>
-                  {' / '}
-                  {formatCurrency(CryptoCurrency.SNX, cellProps.row.original.rewards, {
+                  {isClaim && value.eq(0) ? '' : ' / '}
+                  {formatCurrency(CryptoCurrency.SNX, rewards, {
                     currencyKey: CryptoCurrency.SNX,
                   })}
                 </>
               )}
-          </div>
-        ),
+            </div>
+          );
+        },
         sortable: true,
         width: 200,
       },

--- a/v2/ui/sections/merge-accounts/common.ts
+++ b/v2/ui/sections/merge-accounts/common.ts
@@ -179,6 +179,7 @@ export const TxModalItem = styled.div`
 `;
 
 export const Cols = styled.div`
+  margin-top: 36px;
   ${media.greaterThan('mdUp')`
   display: grid;
   grid-template-columns: 3fr 2fr;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7217,12 +7217,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v2/useFeesClaimed@workspace:v2/lib/useFeesClaimed":
+"@snx-v2/useFeesClaimed@workspace:*, @snx-v2/useFeesClaimed@workspace:v2/lib/useFeesClaimed":
   version: 0.0.0-use.local
   resolution: "@snx-v2/useFeesClaimed@workspace:v2/lib/useFeesClaimed"
   dependencies:
     "@snx-v2/Constants": "workspace:*"
     "@snx-v2/ContractContext": "workspace:*"
+    "@synthetixio/wei": "workspace:*"
     "@tanstack/react-query": ^4.24.6
     react: ^18.2.0
   languageName: unknown
@@ -7267,7 +7268,6 @@ __metadata:
   dependencies:
     "@snx-v2/useExchangeRatesData": "workspace:*"
     "@tanstack/react-query": ^4.24.6
-    date-fns: ^2.29.3
     react: ^18.2.0
   languageName: unknown
   linkType: soft
@@ -10252,6 +10252,7 @@ __metadata:
     "@snx-v2/Welcome": "workspace:^"
     "@snx-v2/formatters": "workspace:*"
     "@snx-v2/icons": "workspace:*"
+    "@snx-v2/useFeesClaimed": "workspace:*"
     "@snx-v2/useLiquidationData": "workspace:*"
     "@socket.tech/plugin": ^1.0.3
     "@storybook/addon-actions": ^6.5.16


### PR DESCRIPTION
- Remove incorrect state from Delegate and Merge Account page
- Move schedar release workaround to useFeesClaimed hook
- Use `useFeesClaimed` on the history page, so that rewards are showing up correctly

### History:
<img width="882" alt="Screenshot 2023-02-20 at 11 38 10 am" src="https://user-images.githubusercontent.com/5688912/220180173-ff88c0ad-2d6d-44d4-a2d5-02f9c515314b.png">

### Stats removed from delegate
<img width="984" alt="Screenshot 2023-02-20 at 11 38 24 am" src="https://user-images.githubusercontent.com/5688912/220180065-37605d7d-a9a5-4558-8cab-e8b4a7578f68.png">
<img width="928" alt="Screenshot 2023-02-20 at 11 38 36 am" src="https://user-images.githubusercontent.com/5688912/220180057-d74ba963-d818-4a0f-abf3-77c39bf00e8e.png">

### Stats removed for Merge account
<img width="946" alt="Screenshot 2023-02-20 at 11 39 08 am" src="https://user-images.githubusercontent.com/5688912/220179907-195a581c-8d56-4e7f-b486-30c83d9c932e.png">
<img width="1001" alt="Screenshot 2023-02-20 at 11 41 54 am" src="https://user-images.githubusercontent.com/5688912/220179905-38ab5157-3ef2-4ada-8a72-96805753bd51.png">

