### PR TITLE
Remove incorrect escrowed SNX. Just grab it from hook/contract

### DIFF
--- a/v2/components/MintOrBurnChanges/package.json
+++ b/v2/components/MintOrBurnChanges/package.json
@@ -9,6 +9,7 @@
     "@snx-v2/icons": "workspace:*",
     "@snx-v2/stakingCalculations": "workspace:*",
     "@snx-v2/useDebtData": "workspace:*",
+    "@snx-v2/useEscrowBalance": "workspace:*",
     "@snx-v2/useExchangeRatesData": "workspace:*",
     "@snx-v2/useSynthsBalances": "workspace:*",
     "react": "^18.2.0",

--- a/v2/lib/stakingCalculations/stakingCalculations.test.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.test.ts
@@ -210,20 +210,17 @@ describe('stakingCalculation', () => {
   describe('calculateChangesFromBurn', () => {
     test('burning 10SNX', () => {
       const burnAmountSusd = 5;
-      const stakedSnx = 20;
       const debtBalance = 10;
-      const transferable = 50;
       const sUSDBalance = 10;
       const collateral = 50;
       const collateralUsdValue = 100;
       const targetCRatio = 0.25;
-
+      const escrowedSnx = 10;
       expect(
         calculateChangesFromBurn({
           burnAmountSusd,
-          stakedSnx,
+          escrowedSnx,
           debtBalance,
-          transferable,
           sUSDBalance,
           collateralUsdValue,
           collateral,
@@ -233,26 +230,24 @@ describe('stakingCalculation', () => {
         newCratio: 0.05,
         newDebtBalance: 5,
         newStakedAmountSnx: 10,
-        newTransferable: 60,
+        newTransferable: 30, // collateral - escrowedSnx - newStakedAmountSnx = 50 - 10 - 10 = 30
         newSUSDBalance: 5,
       });
     });
     test('burning more than debt balance', () => {
       const burnAmountSusd = 500;
-      const stakedSnx = 10;
       const debtBalance = 10;
-      const transferable = 20;
       const sUSDBalance = 10;
       const collateralUsdValue = 100;
       const collateral = 50;
       const targetCRatio = 0.25;
+      const escrowedSnx = 10;
 
       expect(
         calculateChangesFromBurn({
           burnAmountSusd,
-          stakedSnx,
+          escrowedSnx,
           debtBalance,
-          transferable,
           sUSDBalance,
           collateralUsdValue,
           collateral,
@@ -262,7 +257,7 @@ describe('stakingCalculation', () => {
         newCratio: 0,
         newDebtBalance: 0,
         newStakedAmountSnx: 0,
-        newTransferable: 30, // collateral - (collateral - staked - transferable)
+        newTransferable: 40, // collateral - escrowedSnx - newStakedAmountSnx = 50 - 10 - 0 = 40
         newSUSDBalance: 0,
       });
     });

--- a/v2/lib/stakingCalculations/stakingCalculations.ts
+++ b/v2/lib/stakingCalculations/stakingCalculations.ts
@@ -125,21 +125,19 @@ export const calculateChangesFromMint = ({
 export const calculateChangesFromBurn = ({
   burnAmountSusd,
   debtBalance,
-  stakedSnx,
-  transferable,
   sUSDBalance,
   collateralUsdValue,
   collateral,
   targetCRatio,
+  escrowedSnx,
 }: {
   burnAmountSusd: number;
   debtBalance: number;
-  stakedSnx: number;
-  transferable: number;
   sUSDBalance: number;
   collateralUsdValue: number;
   collateral: number;
   targetCRatio: number;
+  escrowedSnx: number;
 }) => {
   const newDebtBalance = Math.max(debtBalance - burnAmountSusd, 0);
   const newCratio = newDebtBalance / collateralUsdValue || 0;
@@ -149,8 +147,7 @@ export const calculateChangesFromBurn = ({
     collateral: wei(collateral),
   }).toNumber();
 
-  const escrowedSnx = collateral - stakedSnx - transferable;
-  const newTransferable = collateral - escrowedSnx - newStakedAmountSnx;
+  const newTransferable = Math.max(collateral - escrowedSnx - newStakedAmountSnx, 0);
 
   const newSUSDBalance = Math.max(sUSDBalance - burnAmountSusd, 0);
   return { newDebtBalance, newStakedAmountSnx, newCratio, newTransferable, newSUSDBalance };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6598,6 +6598,7 @@ __metadata:
     "@snx-v2/icons": "workspace:*"
     "@snx-v2/stakingCalculations": "workspace:*"
     "@snx-v2/useDebtData": "workspace:*"
+    "@snx-v2/useEscrowBalance": "workspace:*"
     "@snx-v2/useExchangeRatesData": "workspace:*"
     "@snx-v2/useSynthsBalances": "workspace:*"
     react: ^18.2.0


### PR DESCRIPTION
Fix calculation for changes from burn. Previously we tried to calculate escrowed snx, the calculation used was wrong. Now we instead fetch escrowedSnx.
So:
`const newTransferable = Math.max(collateral - escrowedSnx - newStakedAmountSnx, 0);`