### PR TITLE
Historical trade stats

### DIFF
--- a/v2/perps-v2/perps-subgraph/generated/schema.ts
+++ b/v2/perps-v2/perps-subgraph/generated/schema.ts
@@ -479,6 +479,318 @@ export class FuturesTrade extends Entity {
   }
 }
 
+export class DailyMarketStats extends Entity {
+  constructor(id: string) {
+    super();
+    this.set('id', Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get('id');
+    assert(id != null, 'Cannot save DailyMarketStats entity without an ID');
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type DailyMarketStats must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set('DailyMarketStats', id.toString(), this);
+    }
+  }
+
+  static load(id: string): DailyMarketStats | null {
+    return changetype<DailyMarketStats | null>(store.get('DailyMarketStats', id));
+  }
+
+  get id(): string {
+    let value = this.get('id');
+    return value!.toString();
+  }
+
+  set id(value: string) {
+    this.set('id', Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get('market');
+    return value!.toString();
+  }
+
+  set market(value: string) {
+    this.set('market', Value.fromString(value));
+  }
+
+  get day(): string {
+    let value = this.get('day');
+    return value!.toString();
+  }
+
+  set day(value: string) {
+    this.set('day', Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get('timestamp');
+    return value!.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set('timestamp', Value.fromBigInt(value));
+  }
+
+  get volume(): BigInt {
+    let value = this.get('volume');
+    return value!.toBigInt();
+  }
+
+  set volume(value: BigInt) {
+    this.set('volume', Value.fromBigInt(value));
+  }
+
+  get cumulativeVolume(): BigInt {
+    let value = this.get('cumulativeVolume');
+    return value!.toBigInt();
+  }
+
+  set cumulativeVolume(value: BigInt) {
+    this.set('cumulativeVolume', Value.fromBigInt(value));
+  }
+
+  get fees(): BigInt {
+    let value = this.get('fees');
+    return value!.toBigInt();
+  }
+
+  set fees(value: BigInt) {
+    this.set('fees', Value.fromBigInt(value));
+  }
+
+  get cumulativeFees(): BigInt {
+    let value = this.get('cumulativeFees');
+    return value!.toBigInt();
+  }
+
+  set cumulativeFees(value: BigInt) {
+    this.set('cumulativeFees', Value.fromBigInt(value));
+  }
+
+  get trades(): BigInt {
+    let value = this.get('trades');
+    return value!.toBigInt();
+  }
+
+  set trades(value: BigInt) {
+    this.set('trades', Value.fromBigInt(value));
+  }
+
+  get cumulativeTrades(): BigInt {
+    let value = this.get('cumulativeTrades');
+    return value!.toBigInt();
+  }
+
+  set cumulativeTrades(value: BigInt) {
+    this.set('cumulativeTrades', Value.fromBigInt(value));
+  }
+}
+
+export class DailyStats extends Entity {
+  constructor(id: string) {
+    super();
+    this.set('id', Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get('id');
+    assert(id != null, 'Cannot save DailyStats entity without an ID');
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type DailyStats must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set('DailyStats', id.toString(), this);
+    }
+  }
+
+  static load(id: string): DailyStats | null {
+    return changetype<DailyStats | null>(store.get('DailyStats', id));
+  }
+
+  get id(): string {
+    let value = this.get('id');
+    return value!.toString();
+  }
+
+  set id(value: string) {
+    this.set('id', Value.fromString(value));
+  }
+
+  get day(): string {
+    let value = this.get('day');
+    return value!.toString();
+  }
+
+  set day(value: string) {
+    this.set('day', Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get('timestamp');
+    return value!.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set('timestamp', Value.fromBigInt(value));
+  }
+
+  get volume(): BigInt {
+    let value = this.get('volume');
+    return value!.toBigInt();
+  }
+
+  set volume(value: BigInt) {
+    this.set('volume', Value.fromBigInt(value));
+  }
+
+  get cumulativeVolume(): BigInt {
+    let value = this.get('cumulativeVolume');
+    return value!.toBigInt();
+  }
+
+  set cumulativeVolume(value: BigInt) {
+    this.set('cumulativeVolume', Value.fromBigInt(value));
+  }
+
+  get fees(): BigInt {
+    let value = this.get('fees');
+    return value!.toBigInt();
+  }
+
+  set fees(value: BigInt) {
+    this.set('fees', Value.fromBigInt(value));
+  }
+
+  get cumulativeFees(): BigInt {
+    let value = this.get('cumulativeFees');
+    return value!.toBigInt();
+  }
+
+  set cumulativeFees(value: BigInt) {
+    this.set('cumulativeFees', Value.fromBigInt(value));
+  }
+
+  get trades(): BigInt {
+    let value = this.get('trades');
+    return value!.toBigInt();
+  }
+
+  set trades(value: BigInt) {
+    this.set('trades', Value.fromBigInt(value));
+  }
+
+  get cumulativeTrades(): BigInt {
+    let value = this.get('cumulativeTrades');
+    return value!.toBigInt();
+  }
+
+  set cumulativeTrades(value: BigInt) {
+    this.set('cumulativeTrades', Value.fromBigInt(value));
+  }
+
+  get newTraders(): BigInt {
+    let value = this.get('newTraders');
+    return value!.toBigInt();
+  }
+
+  set newTraders(value: BigInt) {
+    this.set('newTraders', Value.fromBigInt(value));
+  }
+
+  get existingTraders(): BigInt {
+    let value = this.get('existingTraders');
+    return value!.toBigInt();
+  }
+
+  set existingTraders(value: BigInt) {
+    this.set('existingTraders', Value.fromBigInt(value));
+  }
+
+  get cumulativeTraders(): BigInt {
+    let value = this.get('cumulativeTraders');
+    return value!.toBigInt();
+  }
+
+  set cumulativeTraders(value: BigInt) {
+    this.set('cumulativeTraders', Value.fromBigInt(value));
+  }
+}
+
+export class CumulativeMarketStats extends Entity {
+  constructor(id: string) {
+    super();
+    this.set('id', Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get('id');
+    assert(id != null, 'Cannot save CumulativeMarketStats entity without an ID');
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type CumulativeMarketStats must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set('CumulativeMarketStats', id.toString(), this);
+    }
+  }
+
+  static load(id: string): CumulativeMarketStats | null {
+    return changetype<CumulativeMarketStats | null>(store.get('CumulativeMarketStats', id));
+  }
+
+  get id(): string {
+    let value = this.get('id');
+    return value!.toString();
+  }
+
+  set id(value: string) {
+    this.set('id', Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get('market');
+    return value!.toString();
+  }
+
+  set market(value: string) {
+    this.set('market', Value.fromString(value));
+  }
+
+  get cumulativeFees(): BigInt {
+    let value = this.get('cumulativeFees');
+    return value!.toBigInt();
+  }
+
+  set cumulativeFees(value: BigInt) {
+    this.set('cumulativeFees', Value.fromBigInt(value));
+  }
+
+  get cumulativeVolume(): BigInt {
+    let value = this.get('cumulativeVolume');
+    return value!.toBigInt();
+  }
+
+  set cumulativeVolume(value: BigInt) {
+    this.set('cumulativeVolume', Value.fromBigInt(value));
+  }
+
+  get cumulativeTrades(): BigInt {
+    let value = this.get('cumulativeTrades');
+    return value!.toBigInt();
+  }
+
+  set cumulativeTrades(value: BigInt) {
+    this.set('cumulativeTrades', Value.fromBigInt(value));
+  }
+}
+
 export class Synthetix extends Entity {
   constructor(id: string) {
     super();
@@ -553,6 +865,15 @@ export class Synthetix extends Entity {
 
   set totalTraders(value: BigInt) {
     this.set('totalTraders', Value.fromBigInt(value));
+  }
+
+  get totalTrades(): BigInt {
+    let value = this.get('totalTrades');
+    return value!.toBigInt();
+  }
+
+  set totalTrades(value: BigInt) {
+    this.set('totalTrades', Value.fromBigInt(value));
   }
 }
 

--- a/v2/perps-v2/perps-subgraph/schema.graphql
+++ b/v2/perps-v2/perps-subgraph/schema.graphql
@@ -50,6 +50,43 @@ type FuturesTrade @entity {
   txHash: String!
 }
 
+type DailyMarketStats @entity {
+  "marketAddress-YYYY-MM-DD"
+  id: ID!
+  market: FuturesMarket!
+  day: String!
+  timestamp: BigInt!
+  volume: BigInt!
+  cumulativeVolume: BigInt!
+  fees: BigInt!
+  cumulativeFees: BigInt!
+  trades: BigInt!
+  cumulativeTrades: BigInt!
+}
+type DailyStats @entity {
+  "DailyStats-YYYY-MM-DD"
+  id: ID!
+  day: String!
+  timestamp: BigInt!
+  volume: BigInt!
+  cumulativeVolume: BigInt!
+  fees: BigInt!
+  cumulativeFees: BigInt!
+  trades: BigInt!
+  cumulativeTrades: BigInt!
+  newTraders: BigInt!
+  existingTraders: BigInt!
+  cumulativeTraders: BigInt!
+}
+
+type CumulativeMarketStats @entity {
+  "CumulativeMarketStats-marketAddress"
+  id: ID!
+  market: FuturesMarket!
+  cumulativeFees: BigInt!
+  cumulativeVolume: BigInt!
+  cumulativeTrades: BigInt!
+}
 type Synthetix @entity {
   id: ID!
   feesByLiquidations: BigInt!
@@ -57,6 +94,7 @@ type Synthetix @entity {
   totalLiquidations: BigInt!
   totalVolume: BigInt!
   totalTraders: BigInt!
+  totalTrades: BigInt!
 }
 
 type FuturesPosition @entity {

--- a/v2/perps-v2/perps-subgraph/src/historical-trade-stats.ts
+++ b/v2/perps-v2/perps-subgraph/src/historical-trade-stats.ts
@@ -1,0 +1,151 @@
+import { PositionModified1 as PositionModifiedNewEvent } from '../generated/FuturesMarketManagerNew/PerpsV2Proxy';
+import { BigInt } from '@graphprotocol/graph-ts';
+import {
+  CumulativeMarketStats,
+  DailyMarketStats,
+  DailyStats,
+  Synthetix,
+  Trader,
+} from '../generated/schema';
+import { calculateVolume } from './calculations';
+
+function timestampToDate(timestamp: BigInt): string {
+  const seconds = timestamp.toI32();
+  const milliseconds = seconds * 1000;
+  const date = new Date(milliseconds);
+  const year = date.getUTCFullYear();
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = date.getUTCDate().toString().padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+const getOrCreateDailyStat = (event: PositionModifiedNewEvent): DailyStats => {
+  const day = timestampToDate(event.block.timestamp);
+  const id = 'DailyStats-'.concat(day);
+  let synthetix = Synthetix.load('synthetix');
+
+  if (!synthetix) {
+    synthetix = new Synthetix('synthetix');
+    synthetix.totalVolume = BigInt.fromI32(0);
+    synthetix.feesByLiquidations = BigInt.fromI32(0);
+    synthetix.feesByPositionModifications = BigInt.fromI32(0);
+    synthetix.totalTraders = BigInt.fromI32(0);
+    synthetix.totalTrades = BigInt.fromI32(0);
+  }
+  let dailyStat = DailyStats.load(id);
+  if (dailyStat) return dailyStat;
+  dailyStat = new DailyStats(id);
+
+  dailyStat.timestamp = BigInt.fromI32(<i32>Math.floor(<i32>(Date.parse(day).getTime() / 1000)));
+  dailyStat.day = day;
+  dailyStat.volume = BigInt.fromI32(0);
+  dailyStat.fees = BigInt.fromI32(0);
+  dailyStat.trades = BigInt.fromI32(0);
+  dailyStat.cumulativeTraders = synthetix.totalTraders;
+  dailyStat.newTraders = BigInt.fromI32(0);
+  dailyStat.existingTraders = BigInt.fromI32(0);
+  dailyStat.cumulativeVolume = synthetix.totalVolume;
+
+  dailyStat.cumulativeFees = synthetix.feesByPositionModifications.plus(
+    synthetix.feesByLiquidations
+  );
+  dailyStat.cumulativeTrades = synthetix.totalTrades;
+  return dailyStat;
+};
+function updateDailyStats(event: PositionModifiedNewEvent): void {
+  if (event.params.tradeSize.equals(BigInt.fromI32(0))) return; // not a trade
+  const dailyStat = getOrCreateDailyStat(event);
+  const newVol = calculateVolume(event.params.tradeSize, event.params.lastPrice);
+  const newFee = event.params.fee;
+  const newTrades = BigInt.fromI32(1);
+  dailyStat.volume = dailyStat.volume.plus(newVol);
+  dailyStat.fees = dailyStat.fees.plus(newFee);
+  dailyStat.trades = dailyStat.trades.plus(BigInt.fromI32(1));
+
+  dailyStat.cumulativeVolume = dailyStat.cumulativeVolume.plus(newVol);
+  dailyStat.cumulativeFees = dailyStat.cumulativeFees.plus(newFee);
+  dailyStat.cumulativeTrades = dailyStat.cumulativeTrades.plus(newTrades);
+
+  let trader = Trader.load(event.params.account.toHex());
+  if (!trader) {
+    dailyStat.cumulativeTraders = dailyStat.cumulativeTraders.plus(BigInt.fromI32(1));
+    dailyStat.newTraders = dailyStat.newTraders.plus(BigInt.fromI32(1));
+  } else {
+    dailyStat.existingTraders = dailyStat.existingTraders.plus(BigInt.fromI32(1));
+  }
+  dailyStat.save();
+}
+const getOrCreateDailyMarketStat = (event: PositionModifiedNewEvent): DailyMarketStats => {
+  const day = timestampToDate(event.block.timestamp);
+  const id = event.address.toHex().toString().concat('-').concat(day);
+
+  let dailyMarketStat = DailyMarketStats.load(id);
+  if (dailyMarketStat) return dailyMarketStat;
+  dailyMarketStat = new DailyMarketStats(id);
+  dailyMarketStat.market = event.address.toHex();
+  dailyMarketStat.timestamp = BigInt.fromI32(
+    <i32>Math.floor(<i32>(Date.parse(day).getTime() / 1000))
+  );
+  dailyMarketStat.day = day;
+  dailyMarketStat.volume = BigInt.fromI32(0);
+  dailyMarketStat.fees = BigInt.fromI32(0);
+  dailyMarketStat.trades = BigInt.fromI32(0);
+
+  return dailyMarketStat;
+};
+function updateDailyMarketStats(event: PositionModifiedNewEvent): void {
+  const cumulativeMarketStats = CumulativeMarketStats.load(
+    'CumulativeMarketStats-'.concat(event.address.toHex())
+  );
+  if (!cumulativeMarketStats) {
+    throw new Error('Expect cumulativeMarketStats to exist');
+  }
+  if (event.params.tradeSize.equals(BigInt.fromI32(0))) return; // not a trade
+  const dailyMarketStat = getOrCreateDailyMarketStat(event);
+  // We expect cumulativeMarketStats to already be updated.
+  dailyMarketStat.cumulativeVolume = cumulativeMarketStats.cumulativeVolume;
+  dailyMarketStat.cumulativeFees = cumulativeMarketStats.cumulativeFees;
+  dailyMarketStat.cumulativeTrades = cumulativeMarketStats.cumulativeTrades;
+  dailyMarketStat.volume = dailyMarketStat.volume.plus(
+    calculateVolume(event.params.tradeSize, event.params.lastPrice)
+  );
+  dailyMarketStat.fees = dailyMarketStat.fees.plus(event.params.fee);
+  dailyMarketStat.trades = dailyMarketStat.trades.plus(BigInt.fromI32(1));
+
+  dailyMarketStat.save();
+}
+
+const getOrCreateCumulativeMarketStats = (marketAddress: string): CumulativeMarketStats => {
+  const id = 'CumulativeMarketStats-'.concat(marketAddress);
+
+  let cumulativeMarketStats = CumulativeMarketStats.load(id);
+  if (cumulativeMarketStats) return cumulativeMarketStats;
+  cumulativeMarketStats = new CumulativeMarketStats(id);
+  cumulativeMarketStats.market = marketAddress;
+  cumulativeMarketStats.cumulativeFees = BigInt.fromI32(0);
+  cumulativeMarketStats.cumulativeVolume = BigInt.fromI32(0);
+  cumulativeMarketStats.cumulativeTrades = BigInt.fromI32(0);
+  return cumulativeMarketStats;
+};
+
+function updateCumulativeMarketStats(event: PositionModifiedNewEvent): void {
+  const cumulativeMarketStats = getOrCreateCumulativeMarketStats(event.address.toHex());
+  cumulativeMarketStats.cumulativeFees = cumulativeMarketStats.cumulativeFees.plus(
+    event.params.fee
+  );
+  cumulativeMarketStats.cumulativeVolume = cumulativeMarketStats.cumulativeVolume.plus(
+    calculateVolume(event.params.tradeSize, event.params.lastPrice)
+  );
+
+  cumulativeMarketStats.cumulativeTrades = cumulativeMarketStats.cumulativeTrades.plus(
+    BigInt.fromI32(1)
+  );
+  cumulativeMarketStats.save();
+}
+
+export function updateHistoricalTradeStats(event: PositionModifiedNewEvent): void {
+  if (event.params.tradeSize.equals(BigInt.fromI32(0))) return; // not a trade
+  updateCumulativeMarketStats(event);
+  updateDailyStats(event);
+  updateDailyMarketStats(event);
+}

--- a/v2/perps-v2/perps-subgraph/src/position-modified.ts
+++ b/v2/perps-v2/perps-subgraph/src/position-modified.ts
@@ -115,7 +115,9 @@ function handlePositionOpenUpdates(
   positionId: string
 ): FuturesPosition {
   createTradeEntityForNewPosition(event, positionId);
-  synthetix.feesByPositionModifications = synthetix.feesByLiquidations.plus(event.params.fee);
+  synthetix.feesByPositionModifications = synthetix.feesByPositionModifications.plus(
+    event.params.fee
+  );
   const volume = calculateVolume(event.params.tradeSize, event.params.lastPrice);
 
   synthetix.totalVolume = synthetix.totalVolume.plus(volume);

--- a/v2/perps-v2/perps-subgraph/src/position-modified.ts
+++ b/v2/perps-v2/perps-subgraph/src/position-modified.ts
@@ -81,7 +81,7 @@ function createFuturesPosition(
   futuresPosition.avgEntryPrice = event.params.lastPrice;
   futuresPosition.feesPaidToSynthetix = event.params.fee;
   futuresPosition.netTransfers = BigInt.fromI32(0);
-  futuresPosition.initialMargin = event.params.margin;
+  futuresPosition.initialMargin = event.params.margin.minus(event.params.fee);
   futuresPosition.margin = event.params.margin;
   futuresPosition.realizedPnl = event.params.fee.times(BigInt.fromI32(-1));
   futuresPosition.unrealizedPnl = BigInt.fromI32(0);

--- a/v2/perps-v2/perps-subgraph/src/position-modified.ts
+++ b/v2/perps-v2/perps-subgraph/src/position-modified.ts
@@ -15,6 +15,7 @@ import {
   calculateAccruedPnlForReducingPositions,
   calculateVolume,
 } from './calculations';
+import { updateHistoricalTradeStats } from './historical-trade-stats';
 import {
   createTradeEntityForNewPosition,
   createTradeEntityForPositionClosed,
@@ -49,6 +50,7 @@ function getOrCreateSynthetix(): Synthetix {
     synthetix.totalLiquidations = BigInt.fromI32(0);
     synthetix.totalTraders = BigInt.fromI32(0);
     synthetix.totalVolume = BigInt.fromI32(0);
+    synthetix.totalTrades = BigInt.fromI32(0);
   }
   return synthetix;
 }
@@ -63,6 +65,7 @@ function updateTrades(event: PositionModifiedNewEvent, synthetix: Synthetix, tra
   if (trader.trades.length == 0) {
     synthetix.totalTraders = synthetix.totalTraders.plus(BigInt.fromI32(1));
   }
+  synthetix.totalTrades = synthetix.totalTrades.plus(BigInt.fromI32(1));
   const oldTrades = trader.trades;
   oldTrades.push(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
   trader.trades = oldTrades;
@@ -347,6 +350,7 @@ export function updateFunding(
   return BigInt.fromI32(0);
 }
 export function handlePositionModified(event: PositionModifiedNewEvent): void {
+  updateHistoricalTradeStats(event);
   const positionId = event.address.toHex() + '-' + event.params.id.toHex();
   let futuresPosition = FuturesPosition.load(positionId);
   let synthetix = getOrCreateSynthetix();

--- a/v2/perps-v2/perps-subgraph/src/position-modified.ts
+++ b/v2/perps-v2/perps-subgraph/src/position-modified.ts
@@ -57,6 +57,9 @@ function getOrCreateSynthetix(): Synthetix {
  * Mutative functions
  */
 function updateTrades(event: PositionModifiedNewEvent, synthetix: Synthetix, trader: Trader): void {
+  if (event.params.tradeSize.equals(BigInt.fromI32(0))) {
+    return;
+  }
   if (trader.trades.length == 0) {
     synthetix.totalTraders = synthetix.totalTraders.plus(BigInt.fromI32(1));
   }

--- a/v2/perps-v2/perps-subgraph/tests/historical-trade-stats.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/historical-trade-stats.test.ts
@@ -1,0 +1,377 @@
+import { Address } from '@graphprotocol/graph-ts';
+import { BigInt } from '@graphprotocol/graph-ts';
+import { assert, clearStore, describe, log, logStore, test, afterEach } from 'matchstick-as';
+import { Trader } from '../generated/schema';
+import { handlePositionModified } from '../src/position-modified';
+import { createPositionModifiedEvent, toEth, toGwei } from './perpsV2-utils';
+const trader = '0x1234567890123456789012345678901234567890';
+const trader1 = '0x1234567890123456789012345678901234567891';
+describe('calculateAccruedFunding', () => {
+  afterEach(() => {
+    clearStore();
+  });
+  test('updateHistoricalTradeStats', () => {
+    const timestampDay1 = 10;
+    const timestampDay2 = 86410; // 1 day and 10 seconds
+    const timestampDay4 = 259210; // 3 days and 10 seconds
+
+    const events = [
+      createPositionModifiedEvent(
+        BigInt.fromI32(1), //id
+        Address.fromString(trader), //account
+        toEth(5), //margin
+        toEth(2), //size
+        toEth(2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), //fee
+        timestampDay1, // timestamp
+        BigInt.fromI32(12), //skew
+        1 //logIndex
+      ),
+      createPositionModifiedEvent(
+        BigInt.fromI32(2), //id
+        Address.fromString(trader), //account
+        toEth(5), //margin
+        toEth(4), //size
+        toEth(2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), //fee
+        timestampDay1, // timestamp
+        BigInt.fromI32(12), //skew
+        2 //logIndex
+      ),
+      createPositionModifiedEvent(
+        BigInt.fromI32(3), //id
+        Address.fromString(trader), //account
+        toEth(5), //margin
+        toEth(6), //size
+        toEth(2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), //fee
+        timestampDay2, // timestamp
+        BigInt.fromI32(12), //skew
+        3 //logIndex
+      ),
+      createPositionModifiedEvent(
+        BigInt.fromI32(4), //id
+        Address.fromString(trader), //account
+        toEth(5), //margin
+        toEth(8), //size
+        toEth(2), // trade size
+        toEth(1000), // last price
+        BigInt.fromI32(1), // funding index
+        toGwei(1000000000), //fee
+        timestampDay4, // timestamp
+        BigInt.fromI32(12), //skew
+        4 //logIndex
+      ),
+    ];
+
+    for (let i = 0; i < events.length; i++) {
+      // we call handlePositionModified instead of updateHistoricalTradeStats so that other entires, like Trader and Synthetix are created/ updated
+      handlePositionModified(events[i]);
+    }
+
+    // Check DailyStats for Day 1
+    const idDay1 = 'DailyStats-1970-01-01';
+    assert.fieldEquals('DailyStats', idDay1, 'volume', toEth(4000).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'fees', toGwei(2000000000).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'trades', BigInt.fromI32(2).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'newTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'existingTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'cumulativeFees', toGwei(2000000000).toString());
+
+    // Check DailyStats for Day 2
+    const idDay2 = 'DailyStats-1970-01-02';
+    assert.fieldEquals('DailyStats', idDay2, 'volume', toEth(2000).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'fees', toGwei(1000000000).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'trades', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'newTraders', BigInt.fromI32(0).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'existingTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'cumulativeVolume', toEth(6000).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'cumulativeFees', toGwei(3000000000).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'cumulativeTrades', BigInt.fromI32(3).toString());
+
+    // Check DailyStats for Day 4
+    const idDay4 = 'DailyStats-1970-01-04';
+    assert.fieldEquals('DailyStats', idDay4, 'volume', toEth(2000).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'fees', toGwei(1000000000).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'trades', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'newTraders', BigInt.fromI32(0).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'existingTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'cumulativeVolume', toEth(8000).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'cumulativeFees', toGwei(4000000000).toString());
+    assert.fieldEquals('DailyStats', idDay4, 'cumulativeTrades', BigInt.fromI32(4).toString());
+
+    // Check DailyMarketStats for Day 1
+    const marketIdDay1 = events[0].address.toHex().toString().concat('-1970-01-01');
+    assert.fieldEquals('DailyMarketStats', marketIdDay1, 'market', events[0].address.toHex());
+    assert.fieldEquals('DailyMarketStats', marketIdDay1, 'volume', toEth(4000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay1, 'fees', toGwei(2000000000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay1, 'trades', BigInt.fromI32(2).toString());
+
+    // Check DailyMarketStats for Day 2
+    const marketIdDay2 = events[0].address.toHex().toString().concat('-1970-01-02');
+    assert.fieldEquals('DailyMarketStats', marketIdDay2, 'volume', toEth(2000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay2, 'fees', toGwei(1000000000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay2, 'trades', BigInt.fromI32(1).toString());
+
+    // Check DailyMarketStats for Day 4
+    const marketIdDay4 = events[0].address.toHex().toString().concat('-1970-01-04');
+    assert.fieldEquals('DailyMarketStats', marketIdDay4, 'volume', toEth(2000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay4, 'fees', toGwei(1000000000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay4, 'trades', BigInt.fromI32(1).toString());
+    // Check CumulativeMarketStats
+    const marketAddress = events[0].address.toHex().toString();
+    const id = 'CumulativeMarketStats-' + marketAddress;
+
+    assert.fieldEquals('CumulativeMarketStats', id, 'cumulativeVolume', toEth(8000).toString());
+    assert.fieldEquals(
+      'CumulativeMarketStats',
+      id,
+      'cumulativeFees',
+      toGwei(4000000000).toString()
+    );
+    assert.fieldEquals(
+      'CumulativeMarketStats',
+      id,
+      'cumulativeTrades',
+      BigInt.fromI32(4).toString()
+    );
+  });
+  test('Ensure trades on different markets works', () => {
+    // Create two events for different markets and different days
+    const event1 = createPositionModifiedEvent(
+      BigInt.fromI32(1), // id
+      Address.fromString(trader), //account
+      toEth(5), // margin
+      toEth(2), // size
+      toEth(2), //trade size
+      toEth(1000), // last price
+      BigInt.fromI32(1), // funding index
+      toGwei(1000000000), // fee
+      10, // timestamp
+      BigInt.fromI32(12), // skew
+      1 // logIndex
+    );
+    const differentMarketAddress = '0xa16081f360e3847006db660bae1c6d1b2e17ec2b';
+    const event2 = createPositionModifiedEvent(
+      BigInt.fromI32(2), // id
+      Address.fromString(trader), //account
+      toEth(6), // margin
+      toEth(5), // size
+      toEth(3), //trade size
+      toEth(1500), // last price
+      BigInt.fromI32(1), // funding index
+      toGwei(1500000000), // fee
+      60 * 60 * 24 + 10, // One day later
+      BigInt.fromI32(15), // skew
+      2, // logIndex
+      Address.fromString(differentMarketAddress)
+    );
+    const event3 = createPositionModifiedEvent(
+      BigInt.fromI32(2), // id
+      Address.fromString(trader), //account
+      toEth(6), // margin
+      toEth(6), // size
+      toEth(1), //trade size
+      toEth(1500), // last price
+      BigInt.fromI32(1), // funding index
+      toGwei(1500000000), // fee
+      60 * 60 * 24 + 10 + 10000, // Even later
+      BigInt.fromI32(15), // skew
+      2 // logIndex
+    );
+
+    // Process the events
+    handlePositionModified(event1);
+    handlePositionModified(event2);
+    handlePositionModified(event3);
+
+    // // Check DailyStats
+    const idDay1 = 'DailyStats-1970-01-01';
+    const idDay2 = 'DailyStats-1970-01-02';
+
+    assert.fieldEquals('DailyStats', idDay1, 'volume', toEth(2000).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'volume', toEth(6000).toString());
+
+    // Check DailyMarketStats for event1 and event2
+    const marketIdDay1Event1 = event1.address.toHex().toString().concat('-1970-01-01');
+    const marketIdDay2Event2 = event2.address.toHex().toString().concat('-1970-01-02');
+    const marketIdDay2Event3 = event3.address.toHex().toString().concat('-1970-01-02');
+
+    assert.fieldEquals('DailyMarketStats', marketIdDay1Event1, 'volume', toEth(2000).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay2Event2, 'volume', toEth(4500).toString());
+    assert.fieldEquals('DailyMarketStats', marketIdDay2Event3, 'volume', toEth(1500).toString());
+
+    // Check CumulativeMarketStats for event1 and event2
+    const defaultMarketId = 'CumulativeMarketStats-'.concat(event1.address.toHex().toString());
+    const differentMarketId = 'CumulativeMarketStats-'.concat(differentMarketAddress);
+
+    assert.fieldEquals(
+      'CumulativeMarketStats',
+      defaultMarketId,
+      'cumulativeVolume',
+      toEth(3500).toString()
+    );
+    assert.fieldEquals('CumulativeMarketStats', defaultMarketId, 'market', event1.address.toHex());
+    assert.fieldEquals(
+      'CumulativeMarketStats',
+      differentMarketId,
+      'cumulativeVolume',
+      toEth(4500).toString()
+    );
+    assert.fieldEquals(
+      'CumulativeMarketStats',
+      differentMarketId,
+      'market',
+      event2.address.toHex()
+    );
+  });
+  test('Daily stats updated for two new traders', () => {
+    // Create two events for the same day with different traders
+    const event1 = createPositionModifiedEvent(
+      BigInt.fromI32(1), // id
+      Address.fromString(trader), //account
+      toEth(5), // margin
+      toEth(2), // size
+      toEth(2), //trade size
+      toEth(1000), //  last price
+      BigInt.fromI32(1), //  funding index
+      toGwei(1000000000), //  fee
+      10, //  timestamp
+      BigInt.fromI32(12), // skew
+      1 // logIndex
+    );
+
+    const event2 = createPositionModifiedEvent(
+      BigInt.fromI32(2), // id
+      Address.fromString(trader1), // account
+      toEth(7), // margin
+      toEth(3), // size
+      toEth(3), // trade size
+      toEth(1500), // last price
+      BigInt.fromI32(1), // funding index
+      toGwei(1000000000), // fee
+      10, // timestamp
+      BigInt.fromI32(15), // skew
+      2 // logIndex
+    );
+
+    handlePositionModified(event1);
+    handlePositionModified(event2);
+
+    // Get the day string
+    const day = '1970-01-01';
+    const id = 'DailyStats-'.concat(day);
+
+    // Check if traders are created correctly in DailyStats
+    assert.fieldEquals('DailyStats', id, 'cumulativeTraders', BigInt.fromI32(2).toString());
+    assert.fieldEquals('DailyStats', id, 'newTraders', BigInt.fromI32(2).toString());
+    assert.fieldEquals('DailyStats', id, 'existingTraders', BigInt.fromI32(0).toString());
+
+    // Check if Trader entities are created correctly
+    const traderEntity1 = Trader.load(trader);
+    const traderEntity2 = Trader.load(trader1);
+    assert.assertNotNull(traderEntity1);
+    assert.assertNotNull(traderEntity2);
+  });
+  test('Daily stats updated for 1 trader which trades over multiple days', () => {
+    // Create two events for the same day with the same trader
+    const event1 = createPositionModifiedEvent(
+      BigInt.fromI32(1),
+      Address.fromString(trader1),
+      toEth(5),
+      toEth(2),
+      toEth(2),
+      toEth(1000),
+      BigInt.fromI32(1),
+      toGwei(1000000000),
+      10,
+      BigInt.fromI32(12),
+      1
+    );
+
+    const event2 = createPositionModifiedEvent(
+      BigInt.fromI32(2),
+      Address.fromString(trader1),
+      toEth(7),
+      toEth(3),
+      toEth(3),
+      toEth(1500),
+      BigInt.fromI32(1),
+      toGwei(1000000000),
+      10,
+      BigInt.fromI32(15),
+      2
+    );
+    const event3 = createPositionModifiedEvent(
+      BigInt.fromI32(2),
+      Address.fromString(trader1),
+      toEth(7),
+      toEth(3),
+      toEth(3),
+      toEth(1500),
+      BigInt.fromI32(1),
+      toGwei(1000000000),
+      60 * 60 * 24 + 10, // 1 day later
+      BigInt.fromI32(15),
+      2
+    );
+
+    handlePositionModified(event1);
+    handlePositionModified(event2);
+    handlePositionModified(event3);
+
+    // Get the day string
+    const idDay1 = 'DailyStats-1970-01-01';
+    const idDay2 = 'DailyStats-1970-01-02';
+
+    // Day1 Check if existingTraders is incremented correctly in DailyStats
+    assert.fieldEquals('DailyStats', idDay1, 'cumulativeTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'newTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay1, 'existingTraders', BigInt.fromI32(1).toString());
+    // Day2 Check if existingTraders is incremented correctly in DailyStats
+    assert.fieldEquals('DailyStats', idDay2, 'cumulativeTraders', BigInt.fromI32(1).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'newTraders', BigInt.fromI32(0).toString());
+    assert.fieldEquals('DailyStats', idDay2, 'existingTraders', BigInt.fromI32(1).toString());
+
+    // Check if Trader entity is updated correctly
+    const traderEntity = Trader.load(trader1);
+    assert.assertNotNull(traderEntity);
+  });
+
+  test('make sure postition modification with a trade size of 0 gets ignored', () => {
+    // Create the event
+    const event = createPositionModifiedEvent(
+      BigInt.fromI32(1), // id
+      Address.fromString(trader), // account
+      toEth(5), // margin
+      toEth(2), // size
+      toEth(0), // trade size (set to 0)
+      toEth(1000), // last price
+      BigInt.fromI32(1), // funding index
+      toGwei(1000000000), // fee
+      10, // timestamp
+      BigInt.fromI32(12), // skew
+      1 // log index
+    );
+
+    // Process the event
+    handlePositionModified(event);
+
+    // Define the day and id
+    const day = '1970-01-01';
+    const dailyStatsId = 'DailyStats-'.concat(day);
+    const dailyMarketStatsId = 'DailyMarketStats-'.concat(day);
+    const cumulativeMarketStatsId = 'CumulativeMarketStats-'.concat(day);
+
+    // Check that the entities have not been created
+    assert.notInStore('DailyStats', dailyStatsId);
+    assert.notInStore('DailyMarketStats', dailyMarketStatsId);
+    assert.notInStore('CumulativeMarketStats', cumulativeMarketStatsId);
+  });
+});

--- a/v2/perps-v2/perps-subgraph/tests/perpsV2-utils.ts
+++ b/v2/perps-v2/perps-subgraph/tests/perpsV2-utils.ts
@@ -36,9 +36,12 @@ export function createPositionModifiedEvent(
   fee: BigInt,
   timestamp: i64,
   skew: BigInt = BigInt.fromI32(200),
-  logIndex: i64 = 0
+  logIndex: i64 = 0,
+  marketAddress: Address = Address.fromString('0xA16081F360e3847006dB660bae1c6d1b2e17eC2A')
 ): positionModifiedEventNew {
   let positionModifiedEvent = changetype<positionModifiedEventNew>(newMockEvent());
+
+  positionModifiedEvent.address = marketAddress;
   positionModifiedEvent.parameters = new Array();
   const block = createBlock(timestamp, 5);
   positionModifiedEvent.parameters.push(

--- a/v2/perps-v2/perps-subgraph/tests/perpsV2.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/perpsV2.test.ts
@@ -190,7 +190,7 @@ describe('Perps V2', () => {
       'FuturesPosition',
       `${modifyPositionEvent.address.toHex() + '-' + '0x1'}`,
       'initialMargin',
-      toEth(5).toString()
+      '4999999999000000000' // margin sent from contract minus fee
     );
     assert.fieldEquals(
       'FuturesPosition',


### PR DESCRIPTION
This adds a three new entities:
`DailyMarketStats`
`DailyStats`
`CumulativeMarketStats`

This should be enough to create most of the charts on the dashboard designs.
We could also add:
Monthly stats
MonhtlyMarket stats
if we want to avoid aggregations on the frontend.

As I was working on historical stats I found some bugs a long the way:

- Dont update trades if tradesize is 0, this means it's not a trade.
- Correct initialMargin
- Correct update of fesByPositionModification