### PR TITLE
Subgraph pnl

### DIFF
--- a/v2/perps-v2/perps-subgraph/generated/schema.ts
+++ b/v2/perps-v2/perps-subgraph/generated/schema.ts
@@ -268,13 +268,13 @@ export class Trader extends Entity {
     this.set('totalVolume', Value.fromBigDecimal(value));
   }
 
-  get pnl(): BigInt {
-    let value = this.get('pnl');
+  get realizedPnl(): BigInt {
+    let value = this.get('realizedPnl');
     return value!.toBigInt();
   }
 
-  set pnl(value: BigInt) {
-    this.set('pnl', Value.fromBigInt(value));
+  set realizedPnl(value: BigInt) {
+    this.set('realizedPnl', Value.fromBigInt(value));
   }
 
   get trades(): Array<string> {
@@ -416,13 +416,22 @@ export class FuturesTrade extends Entity {
     this.set('positionClosed', Value.fromBoolean(value));
   }
 
-  get pnl(): BigInt {
-    let value = this.get('pnl');
+  get realizedPnl(): BigInt {
+    let value = this.get('realizedPnl');
     return value!.toBigInt();
   }
 
-  set pnl(value: BigInt) {
-    this.set('pnl', Value.fromBigInt(value));
+  set realizedPnl(value: BigInt) {
+    this.set('realizedPnl', Value.fromBigInt(value));
+  }
+
+  get netFunding(): BigInt {
+    let value = this.get('netFunding');
+    return value!.toBigInt();
+  }
+
+  set netFunding(value: BigInt) {
+    this.set('netFunding', Value.fromBigInt(value));
   }
 
   get feesPaidToSynthetix(): BigDecimal {
@@ -695,13 +704,22 @@ export class FuturesPosition extends Entity {
     this.set('margin', Value.fromBigInt(value));
   }
 
-  get pnl(): BigInt {
-    let value = this.get('pnl');
+  get realizedPnl(): BigInt {
+    let value = this.get('realizedPnl');
     return value!.toBigInt();
   }
 
-  set pnl(value: BigInt) {
-    this.set('pnl', Value.fromBigInt(value));
+  set realizedPnl(value: BigInt) {
+    this.set('realizedPnl', Value.fromBigInt(value));
+  }
+
+  get unrealizedPnl(): BigInt {
+    let value = this.get('unrealizedPnl');
+    return value!.toBigInt();
+  }
+
+  set unrealizedPnl(value: BigInt) {
+    this.set('unrealizedPnl', Value.fromBigInt(value));
   }
 
   get fundingIndex(): BigInt {

--- a/v2/perps-v2/perps-subgraph/generated/schema.ts
+++ b/v2/perps-v2/perps-subgraph/generated/schema.ts
@@ -69,31 +69,31 @@ export class PositionLiquidated extends Entity {
     this.set('liquidator', Value.fromBytes(value));
   }
 
-  get size(): BigDecimal {
+  get size(): BigInt {
     let value = this.get('size');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set size(value: BigDecimal) {
-    this.set('size', Value.fromBigDecimal(value));
+  set size(value: BigInt) {
+    this.set('size', Value.fromBigInt(value));
   }
 
-  get price(): BigDecimal {
+  get price(): BigInt {
     let value = this.get('price');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set price(value: BigDecimal) {
-    this.set('price', Value.fromBigDecimal(value));
+  set price(value: BigInt) {
+    this.set('price', Value.fromBigInt(value));
   }
 
-  get fee(): BigDecimal {
+  get fee(): BigInt {
     let value = this.get('fee');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set fee(value: BigDecimal) {
-    this.set('fee', Value.fromBigDecimal(value));
+  set fee(value: BigInt) {
+    this.set('fee', Value.fromBigInt(value));
   }
 
   get futuresPosition(): string {
@@ -223,13 +223,13 @@ export class Trader extends Entity {
     this.set('timestamp', Value.fromBigInt(value));
   }
 
-  get margin(): BigDecimal {
+  get margin(): BigInt {
     let value = this.get('margin');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set margin(value: BigDecimal) {
-    this.set('margin', Value.fromBigDecimal(value));
+  set margin(value: BigInt) {
+    this.set('margin', Value.fromBigInt(value));
   }
 
   get totalLiquidations(): BigInt {
@@ -241,31 +241,31 @@ export class Trader extends Entity {
     this.set('totalLiquidations', Value.fromBigInt(value));
   }
 
-  get totalMarginLiquidated(): BigDecimal {
+  get totalMarginLiquidated(): BigInt {
     let value = this.get('totalMarginLiquidated');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set totalMarginLiquidated(value: BigDecimal) {
-    this.set('totalMarginLiquidated', Value.fromBigDecimal(value));
+  set totalMarginLiquidated(value: BigInt) {
+    this.set('totalMarginLiquidated', Value.fromBigInt(value));
   }
 
-  get feesPaidToSynthetix(): BigDecimal {
+  get feesPaidToSynthetix(): BigInt {
     let value = this.get('feesPaidToSynthetix');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set feesPaidToSynthetix(value: BigDecimal) {
-    this.set('feesPaidToSynthetix', Value.fromBigDecimal(value));
+  set feesPaidToSynthetix(value: BigInt) {
+    this.set('feesPaidToSynthetix', Value.fromBigInt(value));
   }
 
-  get totalVolume(): BigDecimal {
+  get totalVolume(): BigInt {
     let value = this.get('totalVolume');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set totalVolume(value: BigDecimal) {
-    this.set('totalVolume', Value.fromBigDecimal(value));
+  set totalVolume(value: BigInt) {
+    this.set('totalVolume', Value.fromBigInt(value));
   }
 
   get realizedPnl(): BigInt {
@@ -371,13 +371,13 @@ export class FuturesTrade extends Entity {
     }
   }
 
-  get size(): BigDecimal {
+  get size(): BigInt {
     let value = this.get('size');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set size(value: BigDecimal) {
-    this.set('size', Value.fromBigDecimal(value));
+  set size(value: BigInt) {
+    this.set('size', Value.fromBigInt(value));
   }
 
   get market(): string {
@@ -389,22 +389,22 @@ export class FuturesTrade extends Entity {
     this.set('market', Value.fromString(value));
   }
 
-  get price(): BigDecimal {
+  get price(): BigInt {
     let value = this.get('price');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set price(value: BigDecimal) {
-    this.set('price', Value.fromBigDecimal(value));
+  set price(value: BigInt) {
+    this.set('price', Value.fromBigInt(value));
   }
 
-  get positionSize(): BigDecimal {
+  get positionSize(): BigInt {
     let value = this.get('positionSize');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set positionSize(value: BigDecimal) {
-    this.set('positionSize', Value.fromBigDecimal(value));
+  set positionSize(value: BigInt) {
+    this.set('positionSize', Value.fromBigInt(value));
   }
 
   get positionClosed(): boolean {
@@ -434,13 +434,13 @@ export class FuturesTrade extends Entity {
     this.set('netFunding', Value.fromBigInt(value));
   }
 
-  get feesPaidToSynthetix(): BigDecimal {
+  get feesPaidToSynthetix(): BigInt {
     let value = this.get('feesPaidToSynthetix');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set feesPaidToSynthetix(value: BigDecimal) {
-    this.set('feesPaidToSynthetix', Value.fromBigDecimal(value));
+  set feesPaidToSynthetix(value: BigInt) {
+    this.set('feesPaidToSynthetix', Value.fromBigInt(value));
   }
 
   get type(): string {
@@ -493,22 +493,22 @@ export class Synthetix extends Entity {
     this.set('id', Value.fromString(value));
   }
 
-  get feesByLiquidations(): BigDecimal {
+  get feesByLiquidations(): BigInt {
     let value = this.get('feesByLiquidations');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set feesByLiquidations(value: BigDecimal) {
-    this.set('feesByLiquidations', Value.fromBigDecimal(value));
+  set feesByLiquidations(value: BigInt) {
+    this.set('feesByLiquidations', Value.fromBigInt(value));
   }
 
-  get feesByPositionModifications(): BigDecimal {
+  get feesByPositionModifications(): BigInt {
     let value = this.get('feesByPositionModifications');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set feesByPositionModifications(value: BigDecimal) {
-    this.set('feesByPositionModifications', Value.fromBigDecimal(value));
+  set feesByPositionModifications(value: BigInt) {
+    this.set('feesByPositionModifications', Value.fromBigInt(value));
   }
 
   get totalLiquidations(): BigInt {
@@ -520,13 +520,13 @@ export class Synthetix extends Entity {
     this.set('totalLiquidations', Value.fromBigInt(value));
   }
 
-  get totalVolume(): BigDecimal {
+  get totalVolume(): BigInt {
     let value = this.get('totalVolume');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set totalVolume(value: BigDecimal) {
-    this.set('totalVolume', Value.fromBigDecimal(value));
+  set totalVolume(value: BigInt) {
+    this.set('totalVolume', Value.fromBigInt(value));
   }
 
   get totalTraders(): BigInt {
@@ -731,13 +731,13 @@ export class FuturesPosition extends Entity {
     this.set('fundingIndex', Value.fromBigInt(value));
   }
 
-  get totalVolume(): BigDecimal {
+  get totalVolume(): BigInt {
     let value = this.get('totalVolume');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set totalVolume(value: BigDecimal) {
-    this.set('totalVolume', Value.fromBigDecimal(value));
+  set totalVolume(value: BigInt) {
+    this.set('totalVolume', Value.fromBigInt(value));
   }
 
   get entryPrice(): BigInt {
@@ -758,13 +758,13 @@ export class FuturesPosition extends Entity {
     this.set('netTransfers', Value.fromBigInt(value));
   }
 
-  get lastPrice(): BigDecimal {
+  get lastPrice(): BigInt {
     let value = this.get('lastPrice');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set lastPrice(value: BigDecimal) {
-    this.set('lastPrice', Value.fromBigDecimal(value));
+  set lastPrice(value: BigInt) {
+    this.set('lastPrice', Value.fromBigInt(value));
   }
 
   get avgEntryPrice(): BigInt {
@@ -851,13 +851,13 @@ export class FuturesOrder extends Entity {
     this.set('id', Value.fromString(value));
   }
 
-  get size(): BigDecimal {
+  get size(): BigInt {
     let value = this.get('size');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set size(value: BigDecimal) {
-    this.set('size', Value.fromBigDecimal(value));
+  set size(value: BigInt) {
+    this.set('size', Value.fromBigInt(value));
   }
 
   get market(): string {
@@ -896,13 +896,13 @@ export class FuturesOrder extends Entity {
     this.set('targetRoundId', Value.fromBigInt(value));
   }
 
-  get targetPrice(): BigDecimal {
+  get targetPrice(): BigInt {
     let value = this.get('targetPrice');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set targetPrice(value: BigDecimal) {
-    this.set('targetPrice', Value.fromBigDecimal(value));
+  set targetPrice(value: BigInt) {
+    this.set('targetPrice', Value.fromBigInt(value));
   }
 
   get marginDelta(): BigInt {
@@ -941,13 +941,13 @@ export class FuturesOrder extends Entity {
     this.set('status', Value.fromString(value));
   }
 
-  get fee(): BigDecimal {
+  get fee(): BigInt {
     let value = this.get('fee');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set fee(value: BigDecimal) {
-    this.set('fee', Value.fromBigDecimal(value));
+  set fee(value: BigInt) {
+    this.set('fee', Value.fromBigInt(value));
   }
 
   get keeper(): Bytes {
@@ -1121,13 +1121,13 @@ export class FuturesMarginTransfer extends Entity {
     this.set('market', Value.fromString(value));
   }
 
-  get size(): BigDecimal {
+  get size(): BigInt {
     let value = this.get('size');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set size(value: BigDecimal) {
-    this.set('size', Value.fromBigDecimal(value));
+  set size(value: BigInt) {
+    this.set('size', Value.fromBigInt(value));
   }
 
   get txHash(): string {
@@ -1248,22 +1248,22 @@ export class Frontend extends Entity {
     this.set('markets', Value.fromStringArray(value));
   }
 
-  get amount(): BigDecimal {
+  get amount(): BigInt {
     let value = this.get('amount');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set amount(value: BigDecimal) {
-    this.set('amount', Value.fromBigDecimal(value));
+  set amount(value: BigInt) {
+    this.set('amount', Value.fromBigInt(value));
   }
 
-  get fees(): BigDecimal {
+  get fees(): BigInt {
     let value = this.get('fees');
-    return value!.toBigDecimal();
+    return value!.toBigInt();
   }
 
-  set fees(value: BigDecimal) {
-    this.set('fees', Value.fromBigDecimal(value));
+  set fees(value: BigInt) {
+    this.set('fees', Value.fromBigInt(value));
   }
 }
 

--- a/v2/perps-v2/perps-subgraph/schema.graphql
+++ b/v2/perps-v2/perps-subgraph/schema.graphql
@@ -3,9 +3,9 @@ type PositionLiquidated @entity {
   trader: Trader!
   market: FuturesMarket!
   liquidator: Bytes!
-  size: BigDecimal!
-  price: BigDecimal!
-  fee: BigDecimal!
+  size: BigInt!
+  price: BigInt!
+  fee: BigInt!
   futuresPosition: FuturesPosition!
   timestamp: BigInt!
   txHash: String!
@@ -21,11 +21,11 @@ type PositionFlagged @entity {
 type Trader @entity {
   id: ID!
   timestamp: BigInt!
-  margin: BigDecimal!
+  margin: BigInt!
   totalLiquidations: BigInt!
-  totalMarginLiquidated: BigDecimal!
-  feesPaidToSynthetix: BigDecimal!
-  totalVolume: BigDecimal!
+  totalMarginLiquidated: BigInt!
+  feesPaidToSynthetix: BigInt!
+  totalVolume: BigInt!
   realizedPnl: BigInt!
   trades: [FuturesTrade!]!
 }
@@ -37,24 +37,24 @@ type FuturesTrade @entity {
   margin: BigInt!
   futuresPosition: FuturesPosition!
   futuresOrder: FuturesOrder
-  size: BigDecimal!
+  size: BigInt!
   market: FuturesMarket!
-  price: BigDecimal!
-  positionSize: BigDecimal!
+  price: BigInt!
+  positionSize: BigInt!
   positionClosed: Boolean!
   realizedPnl: BigInt!
   netFunding: BigInt!
-  feesPaidToSynthetix: BigDecimal!
+  feesPaidToSynthetix: BigInt!
   type: FuturesTradeType!
   txHash: String!
 }
 
 type Synthetix @entity {
   id: ID!
-  feesByLiquidations: BigDecimal!
-  feesByPositionModifications: BigDecimal!
+  feesByLiquidations: BigInt!
+  feesByPositionModifications: BigInt!
   totalLiquidations: BigInt!
-  totalVolume: BigDecimal!
+  totalVolume: BigInt!
   totalTraders: BigInt!
 }
 
@@ -77,10 +77,10 @@ type FuturesPosition @entity {
   realizedPnl: BigInt!
   unrealizedPnl: BigInt!
   fundingIndex: BigInt!
-  totalVolume: BigDecimal!
+  totalVolume: BigInt!
   entryPrice: BigInt!
   netTransfers: BigInt!
-  lastPrice: BigDecimal!
+  lastPrice: BigInt!
   avgEntryPrice: BigInt!
   txHash: String!
   exitPrice: BigInt
@@ -89,17 +89,17 @@ type FuturesPosition @entity {
 
 type FuturesOrder @entity {
   id: ID!
-  size: BigDecimal!
+  size: BigInt!
   market: FuturesMarket!
   trader: Trader!
   orderId: BigInt!
   targetRoundId: BigInt!
-  targetPrice: BigDecimal!
+  targetPrice: BigInt!
   marginDelta: BigInt!
   timestamp: BigInt!
   orderType: FuturesOrderType!
   status: FuturesOrderStatus!
-  fee: BigDecimal!
+  fee: BigInt!
   keeper: Bytes!
   futuresPosition: FuturesPosition
   txHash: String!
@@ -119,7 +119,7 @@ type FuturesMarginTransfer @entity {
   timestamp: BigInt!
   trader: Trader!
   market: FuturesMarket!
-  size: BigDecimal!
+  size: BigInt!
   txHash: String!
 }
 
@@ -134,8 +134,8 @@ type FuturesMarket @entity {
 type Frontend @entity {
   id: ID!
   markets: [FuturesMarket!]!
-  amount: BigDecimal!
-  fees: BigDecimal!
+  amount: BigInt!
+  fees: BigInt!
 }
 
 type Candle @entity {

--- a/v2/perps-v2/perps-subgraph/schema.graphql
+++ b/v2/perps-v2/perps-subgraph/schema.graphql
@@ -26,7 +26,7 @@ type Trader @entity {
   totalMarginLiquidated: BigDecimal!
   feesPaidToSynthetix: BigDecimal!
   totalVolume: BigDecimal!
-  pnl: BigInt!
+  realizedPnl: BigInt!
   trades: [FuturesTrade!]!
 }
 
@@ -42,7 +42,8 @@ type FuturesTrade @entity {
   price: BigDecimal!
   positionSize: BigDecimal!
   positionClosed: Boolean!
-  pnl: BigInt!
+  realizedPnl: BigInt!
+  netFunding: BigInt!
   feesPaidToSynthetix: BigDecimal!
   type: FuturesTradeType!
   txHash: String!
@@ -73,7 +74,8 @@ type FuturesPosition @entity {
   leverage: BigInt!
   netFunding: BigInt!
   margin: BigInt!
-  pnl: BigInt!
+  realizedPnl: BigInt!
+  unrealizedPnl: BigInt!
   fundingIndex: BigInt!
   totalVolume: BigDecimal!
   entryPrice: BigInt!

--- a/v2/perps-v2/perps-subgraph/src/calculations.ts
+++ b/v2/perps-v2/perps-subgraph/src/calculations.ts
@@ -1,7 +1,7 @@
-import { BigDecimal, BigInt } from '@graphprotocol/graph-ts';
+import { BigInt } from '@graphprotocol/graph-ts';
 
-export function calculateVolume(tradeSize: BigInt, lastPrice: BigInt): BigDecimal {
-  return tradeSize.times(lastPrice).div(BigInt.fromI32(10).pow(18)).abs().toBigDecimal();
+export function calculateVolume(tradeSize: BigInt, lastPrice: BigInt): BigInt {
+  return tradeSize.times(lastPrice).div(BigInt.fromI32(10).pow(18)).abs();
 }
 
 export function calculateLeverage(size: BigInt, lastPrice: BigInt, margin: BigInt): BigInt {

--- a/v2/perps-v2/perps-subgraph/src/calculations.ts
+++ b/v2/perps-v2/perps-subgraph/src/calculations.ts
@@ -1,5 +1,4 @@
 import { BigDecimal, BigInt } from '@graphprotocol/graph-ts';
-import { FundingRateUpdate } from '../generated/schema';
 
 export function calculateVolume(tradeSize: BigInt, lastPrice: BigInt): BigDecimal {
   return tradeSize.times(lastPrice).div(BigInt.fromI32(10).pow(18)).abs().toBigDecimal();
@@ -11,6 +10,19 @@ export function calculateLeverage(size: BigInt, lastPrice: BigInt, margin: BigIn
 
 export function calculatePnl(lastPrice: BigInt, avgEntryPrice: BigInt, size: BigInt): BigInt {
   return lastPrice.minus(avgEntryPrice).times(size).div(BigInt.fromI32(10).pow(18));
+}
+
+export function calculateAccruedPnlForReducingPositions(
+  lastPrice: BigInt,
+  avgEntryPrice: BigInt,
+  tradeSize: BigInt
+): BigInt {
+  const tradeSizeFlipped = tradeSize.times(BigInt.fromI32(-1));
+  const accruedPnl = lastPrice
+    .minus(avgEntryPrice)
+    .times(tradeSizeFlipped)
+    .div(BigInt.fromI32(10).pow(18));
+  return accruedPnl;
 }
 export function calculateAccruedFunding(
   pastFunding: BigInt,

--- a/v2/perps-v2/perps-subgraph/src/futures.ts
+++ b/v2/perps-v2/perps-subgraph/src/futures.ts
@@ -108,11 +108,6 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     futuresPosition.isOpen = false;
     futuresPosition.closeTimestamp = event.block.timestamp;
     futuresPosition.feesPaidToSynthetix = event.params.fee;
-    futuresPosition.unrealizedPnl = BigInt.fromI32(0);
-    // TODO validate that this is correct
-    futuresPosition.realizedPnl = futuresPosition.realizedPnl
-      .minus(futuresPosition.feesPaidToSynthetix)
-      .plus(futuresPosition.netFunding);
     futuresPosition.exitPrice = event.params.price;
     futuresPosition.save();
   }

--- a/v2/perps-v2/perps-subgraph/src/futures.ts
+++ b/v2/perps-v2/perps-subgraph/src/futures.ts
@@ -1,11 +1,4 @@
-import {
-  Address,
-  BigDecimal,
-  BigInt,
-  dataSource,
-  DataSourceContext,
-  log,
-} from '@graphprotocol/graph-ts';
+import { Address, BigInt, DataSourceContext, log } from '@graphprotocol/graph-ts';
 import { PerpetualFuturesMarket } from '../generated/templates';
 import {
   DelayedOrderRemoved as DelayedOrderRemovedEvent,
@@ -71,9 +64,9 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
   positionLiquidatedEntity.trader = event.params.account.toHex();
   positionLiquidatedEntity.market = event.address.toHex();
   positionLiquidatedEntity.liquidator = event.params.liquidator;
-  positionLiquidatedEntity.size = event.params.size.toBigDecimal();
-  positionLiquidatedEntity.price = event.params.price.toBigDecimal();
-  positionLiquidatedEntity.fee = event.params.fee.toBigDecimal();
+  positionLiquidatedEntity.size = event.params.size;
+  positionLiquidatedEntity.price = event.params.price;
+  positionLiquidatedEntity.fee = event.params.fee;
   positionLiquidatedEntity.futuresPosition = futuresPositionId;
   positionLiquidatedEntity.timestamp = event.block.timestamp;
   positionLiquidatedEntity.txHash = event.transaction.hash.toHex();
@@ -83,27 +76,28 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     event.transaction.hash.toHex() + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString()
   );
   if (tradeEntity) {
-    tradeEntity.size = event.params.size.times(BigInt.fromI32(-1)).toBigDecimal();
+    tradeEntity.size = event.params.size.times(BigInt.fromI32(-1));
     tradeEntity.positionClosed = true;
     tradeEntity.timestamp = event.block.timestamp;
     tradeEntity.trader = event.params.account.toHex();
     tradeEntity.futuresPosition = futuresPositionId;
-    tradeEntity.price = event.params.price.toBigDecimal();
+    tradeEntity.price = event.params.price;
     tradeEntity.txHash = event.transaction.hash.toHex();
-    tradeEntity.positionSize = BigDecimal.fromString('0');
-    tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(
-      event.params.fee.toBigDecimal()
-    );
-    tradeEntity.pnl = tradeEntity.pnl.plus(event.params.fee);
+    tradeEntity.positionSize = BigInt.fromI32(0);
+    tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(event.params.fee);
+
+    // TODO make sure this is correct. I think we need to subtract something else.
+    tradeEntity.realizedPnl = tradeEntity.realizedPnl
+      .minus(event.params.fee)
+      .minus(tradeEntity.netFunding); // you loose funding when liquidated
+    tradeEntity.netFunding = BigInt.fromI32(0);
     tradeEntity.type = 'Liquidated';
     tradeEntity.save();
   }
 
   const synthetix = Synthetix.load('synthetix');
   if (synthetix) {
-    synthetix.feesByLiquidations = synthetix.feesByLiquidations.plus(
-      event.params.fee.toBigDecimal()
-    );
+    synthetix.feesByLiquidations = synthetix.feesByLiquidations.plus(event.params.fee);
     synthetix.totalLiquidations = synthetix.totalLiquidations.plus(BigInt.fromI32(1));
     synthetix.save();
   }
@@ -114,7 +108,9 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     futuresPosition.isOpen = false;
     futuresPosition.closeTimestamp = event.block.timestamp;
     futuresPosition.feesPaidToSynthetix = event.params.fee;
-    futuresPosition.pnl = futuresPosition.pnl
+    futuresPosition.unrealizedPnl = BigInt.fromI32(0);
+    // TODO validate that this is correct
+    futuresPosition.realizedPnl = futuresPosition.realizedPnl
       .minus(futuresPosition.feesPaidToSynthetix)
       .plus(futuresPosition.netFunding);
     futuresPosition.exitPrice = event.params.price;
@@ -123,12 +119,10 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
 
   let trader = Trader.load(event.params.account.toHex());
   if (trader) {
-    trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(event.params.fee.toBigDecimal());
+    trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(event.params.fee);
     trader.totalLiquidations = trader.totalLiquidations.plus(BigInt.fromI32(1));
-    trader.totalMarginLiquidated = trader.totalMarginLiquidated.plus(
-      event.params.size.toBigDecimal()
-    );
-    trader.margin = trader.margin.minus(event.params.size.toBigDecimal());
+    trader.totalMarginLiquidated = trader.totalMarginLiquidated.plus(event.params.size);
+    trader.margin = trader.margin.minus(event.params.size);
     trader.save();
   }
 }
@@ -141,36 +135,36 @@ export function handleMarginTransferred(event: MarginTransferredEvent): void {
   );
 
   marginTransferEntity.market = event.address.toHex();
-  marginTransferEntity.size = event.params.marginDelta.toBigDecimal();
+  marginTransferEntity.size = event.params.marginDelta;
   marginTransferEntity.trader = event.params.account.toHex();
   marginTransferEntity.timestamp = event.block.timestamp;
   marginTransferEntity.txHash = event.transaction.hash.toHex();
 
   if (!synthetix) {
     synthetix = new Synthetix('synthetix');
-    synthetix.feesByLiquidations = BigDecimal.fromString('0');
-    synthetix.feesByPositionModifications = BigDecimal.fromString('0');
+    synthetix.feesByLiquidations = BigInt.fromI32(0);
+    synthetix.feesByPositionModifications = BigInt.fromI32(0);
     synthetix.totalLiquidations = BigInt.fromI32(0);
-    synthetix.totalVolume = BigDecimal.fromString('0');
+    synthetix.totalVolume = BigInt.fromI32(0);
     synthetix.totalTraders = BigInt.fromI32(0);
   }
 
   if (!trader) {
     trader = new Trader(event.params.account.toHex());
     trader.timestamp = event.block.timestamp;
-    trader.feesPaidToSynthetix = BigDecimal.fromString('0');
+    trader.feesPaidToSynthetix = BigInt.fromI32(0);
     trader.trades = [];
-    trader.totalVolume = event.params.marginDelta.toBigDecimal();
+    trader.totalVolume = event.params.marginDelta;
     trader.totalLiquidations = BigInt.fromI32(0);
-    trader.totalMarginLiquidated = BigDecimal.fromString('0');
-    trader.margin = event.params.marginDelta.toBigDecimal();
-    trader.pnl = BigInt.fromI32(0);
+    trader.totalMarginLiquidated = BigInt.fromI32(0);
+    trader.margin = event.params.marginDelta;
+    trader.realizedPnl = BigInt.fromI32(0);
     synthetix.totalTraders = synthetix.totalTraders.plus(BigInt.fromI32(0));
   } else {
     if (event.params.marginDelta.gt(BigInt.fromI32(0))) {
-      trader.margin = trader.margin.plus(event.params.marginDelta.toBigDecimal());
+      trader.margin = trader.margin.plus(event.params.marginDelta);
     } else if (event.params.marginDelta.lt(BigInt.fromI32(0))) {
-      trader.margin = trader.margin.minus(event.params.marginDelta.toBigDecimal());
+      trader.margin = trader.margin.minus(event.params.marginDelta);
     }
   }
   marginTransferEntity.save();
@@ -189,7 +183,7 @@ export function handleDelayedOrderRemoved(event: DelayedOrderRemovedEvent): void
 
   // Update FuturesOrderEntity
   if (futuresOrderEntity) {
-    futuresOrderEntity.fee = event.params.keeperDeposit.toBigDecimal();
+    futuresOrderEntity.fee = event.params.keeperDeposit;
     futuresOrderEntity.keeper = event.transaction.from;
 
     if (tradeEntity) {
@@ -206,7 +200,7 @@ export function handleDelayedOrderRemoved(event: DelayedOrderRemovedEvent): void
       // add fee if not self-executed
       if (futuresOrderEntity.keeper.toString() != futuresOrderEntity.trader) {
         tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(
-          event.params.keeperDeposit.toBigDecimal()
+          event.params.keeperDeposit
         );
         tradeEntity.save();
       }
@@ -214,16 +208,14 @@ export function handleDelayedOrderRemoved(event: DelayedOrderRemovedEvent): void
       // Update Synthetix values
       if (synthetix) {
         synthetix.feesByPositionModifications = synthetix.feesByPositionModifications.plus(
-          event.params.keeperDeposit.toBigDecimal()
+          event.params.keeperDeposit
         );
         synthetix.save();
       }
 
       // Update Trader fee value
       if (trader) {
-        trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(
-          event.params.keeperDeposit.toBigDecimal()
-        );
+        trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(event.params.keeperDeposit);
         trader.save();
       }
       futuresOrderEntity.txHash = event.transaction.hash.toHex();
@@ -243,13 +235,13 @@ export function handleDelayedOrderSubmitted(event: DelayedOrderSubmittedEvent): 
   if (!futuresOrderEntity) {
     futuresOrderEntity = new FuturesOrder(futuresOrderEntityId);
   }
-  futuresOrderEntity.size = event.params.sizeDelta.toBigDecimal();
+  futuresOrderEntity.size = event.params.sizeDelta;
   futuresOrderEntity.market = event.address.toHex();
-  futuresOrderEntity.fee = BigInt.fromI32(0).toBigDecimal();
+  futuresOrderEntity.fee = BigInt.fromI32(0);
   futuresOrderEntity.trader = event.params.account.toHex();
   futuresOrderEntity.orderId = event.params.targetRoundId;
   futuresOrderEntity.targetRoundId = event.params.targetRoundId;
-  futuresOrderEntity.targetPrice = BigInt.fromI32(0).toBigDecimal();
+  futuresOrderEntity.targetPrice = BigInt.fromI32(0);
   futuresOrderEntity.marginDelta = BigInt.fromI32(0);
   futuresOrderEntity.timestamp = event.block.timestamp;
   futuresOrderEntity.orderType = event.params.isOffchain
@@ -279,11 +271,11 @@ export function handlePerpsTracking(event: PerpsTrackingEvent): void {
   if (!frontend) {
     frontend = new Frontend(event.params.trackingCode.toString());
     frontend.markets = [event.address.toHex()];
-    frontend.amount = event.params.sizeDelta.abs().toBigDecimal();
-    frontend.fees = event.params.fee.toBigDecimal();
+    frontend.amount = event.params.sizeDelta.abs();
+    frontend.fees = event.params.fee;
   } else {
-    frontend.amount = frontend.amount.plus(event.params.sizeDelta.abs().toBigDecimal());
-    frontend.fees = frontend.fees.plus(event.params.fee.abs().toBigDecimal());
+    frontend.amount = frontend.amount.plus(event.params.sizeDelta.abs());
+    frontend.fees = frontend.fees.plus(event.params.fee.abs());
     if (!frontend.markets.includes(event.address.toHex())) {
       const oldMarkets = frontend.markets;
       oldMarkets.push(event.address.toHex());

--- a/v2/perps-v2/perps-subgraph/src/trade-entities.ts
+++ b/v2/perps-v2/perps-subgraph/src/trade-entities.ts
@@ -10,11 +10,11 @@ function createBaseTradeEntity(event: PositionModifiedNewEvent, positionId: stri
   tradeEntity.trader = event.params.account.toHex();
   tradeEntity.futuresPosition = positionId;
   tradeEntity.margin = event.params.margin;
-  tradeEntity.size = event.params.tradeSize.toBigDecimal();
-  tradeEntity.positionSize = event.params.size.toBigDecimal();
+  tradeEntity.size = event.params.tradeSize;
+  tradeEntity.positionSize = event.params.size;
   tradeEntity.market = event.address.toHex();
-  tradeEntity.price = event.params.lastPrice.toBigDecimal();
-  tradeEntity.feesPaidToSynthetix = event.params.fee.toBigDecimal();
+  tradeEntity.price = event.params.lastPrice;
+  tradeEntity.feesPaidToSynthetix = event.params.fee;
   tradeEntity.txHash = event.transaction.hash.toHex();
 
   return tradeEntity;

--- a/v2/perps-v2/perps-subgraph/tests/perpsV2-utils.ts
+++ b/v2/perps-v2/perps-subgraph/tests/perpsV2-utils.ts
@@ -9,6 +9,15 @@ import {
   FundingRecomputed,
 } from '../generated/FuturesMarketManagerNew/PerpsV2Proxy';
 
+export function toEth(n: u64): BigInt {
+  if (n < 0) return BigInt.fromU64(n).times(BigInt.fromI32(10).pow(18));
+  return BigInt.fromI64(changetype<i64>(n)).times(BigInt.fromI64(10).pow(18));
+}
+export function toGwei(n: u64): BigInt {
+  if (n < 0) return BigInt.fromU64(n).times(BigInt.fromI32(10).pow(9));
+  return BigInt.fromI64(changetype<i64>(n)).times(BigInt.fromI64(10).pow(9));
+}
+
 function createBlock(timestamp: i64, blockNumber: i64): Map<string, i64> {
   const newBlock = new Map<string, i64>();
   newBlock.set('timestamp', timestamp);

--- a/v2/perps-v2/perps-subgraph/tests/perpsV2.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/perpsV2.test.ts
@@ -306,7 +306,7 @@ describe('Perps V2', () => {
         .plus(toEth(-1).times(toEth(1200)).div(BigInt.fromI32(10).pow(18)).abs())
         .toString()
     );
-    assert.fieldEquals('Trader', trader.toLowerCase(), 'realizedPnl', '-1000000000');
+    assert.fieldEquals('Trader', trader.toLowerCase(), 'realizedPnl', '-2000000000');
     assert.fieldEquals(
       'Trader',
       trader.toLowerCase(),

--- a/v2/perps-v2/perps-subgraph/tests/perpsV2.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/perpsV2.test.ts
@@ -5,6 +5,8 @@ import {
   createMarginTransferredEvent,
   createPositionLiquidatedEvent,
   createPositionModifiedEvent,
+  toEth,
+  toGwei,
 } from './perpsV2-utils';
 import {
   handleFundingRecomputed,
@@ -14,14 +16,6 @@ import {
 } from '../src/futures';
 
 const trader = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
-function toEth(n: u64): BigInt {
-  if (n < 0) return BigInt.fromU64(n).times(BigInt.fromI32(10).pow(18));
-  return BigInt.fromI64(changetype<i64>(n)).times(BigInt.fromI64(10).pow(18));
-}
-function toGwei(n: u64): BigInt {
-  if (n < 0) return BigInt.fromU64(n).times(BigInt.fromI32(10).pow(9));
-  return BigInt.fromI64(changetype<i64>(n)).times(BigInt.fromI64(10).pow(9));
-}
 
 describe('Perps V2', () => {
   afterEach(() => {
@@ -83,8 +77,8 @@ describe('Perps V2', () => {
     // The funding has decreased with 100 since we opened the position
     // When funding decreases and we have a short opened, it means we getting paid.
     // The initial funding was 10000. The new funding is 9900. So a diff of 100
-    // We have a size of 3, which means we expect to net funding to be 100 * 3 = 300
-    assert.fieldEquals('FuturesPosition', positionId, 'netFunding', '300');
+    // We have a size of 2 when opening till now, which means we expect to net funding to be 100 * 2 = 200
+    assert.fieldEquals('FuturesPosition', positionId, 'netFunding', '200');
     assert.fieldEquals('FuturesPosition', positionId, 'fundingIndex', '5');
   });
 
@@ -185,7 +179,7 @@ describe('Perps V2', () => {
       'FuturesPosition',
       `${modifyPositionEvent.address.toHex() + '-' + '0x1'}`,
       'initialMargin',
-      toEth(5).plus(toGwei(1)).toString()
+      toEth(5).toString()
     );
     assert.fieldEquals(
       'FuturesPosition',
@@ -208,8 +202,14 @@ describe('Perps V2', () => {
     assert.fieldEquals(
       'FuturesPosition',
       `${modifyPositionEvent.address.toHex() + '-' + '0x1'}`,
-      'pnl',
-      '-200000000000000000000'
+      'realizedPnl',
+      '-2000000000'
+    );
+    assert.fieldEquals(
+      'FuturesPosition',
+      `${modifyPositionEvent.address.toHex() + '-' + '0x1'}`,
+      'unrealizedPnl',
+      '-400000000000000000002'
     );
     assert.fieldEquals(
       'FuturesPosition',
@@ -306,7 +306,7 @@ describe('Perps V2', () => {
         .plus(toEth(-1).times(toEth(1200)).div(BigInt.fromI32(10).pow(18)).abs())
         .toString()
     );
-    assert.fieldEquals('Trader', trader.toLowerCase(), 'pnl', '-200000000000000000000'); // This trade have only done one position open + position modified. PNL should be the same as the Position
+    assert.fieldEquals('Trader', trader.toLowerCase(), 'realizedPnl', '-1000000000');
     assert.fieldEquals(
       'Trader',
       trader.toLowerCase(),
@@ -334,7 +334,7 @@ describe('Perps V2', () => {
       'FuturesTrade',
       `${positionOpenedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
       'margin',
-      toEth(5).plus(toGwei(1)).toString()
+      toEth(5).toString()
     );
     assert.fieldEquals(
       'FuturesTrade',
@@ -375,7 +375,7 @@ describe('Perps V2', () => {
     assert.fieldEquals(
       'FuturesTrade',
       `${positionOpenedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
-      'pnl',
+      'realizedPnl',
       '-1000000000'
     );
     assert.fieldEquals(
@@ -444,18 +444,7 @@ describe('Perps V2', () => {
       'positionClosed',
       'false'
     );
-    assert.fieldEquals(
-      'FuturesTrade',
-      `${positionOpenedEvent.address.toHex()}-${BigInt.fromI32(2).toString()}`,
-      'pnl',
 
-      toEth(1200)
-        .minus(toEth(1000))
-        .times(toEth(-1).abs())
-        .times(BigInt.fromI32(-1))
-        .div(BigInt.fromI32(10).pow(18))
-        .toString()
-    );
     assert.fieldEquals(
       'FuturesTrade',
       `${positionOpenedEvent.address.toHex()}-${BigInt.fromI32(2).toString()}`,
@@ -467,46 +456,6 @@ describe('Perps V2', () => {
       `${positionOpenedEvent.address.toHex()}-${BigInt.fromI32(2).toString()}`,
       'type',
       'PositionModified'
-    );
-  });
-
-  test('calculate PNL for closed long position', () => {
-    const positionOpenedEvent = createPositionModifiedEvent(
-      BigInt.fromI32(1), // id
-      Address.fromString(trader), // account
-      toEth(5), // margin
-      toEth(2), //size
-      toEth(2), // trade size
-      toEth(1000), // last price
-      BigInt.fromI32(1), // funding index
-      toGwei(1), // fee
-      10, // timestamp
-      BigInt.fromI32(12), // skew
-      1 // log index
-    );
-    handlePositionModified(positionOpenedEvent);
-    const modifyPositionEvent = createPositionModifiedEvent(
-      BigInt.fromI32(1), // id
-      Address.fromString(trader), // account
-      toEth(5), // margin
-      toEth(0), //size
-      toEth(-2), // trade size
-      toEth(1200), // last price
-      BigInt.fromI32(2), // funding index
-      toGwei(1), // fee
-      20, // timestamp
-      BigInt.fromI32(12), //skew
-      2 // log index
-    );
-    handlePositionModified(modifyPositionEvent);
-
-    // FUTURES POSITION
-
-    assert.fieldEquals(
-      'FuturesPosition',
-      `${modifyPositionEvent.address.toHex() + '-' + '0x1'}`,
-      'pnl',
-      '400000000000000000000'
     );
   });
 
@@ -801,13 +750,13 @@ describe('Perps V2', () => {
       'FuturesPosition',
       `${positionModifiedEvent.address.toHex() + '-' + '0x1'}`,
       'entryPrice',
-      existingPrice.plus(newPrice).div(toEth(2)).toString()
+      toEth(1200).toString()
     );
     assert.fieldEquals(
       'FuturesPosition',
       `${positionModifiedEvent.address.toHex() + '-' + '0x1'}`,
       'avgEntryPrice',
-      existingPrice.plus(newPrice).div(toEth(2)).toString()
+      toEth(1200).toString()
     );
   });
 });

--- a/v2/perps-v2/perps-subgraph/tests/position-modified.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/position-modified.test.ts
@@ -1,0 +1,320 @@
+import { Address, BigInt, log, store } from '@graphprotocol/graph-ts';
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  logStore,
+} from 'matchstick-as/assembly/index';
+import {
+  createFunctionRecomputedEvent,
+  createPositionModifiedEvent,
+  toEth,
+  toGwei,
+} from './perpsV2-utils';
+import { handleFundingRecomputed, handlePositionModified } from '../src/futures';
+const trader = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+describe('modify position handler', () => {
+  afterEach(() => {
+    clearStore();
+  });
+  describe('pnl and average entry price', () => {
+    test('long open -> long increase -> close: with price and funding going up', () => {
+      const initialFunding = 1000;
+      const initialFundingRecomputedEvent = createFunctionRecomputedEvent(
+        toEth(initialFunding), // funding
+        toEth(10), // fundingRate
+        BigInt.fromI32(1), // index
+        BigInt.fromI32(15), // block timestamp
+        10 // log index
+      );
+      handleFundingRecomputed(initialFundingRecomputedEvent);
+      const openedEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(2), //size
+        toEth(2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        10, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(openedEvent);
+      const positionId = `${openedEvent.address.toHex() + '-' + '0x1'}`;
+      let expectedRealizedPnl = toEth(-1).toString();
+      let expectedUnrealizedPnl = toEth(0).toString();
+      let expectedEntry = toEth(1000).toString();
+      let expectedTradePnl = toEth(-1).toString();
+
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', expectedRealizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', expectedUnrealizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${openedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedRealizedPnl
+      );
+
+      const FundingRecomputedEvent1 = createFunctionRecomputedEvent(
+        toEth(initialFunding + 10), // funding
+        toEth(10), // fundingRate
+        BigInt.fromI32(2), // index
+        BigInt.fromI32(16), // block timestamp
+        10 // log index
+      );
+      handleFundingRecomputed(FundingRecomputedEvent1);
+
+      const modifyEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(3), //size
+        toEth(1), // trade size
+        toEth(1100), // last price
+        BigInt.fromI32(2), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        20, // timestamp
+        BigInt.fromI32(12), //skew
+        1 // log index
+      );
+      handlePositionModified(modifyEvent);
+
+      expectedRealizedPnl = toEth(18).toString(); // (-1) + (10 * 2) - 1
+      expectedUnrealizedPnl = '200000000000000000001'; // (1100 - 1033.33333) * 3
+      expectedTradePnl = toEth(19).toString(); // (10 * 2) - 1
+      expectedEntry = '1033333333333333333333'; // 1033.33333
+
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${modifyEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', expectedRealizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', expectedUnrealizedPnl);
+
+      const FundingRecomputedEvent2 = createFunctionRecomputedEvent(
+        toEth(initialFunding + 10), // funding
+        toEth(10), // fundingRate
+        BigInt.fromI32(3), // index
+        BigInt.fromI32(16), // block timestamp
+        10 // log index
+      );
+      handleFundingRecomputed(FundingRecomputedEvent2);
+
+      const closeEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(0), //size
+        toEth(-3), // trade size
+        toEth(1200), // last price
+        BigInt.fromI32(3), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        20, // timestamp
+        BigInt.fromI32(12), //skew
+        1 // log index
+      );
+      handlePositionModified(closeEvent);
+
+      expectedRealizedPnl = '517000000000000000001'; // 18 + 19 + ((1200 - 1033.333) * 3). prevRealized + (accruedFunding + fees) + ((current price - avg entry price) * 3)
+      expectedUnrealizedPnl = toEth(0).toString();
+      expectedTradePnl = toEth(299).toString(); //(1200 - 1100) * 3) - 1
+      expectedEntry = '1033333333333333333333'; // 1033.33333
+
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', expectedRealizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', expectedUnrealizedPnl);
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${openedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+    });
+
+    test('short open -> flipped to long -> close: with price going up', () => {
+      const openedEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(-2), //size (short position)
+        toEth(-2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        10, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(openedEvent);
+      const positionId = `${openedEvent.address.toHex() + '-' + '0x1'}`;
+      let realizedPnl = toEth(-1).toString();
+      let unrealizedPnl = toEth(0).toString();
+      let expectedEntry = toEth(1000).toString();
+      let expectedTradePnl = toEth(-1).toString();
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', realizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', unrealizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${openedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+
+      const modifyEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(1), // size (short position decreased)
+        toEth(3), // trade size
+        toEth(1100), // last price
+        BigInt.fromI32(2), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        20, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(modifyEvent);
+
+      realizedPnl = toEth(-202).toString(); // -1 + ((1100 - 1000) * -2) -1
+      unrealizedPnl = toEth(0).toString(); // (1100 - 1000 ) * 1
+      expectedEntry = toEth(1100).toString(); // decreasing a position does not affect entry price
+      expectedTradePnl = toEth(-201).toString(); // ((1100 - 1000) * -2) -1
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${modifyEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', realizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', unrealizedPnl);
+
+      const closeEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(0), // size (position closed)
+        toEth(-1), // trade size
+        toEth(1200), // last price
+        BigInt.fromI32(2), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        20, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(closeEvent);
+      realizedPnl = toEth(-103).toString(); // -202 + ((1200 -1100) * 1) + -1
+      unrealizedPnl = toEth(0).toString();
+      expectedEntry = toEth(1100).toString();
+      expectedTradePnl = toEth(99).toString(); // ((1200 -1100) * 1) + -1
+
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', realizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', unrealizedPnl);
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${openedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+    });
+    test('short open -> short decrease -> close: with price going up', () => {
+      const openedEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(-2), //size (short position)
+        toEth(-2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        10, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(openedEvent);
+      const positionId = `${openedEvent.address.toHex() + '-' + '0x1'}`;
+      let realizedPnl = toEth(-1).toString();
+      let unrealizedPnl = toEth(0).toString();
+      let expectedEntry = toEth(1000).toString();
+      let expectedTradePnl = toEth(-1).toString();
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', realizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', unrealizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${openedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+
+      const modifyEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(-1), // size (short position decreased)
+        toEth(1), // trade size
+        toEth(1100), // last price
+        BigInt.fromI32(2), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        20, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(modifyEvent);
+
+      realizedPnl = toEth(-102).toString(); // -1 + ((1100 - 1000) * -1) -1
+      unrealizedPnl = toEth(-100).toString(); // (1100 - 1000 ) * 1
+      expectedEntry = toEth(1000).toString(); // decreasing a position does not affect entry price
+      expectedTradePnl = toEth(-101).toString(); // ((1100 - 1000) * -1) -1
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${modifyEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', realizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', unrealizedPnl);
+
+      const closeEvent = createPositionModifiedEvent(
+        BigInt.fromI32(1), // id
+        Address.fromString(trader), // account
+        toEth(5), // margin
+        toEth(0), // size (position closed)
+        toEth(1), // trade size
+        toEth(1200), // last price
+        BigInt.fromI32(2), // funding index
+        toGwei(1000000000), // fee  (equal to toETH(1))
+        20, // timestamp
+        BigInt.fromI32(12), // skew
+        1 // log index
+      );
+      handlePositionModified(closeEvent);
+      realizedPnl = toEth(-303).toString(); // -102 + ((1200 -1000) * -1) + -1
+      unrealizedPnl = toEth(0).toString();
+      expectedEntry = toEth(1000).toString();
+      expectedTradePnl = toEth(-101).toString(); // ((1100 - 1000) * -1) -1
+
+      assert.fieldEquals('FuturesPosition', positionId, 'avgEntryPrice', expectedEntry);
+      assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', realizedPnl);
+      assert.fieldEquals('FuturesPosition', positionId, 'unrealizedPnl', unrealizedPnl);
+      assert.fieldEquals(
+        'FuturesTrade',
+        `${openedEvent.address.toHex()}-${BigInt.fromI32(1).toString()}`,
+        'realizedPnl',
+        expectedTradePnl
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR separates realized pnl from unrealized pnl. 
I also changes back types to `BigInt` from `BigDecimal`. We store all values with 18 decimals, so they are all ints. If we start storing values with `val / 1e18` we should change to BigDecimals.
I also made sure that netTransfers are up to date.


PNL Spec:
### Open position:
```
realisedPnl = fees.mul(-1) // funding is 0
unrealisedPnl = 0 
Avg entry price = current price
```

### Decrease position:
```
netTradePnl = gain/loss based on the trade size and avgEntryPrice (happy to share calc if interest)
realisedPnl = previousRealisedPnl.plus(netTradePnl).minus(fees).plus(netAccruedFundingSinceLastInteraction)
unrealised = (currentPrice - avgEntryPrice) * new size
```
### Increase Position: 
```
realisedPnl = previousRealisedPnl.minus(fees).plus(netAccruedFundingSinceLastInteraction)
unrealisedPnl = (currentPrice - prevAvgEntryPrice) * new size
Update average entry price (happy to share calc if interest)
```

### Position flipped:
```
realisedPnl = previousRealisedPnl.plus((currentPrice - prevAvgEntryPrice) * previousSize)
    .minus(fees)
    .plus(netAccruedFundingSinceLastInteraction)
Unrealised = 0
Avg Entry Price = current price
```


### Position Closed:
```
realisedPnl = previousRealisedPnl.plus((currentPrice - avgEntryPrice) * previousSize)
    .minus(fees)
    .plus(netAccruedFundingSinceLastInteraction)
unrealised = 0
```
### Position Liquidated:
```
realisedPnl = (initialMargin + netTransfers) * -1
unrealised = 0
```

