### PR TITLE
Allow switching networks when wallet not yet connected

### DIFF
--- a/v3/ui/src/layouts/Default/NetworkController.tsx
+++ b/v3/ui/src/layouts/Default/NetworkController.tsx
@@ -1,11 +1,19 @@
 import { Button, Flex, Menu, MenuButton, MenuItem, MenuList, Text } from '@chakra-ui/react';
 import { ChevronDown, ChevronUp, WalletIcon } from '@snx-v3/icons';
-import { disconnect, NETWORKS, onboard, useWallet, useNetwork } from '@snx-v3/useBlockchain';
+import {
+  disconnect,
+  NETWORKS,
+  onboard,
+  useNetwork,
+  useSetNetwork,
+  useWallet,
+} from '@snx-v3/useBlockchain';
 import { prettyString } from '@snx-v3/format';
 
 export function NetworkController() {
   const wallet = useWallet();
   const activeNetwork = useNetwork();
+  const setNetwork = useSetNetwork();
   return (
     <Flex>
       <Menu>
@@ -13,7 +21,6 @@ export function NetworkController() {
           <>
             <MenuButton
               as={Button}
-              isDisabled={!Boolean(wallet)}
               variant="outline"
               colorScheme="gray"
               sx={{ '> span': { display: 'flex', alignItems: 'center' } }}
@@ -41,9 +48,7 @@ export function NetworkController() {
                   <MenuItem
                     key={network.name}
                     disabled={!network.isSupported}
-                    onClick={async () => {
-                      await onboard.setChain({ chainId: `0x${network.id.toString(16)}` });
-                    }}
+                    onClick={() => setNetwork(network)}
                   >
                     <network.Icon />
                     <Text variant="nav" ml={2}>


### PR DESCRIPTION
- After page refresh selection is preserved
- If walled connected and network switched inside wallet - that is preserved too (and will be restored if wallet is disconnected)

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/28145325/234478087-473cef7f-8468-4783-ad11-7e2591af84a7.png">

