### PR TITLE
Delegate qa

### DIFF
--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -59,7 +59,7 @@ interface BurnProps {
   isAboveTarget?: boolean;
   burnAmountForCalculations: number;
   activePreset: ActivePreset | null;
-  canBurn: boolean;
+  delegatedToBurn: boolean;
 }
 
 const StyledInput: FC<InputProps> = (props) => {
@@ -103,7 +103,7 @@ export const BurnUi = ({
   isAboveTarget,
   burnAmountForCalculations,
   activePreset,
-  canBurn,
+  delegatedToBurn,
 }: BurnProps) => {
   const { t } = useTranslation();
 
@@ -119,7 +119,6 @@ export const BurnUi = ({
     onPresetClick(badgeType);
   };
   const notEnoughBalance = burnAmountForCalculations > susdBalance;
-
   return (
     <>
       <Box bg="navy.900" borderWidth="1px" borderColor="gray.900" borderRadius="base" p={5}>
@@ -392,11 +391,13 @@ export const BurnUi = ({
           </Flex>
         </Box>
         <MintOrBurnChanges debtChange={burnAmountForCalculations} action="burn" />
-        {gasError || notEnoughBalance ? (
-          <Center>
+        {gasError || notEnoughBalance || !delegatedToBurn ? (
+          <Center mt={2}>
             <FailedIcon width="40px" height="40px" />
             <Text>
-              {notEnoughBalance
+              {!delegatedToBurn
+                ? 'You don’t have the authorisation to perform this action'
+                : notEnoughBalance
                 ? t('staking-v2.burn.balance-error')
                 : `${t('staking-v2.mint.gas-estimation-error')}: ${parseTxnError(gasError)}`}
             </Text>
@@ -417,7 +418,7 @@ export const BurnUi = ({
           w="100%"
           onClick={() => onSubmit()}
           isDisabled={
-            !canBurn ||
+            !delegatedToBurn ||
             burnAmountSusd === '' ||
             burnAmountSusd === '0.00' ||
             Boolean(gasError) ||
@@ -614,7 +615,7 @@ export const Burn: FC = () => {
       >
         <Box width={{ base: 'full', md: leftColWidth }}>
           <BurnUi
-            canBurn={delegateWallet ? delegateWallet.canBurn : true}
+            delegatedToBurn={delegateWallet ? delegateWallet.canBurn : true}
             stakedSnx={stakedSnx.toNumber()}
             debtBalance={debtData?.debtBalance.toNumber()}
             isLoading={isLoading}

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -396,7 +396,7 @@ export const BurnUi = ({
             <FailedIcon width="40px" height="40px" />
             <Text>
               {!delegatedToBurn
-                ? 'You don’t have the authorisation to perform this action'
+                ? t('staking-v2.delegate.missing-permission')
                 : notEnoughBalance
                 ? t('staking-v2.burn.balance-error')
                 : `${t('staking-v2.mint.gas-estimation-error')}: ${parseTxnError(gasError)}`}

--- a/v2/components/Mint/Mint.tsx
+++ b/v2/components/Mint/Mint.tsx
@@ -208,7 +208,7 @@ export const MintUi = ({
             <FailedIcon width="40px" height="40px" />
             <Text>
               {!delegatedToMint
-                ? 'You don’t have the authorisation to perform this action'
+                ? t('staking-v2.delegate.missing-permission')
                 : belowTargetError
                 ? t('staking-v2.mint.below-target-error')
                 : `${t('staking-v2.mint.gas-estimation-error')}: ${parseTxnError(gasError)}`}

--- a/v2/components/Mint/Mint.tsx
+++ b/v2/components/Mint/Mint.tsx
@@ -47,7 +47,7 @@ interface MintProps {
   gasError: Error | null;
   belowTargetError: boolean;
   isGasEnabledAndNotFetched: boolean;
-  canMint: boolean;
+  delegatedToMint: boolean;
 }
 const StyledInput: FC<InputProps> = (props) => {
   return (
@@ -85,7 +85,7 @@ export const MintUi = ({
   gasError,
   belowTargetError,
   isGasEnabledAndNotFetched,
-  canMint,
+  delegatedToMint,
 }: MintProps) => {
   const { t } = useTranslation();
   const [activeBadge, setActiveBadge] = useState(0);
@@ -203,11 +203,13 @@ export const MintUi = ({
           </Flex>
         </Box>
         <MintOrBurnChanges debtChange={parseFloatWithCommas(mintAmountsUSD)} action="mint" />
-        {gasError || belowTargetError ? (
-          <Center>
+        {gasError || belowTargetError || !delegatedToMint ? (
+          <Center mt={2}>
             <FailedIcon width="40px" height="40px" />
             <Text>
-              {belowTargetError
+              {!delegatedToMint
+                ? 'You don’t have the authorisation to perform this action'
+                : belowTargetError
                 ? t('staking-v2.mint.below-target-error')
                 : `${t('staking-v2.mint.gas-estimation-error')}: ${parseTxnError(gasError)}`}
             </Text>
@@ -231,7 +233,7 @@ export const MintUi = ({
             onSubmit();
           }}
           isDisabled={
-            !canMint ||
+            !delegatedToMint ||
             stakeAmountSNX === '' ||
             Boolean(gasError) ||
             isGasEnabledAndNotFetched ||
@@ -298,7 +300,7 @@ export const Mint: FC = () => {
       >
         <Box width={{ base: 'full', md: leftColWidth }}>
           <MintUi
-            canMint={delegateWallet ? delegateWallet.canMint : true}
+            delegatedToMint={delegateWallet ? delegateWallet.canMint : true}
             isLoading={isLoading}
             stakeAmountSNX={stakeAmountSNX}
             mintAmountsUSD={mintAmountSUSD}

--- a/v2/components/Navigation/Navigation.tsx
+++ b/v2/components/Navigation/Navigation.tsx
@@ -130,6 +130,7 @@ export const NavigationUI = ({
               <>
                 <MenuButton
                   as={Button}
+                  ml={2}
                   variant="outline"
                   colorScheme="gray"
                   sx={{ '> span': { display: 'flex', alignItems: 'center' } }}

--- a/v2/components/RewardsItem/ClaimRewardsBtn.tsx
+++ b/v2/components/RewardsItem/ClaimRewardsBtn.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@chakra-ui/react';
+import { Button, ButtonProps } from '@chakra-ui/react';
 import { formatNumber } from '@snx-v2/formatters';
 import { FC } from 'react';
 import { RewardsTransactionModal } from './RewardsTransactionModal';
@@ -7,6 +7,21 @@ import { useClaimRewardsMutation } from '@snx-v2/useClaimRewardsMutation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDelegateWallet } from '@snx-v2/useDelegateWallet';
 
+const StyledButton = (props: ButtonProps) => (
+  <Button
+    data-testid="claim rewards button"
+    w={['100%', '100%', '100%', '80px']}
+    ml={[6, 6, 6, 4]}
+    {...props}
+  />
+);
+
+const ManageButtonUi = (props: ButtonProps) => <StyledButton {...props}>Maintain</StyledButton>;
+const ClaimButtonUi = (props: ButtonProps) => (
+  <StyledButton variant="solid" {...props}>
+    Maintain
+  </StyledButton>
+);
 export const ClaimRewardsBtn: FC<{
   amountSNX?: number;
   variant: string;
@@ -36,27 +51,25 @@ export const ClaimRewardsBtn: FC<{
       },
     });
   };
-
+  const displayClaimButton = variant === 'success';
   return (
     <>
-      <Button
-        data-testid="claim rewards button"
-        variant={variant !== 'success' ? variant : 'solid'}
-        isDisabled={
-          variant !== 'success' ? false : Boolean(!canClaim || isGasEnabledAndNotFetched || error)
-        }
-        w={['100%', '100%', '100%', '80px']}
-        fontFamily="heading"
-        fontSize="14px"
-        fontWeight="700"
-        ml={[6, 6, 6, 4]}
-        onClick={() => {
-          variant === 'success' ? handleSubmit() : navigate('/staking/burn');
-        }}
-        color="black"
-      >
-        {variant === 'success' ? 'Claim' : 'Maintain'}
-      </Button>
+      {displayClaimButton ? (
+        <ClaimButtonUi
+          isDisabled={Boolean(!canClaim || isGasEnabledAndNotFetched || error)}
+          onClick={() => {
+            handleSubmit();
+          }}
+        />
+      ) : (
+        <ManageButtonUi
+          variant={variant}
+          onClick={() => {
+            navigate('/staking/burn');
+          }}
+        />
+      )}
+
       <RewardsTransactionModal
         txnHash={txnHash}
         settle={settle}

--- a/v2/components/RewardsItem/ClaimRewardsBtn.tsx
+++ b/v2/components/RewardsItem/ClaimRewardsBtn.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useClaimRewardsMutation } from '@snx-v2/useClaimRewardsMutation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDelegateWallet } from '@snx-v2/useDelegateWallet';
+import { useTranslation } from 'react-i18next';
 
 const StyledButton = (props: ButtonProps) => (
   <Button
@@ -16,21 +17,27 @@ const StyledButton = (props: ButtonProps) => (
   />
 );
 
-const ManageButtonUi = (props: ButtonProps) => <StyledButton {...props}>Maintain</StyledButton>;
+const ManageButtonUi = (props: ButtonProps) => {
+  const { t } = useTranslation();
+  return <StyledButton {...props}>{t('staking-v2.earn.maintain')}</StyledButton>;
+};
 
 interface ClaimBtnProps extends ButtonProps {
   delegatedToMint: boolean;
 }
-const ClaimButtonUi = ({ delegatedToMint, ...props }: ClaimBtnProps) => (
-  <Tooltip
-    label={delegatedToMint ? '' : 'You don’t have the authorisation to perform this action'}
-    shouldWrapChildren
-  >
-    <StyledButton variant="solid" {...props}>
-      Claim
-    </StyledButton>
-  </Tooltip>
-);
+const ClaimButtonUi = ({ delegatedToMint, ...props }: ClaimBtnProps) => {
+  const { t } = useTranslation();
+  return (
+    <Tooltip
+      label={delegatedToMint ? '' : t('staking-v2.delegate.missing-permission')}
+      shouldWrapChildren
+    >
+      <StyledButton variant="solid" {...props}>
+        {t('staking-v2.earn.claim')}
+      </StyledButton>
+    </Tooltip>
+  );
+};
 export const ClaimRewardsBtn: FC<{
   amountSNX?: number;
   variant: string;

--- a/v2/components/RewardsItem/ClaimRewardsBtn.tsx
+++ b/v2/components/RewardsItem/ClaimRewardsBtn.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps } from '@chakra-ui/react';
+import { Button, ButtonProps, Tooltip } from '@chakra-ui/react';
 import { formatNumber } from '@snx-v2/formatters';
 import { FC } from 'react';
 import { RewardsTransactionModal } from './RewardsTransactionModal';
@@ -17,10 +17,19 @@ const StyledButton = (props: ButtonProps) => (
 );
 
 const ManageButtonUi = (props: ButtonProps) => <StyledButton {...props}>Maintain</StyledButton>;
-const ClaimButtonUi = (props: ButtonProps) => (
-  <StyledButton variant="solid" {...props}>
-    Maintain
-  </StyledButton>
+
+interface ClaimBtnProps extends ButtonProps {
+  delegatedToMint: boolean;
+}
+const ClaimButtonUi = ({ delegatedToMint, ...props }: ClaimBtnProps) => (
+  <Tooltip
+    label={delegatedToMint ? '' : 'You don’t have the authorisation to perform this action'}
+    shouldWrapChildren
+  >
+    <StyledButton variant="solid" {...props}>
+      Claim
+    </StyledButton>
+  </Tooltip>
 );
 export const ClaimRewardsBtn: FC<{
   amountSNX?: number;
@@ -31,8 +40,8 @@ export const ClaimRewardsBtn: FC<{
 
   const navigate = useNavigate();
   const haveSomethingToClaim = Boolean(amountSNX);
-  const delegatePermission = delegateWallet ? delegateWallet.canClaim : true;
-  const canClaim = haveSomethingToClaim && delegatePermission && variant === 'success';
+  const delegatedToMint = delegateWallet ? delegateWallet.canClaim : true;
+  const canClaim = haveSomethingToClaim && delegatedToMint && variant === 'success';
   const {
     mutate,
     modalOpen,
@@ -56,6 +65,7 @@ export const ClaimRewardsBtn: FC<{
     <>
       {displayClaimButton ? (
         <ClaimButtonUi
+          delegatedToMint={delegatedToMint}
           isDisabled={Boolean(!canClaim || isGasEnabledAndNotFetched || error)}
           onClick={() => {
             handleSubmit();

--- a/v2/components/WalletModal/AuthorisedWallets.tsx
+++ b/v2/components/WalletModal/AuthorisedWallets.tsx
@@ -14,7 +14,7 @@ const StyledBox: FC<PropsWithChildren> = ({ children }) => (
 const AuthorisedWalletsUi: FC<{
   authorisedWallets?: DelegateWallet[];
   isLoading: boolean;
-  onWalletSelected: (wallet: DelegateWallet) => void;
+  onWalletSelected: (wallet: DelegateWallet | null) => void;
 }> = ({ onWalletSelected, authorisedWallets, isLoading }) => {
   if (isLoading) {
     return (
@@ -26,10 +26,15 @@ const AuthorisedWalletsUi: FC<{
   if (!authorisedWallets?.length) {
     return (
       <StyledBox>
-        <Text>This wallet have not been authorized to perform action on any other wallet.</Text>
+        <Text>This wallet has not been authorized to perform action on any other wallet.</Text>
         <Text>
-          Connect the wallet you want to perform actions on and Go to{' '}
-          <Link color="cyan" as={ReactRouterLink} to="/delegate">
+          Connect the wallet you want to perform actions on and go to{' '}
+          <Link
+            onClick={() => onWalletSelected(null)}
+            color="cyan"
+            as={ReactRouterLink}
+            to="/delegate"
+          >
             Delegate
           </Link>{' '}
           to set it up
@@ -67,7 +72,7 @@ const AuthorisedWalletsUi: FC<{
 };
 
 export type AuthorisedWalletsProps = {
-  onWalletSelected: (wallet: DelegateWallet) => void;
+  onWalletSelected: (wallet: DelegateWallet | null) => void;
 };
 export const AuthorisedWallets: FC<AuthorisedWalletsProps> = ({ onWalletSelected }) => {
   const { data, isLoading } = useAuthorisedWallets();

--- a/v2/ui/translations/en.json
+++ b/v2/ui/translations/en.json
@@ -157,6 +157,8 @@
       "staked": "Staked Balance",
       "remaining": "Time Remaining",
       "does-not-expire": "Does not expire",
+      "claim": "Claim",
+      "maintain": "Maintain",
       "badges": {
         "claimable": "CLAIMABLE",
         "claimed": "CLAIMED",
@@ -306,6 +308,9 @@
         "price": "Price",
         "holdings": "Holdings"
       }
+    },
+    "delegate": {
+      "missing-permission": "You don't have the authorisation to perform this action"
     }
   },
   "meta": {


### PR DESCRIPTION
- Add back some missing margin in header that was accidentally removed
- Ensure delegation popup closes when users click on setup Delegate link
- Mint and burn shows custom delegation missing message, like we do for some other cases when button is disabled.
- Claim show the delegation missing message in a tooltip, since we currently not displaying errors for claiming

<img width="1007" alt="Screenshot 2023-02-23 at 11 29 40 am" src="https://user-images.githubusercontent.com/5688912/220998300-0de461e1-661f-4c23-b9cd-165891689f3c.png">
<img width="567" alt="Screenshot 2023-02-23 at 11 28 46 am" src="https://user-images.githubusercontent.com/5688912/220998306-a857c3fc-d88f-471d-a265-705fe1a0217a.png">
<img width="616" alt="Screenshot 2023-02-23 at 11 27 49 am" src="https://user-images.githubusercontent.com/5688912/220998307-0ea08f2a-15c0-46dd-ae01-b6b2c02eb0e2.png">
