### PR TITLE
Only include vesting entries with amount bigger than 0

### DIFF
--- a/packages/queries/src/queries/escrow/useEscrowDataQuery.ts
+++ b/packages/queries/src/queries/escrow/useEscrowDataQuery.ts
@@ -77,7 +77,7 @@ const useEscrowDataQuery = (
             quantity,
             date: new Date(Number(endTime) * 1000),
           });
-          if (endTime.gt(0)) {
+          if (endTime.gt(0) && quantity.gt(0)) {
             migratableEntryIds.push(wei(entryID, 0));
           }
         }


### PR DESCRIPTION
If we try to migrate an escrow entry with amount = 0 it will fail on the optimism side