### PR TITLE
Fix estimated amount and remove out of date tooltip

### DIFF
--- a/v2/ui/sections/debt/components/ManageTab/BuyHedgeTabOptimism.tsx
+++ b/v2/ui/sections/debt/components/ManageTab/BuyHedgeTabOptimism.tsx
@@ -33,7 +33,6 @@ import {
   ModalItem,
   ModalItemText,
   ModalItemTitle,
-  Tooltip,
 } from '@snx-v1/styles';
 import { EXTERNAL_LINKS } from 'constants/links';
 import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
@@ -96,7 +95,7 @@ const BuyHedgeTabOptimism = () => {
   );
   const dSnxAmount =
     actualAmountToSendBn.gt(0) && dSNXPrice
-      ? formatCryptoCurrency(wei(actualAmountToSendBn).sub(actualAmountToSendBn).div(dSNXPrice), {
+      ? formatCryptoCurrency(wei(actualAmountToSendBn).div(dSNXPrice), {
           minDecimals: 3,
         })
       : '';
@@ -163,16 +162,14 @@ const BuyHedgeTabOptimism = () => {
             dSNX
           </StyledCryptoCurrencyBox>
         </StyledInputLabel>
-        <Tooltip content={"This assumes a slippage of 1%, usually it's less than that"}>
-          <InputWrapper>
-            <StyledHedgeInput
-              type="text"
-              onChange={() => {}}
-              disabled
-              value={dSnxAmount ? `~${dSnxAmount}` : '~0'}
-            />
-          </InputWrapper>
-        </Tooltip>
+        <InputWrapper>
+          <StyledHedgeInput
+            type="text"
+            onChange={() => {}}
+            disabled
+            value={dSnxAmount ? `~${dSnxAmount}` : '~0'}
+          />
+        </InputWrapper>
         <StyledBalance>
           {t('debt.actions.manage.balance')}
           {formatCryptoCurrency(dSNXBalance || wei(0), {

--- a/v2/ui/sections/debt/components/ManageTab/SellHedgeTabOptimism.tsx
+++ b/v2/ui/sections/debt/components/ManageTab/SellHedgeTabOptimism.tsx
@@ -13,7 +13,6 @@ import {
   ModalItem,
   ModalItemText,
   ModalItemTitle,
-  Tooltip,
 } from '@snx-v1/styles';
 import { formatCryptoCurrency } from 'utils/formatters/number';
 import Dhedge from 'assets/svg/app/dhedge.svg';
@@ -72,7 +71,7 @@ export default function SellHedgeTabOptimism() {
 
   const dollarAmountToReceive =
     actualAmountToSendBn.gt(0) && dSNXPrice ? wei(actualAmountToSendBn).mul(dSNXPrice) : wei(0);
-  const sUSDToReceiveWei = dollarAmountToReceive.sub(dollarAmountToReceive);
+  const sUSDToReceiveWei = dollarAmountToReceive;
   const sUSDAmountToReceive = sUSDToReceiveWei.gt(0)
     ? formatCryptoCurrency(sUSDToReceiveWei, {
         minDecimals: 3,
@@ -175,17 +174,15 @@ export default function SellHedgeTabOptimism() {
             sUSD
           </StyledCryptoCurrencyBox>
         </StyledInputLabel>
-        <Tooltip content={"This assumes a slippage of 1%, usually it's less than that"}>
-          <InputWrapper>
-            <StyledHedgeInput
-              style={{ margin: 0 }}
-              type="text"
-              onChange={() => {}}
-              disabled
-              value={sUSDAmountToReceive ? `~${sUSDAmountToReceive}` : '0'}
-            />
-          </InputWrapper>
-        </Tooltip>
+        <InputWrapper>
+          <StyledHedgeInput
+            style={{ margin: 0 }}
+            type="text"
+            onChange={() => {}}
+            disabled
+            value={sUSDAmountToReceive ? `~${sUSDAmountToReceive}` : '0'}
+          />
+        </InputWrapper>
         <StyledBalance>
           {t('debt.actions.manage.balance')}
           {formatCryptoCurrency(sUSDBalance, {


### PR DESCRIPTION
I think I made a mistake when I removed slippage.. Prod shows 0 estimation.. this fixes that
<img width="369" alt="Screenshot 2023-03-14 at 6 29 40 pm" src="https://user-images.githubusercontent.com/5688912/224926941-e5c83ea7-0ac8-42ae-9998-b08062d6bb6b.png">
<img width="410" alt="Screenshot 2023-03-14 at 6 29 33 pm" src="https://user-images.githubusercontent.com/5688912/224926946-59dacdb3-54e4-4ab2-a639-19f3a4f8d0a1.png">
