### PR TITLE
Fix missing order trade relation

### DIFF
--- a/v2/perps-v2/perps-subgraph/generated/schema.ts
+++ b/v2/perps-v2/perps-subgraph/generated/schema.ts
@@ -494,6 +494,15 @@ export class FuturesTrade extends Entity {
   set txHash(value: string) {
     this.set('txHash', Value.fromString(value));
   }
+
+  get marketOrder(): boolean {
+    let value = this.get('marketOrder');
+    return value!.toBoolean();
+  }
+
+  set marketOrder(value: boolean) {
+    this.set('marketOrder', Value.fromBoolean(value));
+  }
 }
 
 export class DailyMarketStat extends Entity {

--- a/v2/perps-v2/perps-subgraph/schema.graphql
+++ b/v2/perps-v2/perps-subgraph/schema.graphql
@@ -49,6 +49,7 @@ type FuturesTrade @entity {
   feesPaidToSynthetix: BigInt!
   type: FuturesTradeType!
   txHash: String!
+  marketOrder: Boolean!
 }
 
 type DailyMarketStat @entity {

--- a/v2/perps-v2/perps-subgraph/src/futures.ts
+++ b/v2/perps-v2/perps-subgraph/src/futures.ts
@@ -107,12 +107,7 @@ export function handleMarginTransferred(event: MarginTransferredEvent): void {
     trader.realizedPnl = BigInt.fromI32(0);
     synthetix.totalTraders = synthetix.totalTraders.plus(BigInt.fromI32(0));
   } else {
-    // trader.margin = trader.margin.plus(event.params.marginDelta);
-    if (event.params.marginDelta.gt(BigInt.fromI32(0))) {
-      trader.margin = trader.margin.plus(event.params.marginDelta);
-    } else if (event.params.marginDelta.lt(BigInt.fromI32(0))) {
-      trader.margin = trader.margin.minus(event.params.marginDelta);
-    }
+    trader.margin = trader.margin.plus(event.params.marginDelta);
   }
   marginTransferEntity.save();
   synthetix.save();

--- a/v2/perps-v2/perps-subgraph/src/futures.ts
+++ b/v2/perps-v2/perps-subgraph/src/futures.ts
@@ -1,32 +1,30 @@
-import { Address, BigInt, DataSourceContext, ethereum } from '@graphprotocol/graph-ts';
-import { PerpetualFuturesMarket } from '../generated/templates';
+import { Address, BigInt, DataSourceContext } from '@graphprotocol/graph-ts';
 import {
   DelayedOrderRemoved as DelayedOrderRemovedEvent,
   DelayedOrderSubmitted as DelayedOrderSubmittedEvent,
   FundingRecomputed as FundingRecomputedEvent,
-  PositionLiquidated as PositionLiquidatedEventLegacy,
-  PositionLiquidated1 as PositionLiquidatedEvent,
   MarginTransferred as MarginTransferredEvent,
   MarketAdded as MarketAddedEvent,
   MarketRemoved as MarketRemovedEvent,
   PerpsTracking as PerpsTrackingEvent,
-  PositionFlagged1 as PositionFlaggedEventOld,
   PositionFlagged as PositionFlaggedEventNew,
+  PositionFlagged1 as PositionFlaggedEventOld,
 } from '../generated/FuturesMarketManagerNew/PerpsV2Proxy';
 import {
-  PositionLiquidated,
-  Trader,
-  Synthetix,
-  FuturesPosition,
-  FuturesOrder,
-  FuturesTrade,
+  Frontend,
   FundingRateUpdate,
   FuturesMarginTransfer,
   FuturesMarket,
-  Frontend,
+  FuturesOrder,
+  FuturesPosition,
+  FuturesTrade,
   PositionFlagged,
+  Synthetix,
+  Trader,
 } from '../generated/schema';
+import { PerpetualFuturesMarket } from '../generated/templates';
 import { updateFeeStats } from './historical-trade-stats';
+export * from './liquidation';
 export { handlePositionModified } from './position-modified';
 
 export function handleFuturesMarketAdded(event: MarketAddedEvent): void {
@@ -74,153 +72,6 @@ export function handlePositionFlaggedOld(event: PositionFlaggedEventOld): void {
   positionFlaggedEntity.save();
 }
 
-export function handlePositionLiquidatedLegacy(event: PositionLiquidatedEventLegacy): void {
-  const futuresPositionId = event.address.toHex() + '-' + event.params.id.toHex();
-  const positionLiquidatedEntity = new PositionLiquidated(event.params.id.toString());
-  positionLiquidatedEntity.trader = event.params.account.toHex();
-  positionLiquidatedEntity.market = event.address.toHex();
-  positionLiquidatedEntity.liquidator = event.params.liquidator;
-  positionLiquidatedEntity.size = event.params.size;
-  positionLiquidatedEntity.price = event.params.price;
-  positionLiquidatedEntity.fee = event.params.fee;
-  positionLiquidatedEntity.futuresPosition = futuresPositionId;
-  positionLiquidatedEntity.timestamp = event.block.timestamp;
-  positionLiquidatedEntity.txHash = event.transaction.hash.toHex();
-  positionLiquidatedEntity.save();
-
-  const futuresPosition = FuturesPosition.load(futuresPositionId);
-
-  let feeForSynthetix = BigInt.fromI32(0);
-
-  if (futuresPosition && futuresPosition.margin.gt(BigInt.fromI32(1000).pow(18))) {
-    feeForSynthetix = event.params.fee.minus(BigInt.fromI32(1002).pow(18));
-  } else {
-    const ninetyPercent = event.params.fee
-      .times(BigInt.fromI32(90).pow(18))
-      .div(BigInt.fromI32(100).pow(18));
-    feeForSynthetix = event.params.fee.minus(ninetyPercent);
-  }
-
-  if (futuresPosition) {
-    futuresPosition.isLiquidated = true;
-    futuresPosition.isOpen = false;
-    futuresPosition.closeTimestamp = event.block.timestamp;
-    futuresPosition.feesPaidToSynthetix = futuresPosition.feesPaidToSynthetix.plus(feeForSynthetix);
-    futuresPosition.exitPrice = event.params.price;
-    futuresPosition.save();
-  }
-
-  const tradeEntity = FuturesTrade.load(
-    event.transaction.hash.toHex() + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString()
-  );
-  if (tradeEntity) {
-    tradeEntity.size = event.params.size.times(BigInt.fromI32(-1));
-    tradeEntity.positionClosed = true;
-    tradeEntity.timestamp = event.block.timestamp;
-    tradeEntity.trader = event.params.account.toHex();
-    tradeEntity.futuresPosition = futuresPositionId;
-    tradeEntity.price = event.params.price;
-    tradeEntity.txHash = event.transaction.hash.toHex();
-    tradeEntity.positionSize = BigInt.fromI32(0);
-    tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(feeForSynthetix);
-
-    // TODO make sure this is correct. I think we need to subtract something else.
-    tradeEntity.realizedPnl = tradeEntity.realizedPnl
-      .minus(event.params.fee)
-      .minus(tradeEntity.netFunding); // you loose funding when liquidated
-    tradeEntity.netFunding = BigInt.fromI32(0);
-    tradeEntity.type = 'Liquidated';
-    tradeEntity.save();
-  }
-  updateFeeStats(feeForSynthetix, event.address, event.block.timestamp);
-
-  const synthetix = Synthetix.load('synthetix');
-  if (synthetix) {
-    synthetix.feesByLiquidations = synthetix.feesByLiquidations.plus(feeForSynthetix);
-    synthetix.totalLiquidations = synthetix.totalLiquidations.plus(BigInt.fromI32(1));
-    synthetix.save();
-  }
-
-  let trader = Trader.load(event.params.account.toHex());
-  if (trader) {
-    trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(feeForSynthetix);
-    trader.totalLiquidations = trader.totalLiquidations.plus(BigInt.fromI32(1));
-    trader.totalMarginLiquidated = trader.totalMarginLiquidated.plus(event.params.size);
-    trader.margin = trader.margin.minus(event.params.size);
-    trader.save();
-  }
-}
-
-export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
-  const futuresPositionId = event.address.toHex() + '-' + event.params.id.toHex();
-  const positionLiquidatedEntity = new PositionLiquidated(event.params.id.toString());
-  positionLiquidatedEntity.trader = event.params.account.toHex();
-  positionLiquidatedEntity.market = event.address.toHex();
-  positionLiquidatedEntity.liquidator = event.params.liquidator;
-  positionLiquidatedEntity.size = event.params.size;
-  positionLiquidatedEntity.price = event.params.price;
-  positionLiquidatedEntity.fee = event.params.stakersFee.plus(
-    event.params.flaggerFee.plus(event.params.liquidatorFee)
-  );
-  positionLiquidatedEntity.futuresPosition = futuresPositionId;
-  positionLiquidatedEntity.timestamp = event.block.timestamp;
-  positionLiquidatedEntity.txHash = event.transaction.hash.toHex();
-  positionLiquidatedEntity.save();
-
-  const tradeEntity = FuturesTrade.load(
-    event.transaction.hash.toHex() + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString()
-  );
-  if (tradeEntity) {
-    tradeEntity.size = event.params.size.times(BigInt.fromI32(-1));
-    tradeEntity.positionClosed = true;
-    tradeEntity.timestamp = event.block.timestamp;
-    tradeEntity.trader = event.params.account.toHex();
-    tradeEntity.futuresPosition = futuresPositionId;
-    tradeEntity.price = event.params.price;
-    tradeEntity.txHash = event.transaction.hash.toHex();
-    tradeEntity.positionSize = BigInt.fromI32(0);
-    tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(event.params.stakersFee);
-
-    // TODO make sure this is correct. I think we need to subtract something else.
-    tradeEntity.realizedPnl = tradeEntity.realizedPnl
-      .minus(event.params.stakersFee.plus(event.params.liquidatorFee).plus(event.params.flaggerFee))
-      .minus(tradeEntity.netFunding); // you loose funding when liquidated
-    tradeEntity.netFunding = BigInt.fromI32(0);
-    tradeEntity.type = 'Liquidated';
-    tradeEntity.save();
-  }
-
-  updateFeeStats(event.params.stakersFee, event.address, event.block.timestamp);
-
-  const synthetix = Synthetix.load('synthetix');
-  if (synthetix) {
-    synthetix.feesByLiquidations = synthetix.feesByLiquidations.plus(event.params.stakersFee);
-    synthetix.totalLiquidations = synthetix.totalLiquidations.plus(BigInt.fromI32(1));
-    synthetix.save();
-  }
-
-  const futuresPosition = FuturesPosition.load(futuresPositionId);
-  if (futuresPosition) {
-    futuresPosition.isLiquidated = true;
-    futuresPosition.isOpen = false;
-    futuresPosition.closeTimestamp = event.block.timestamp;
-    futuresPosition.feesPaidToSynthetix = futuresPosition.feesPaidToSynthetix.plus(
-      event.params.stakersFee
-    );
-    futuresPosition.exitPrice = event.params.price;
-    futuresPosition.save();
-  }
-
-  let trader = Trader.load(event.params.account.toHex());
-  if (trader) {
-    trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(event.params.stakersFee);
-    trader.totalLiquidations = trader.totalLiquidations.plus(BigInt.fromI32(1));
-    trader.totalMarginLiquidated = trader.totalMarginLiquidated.plus(event.params.size);
-    trader.margin = trader.margin.minus(event.params.size);
-    trader.save();
-  }
-}
-
 export function handleMarginTransferred(event: MarginTransferredEvent): void {
   let trader = Trader.load(event.params.account.toHex());
   let synthetix = Synthetix.load('synthetix');
@@ -256,6 +107,7 @@ export function handleMarginTransferred(event: MarginTransferredEvent): void {
     trader.realizedPnl = BigInt.fromI32(0);
     synthetix.totalTraders = synthetix.totalTraders.plus(BigInt.fromI32(0));
   } else {
+    // trader.margin = trader.margin.plus(event.params.marginDelta);
     if (event.params.marginDelta.gt(BigInt.fromI32(0))) {
       trader.margin = trader.margin.plus(event.params.marginDelta);
     } else if (event.params.marginDelta.lt(BigInt.fromI32(0))) {

--- a/v2/perps-v2/perps-subgraph/src/liquidation.ts
+++ b/v2/perps-v2/perps-subgraph/src/liquidation.ts
@@ -1,0 +1,164 @@
+import { BigInt, log } from '@graphprotocol/graph-ts';
+import {
+  PositionLiquidated as PositionLiquidatedEventLegacy,
+  PositionLiquidated1 as PositionLiquidatedEvent,
+} from '../generated/FuturesMarketManagerNew/PerpsV2Proxy';
+import {
+  FuturesPosition,
+  FuturesTrade,
+  PositionLiquidated,
+  Synthetix,
+  Trader,
+} from '../generated/schema';
+import { updateFeeStats } from './historical-trade-stats';
+export { handlePositionModified } from './position-modified';
+
+export function handlePositionLiquidatedLegacy(event: PositionLiquidatedEventLegacy): void {
+  log.info('handlePositionLiquidatedLegacy', []);
+  const futuresPositionId = event.address.toHex() + '-' + event.params.id.toHex();
+  const positionLiquidatedEntity = new PositionLiquidated(event.params.id.toString());
+  positionLiquidatedEntity.trader = event.params.account.toHex();
+  positionLiquidatedEntity.market = event.address.toHex();
+  positionLiquidatedEntity.liquidator = event.params.liquidator;
+  positionLiquidatedEntity.size = event.params.size;
+  positionLiquidatedEntity.price = event.params.price;
+  positionLiquidatedEntity.fee = event.params.fee;
+  positionLiquidatedEntity.futuresPosition = futuresPositionId;
+  positionLiquidatedEntity.timestamp = event.block.timestamp;
+  positionLiquidatedEntity.txHash = event.transaction.hash.toHex();
+  positionLiquidatedEntity.save();
+
+  const futuresPosition = FuturesPosition.load(futuresPositionId);
+
+  let feeForSynthetix = BigInt.fromI32(0);
+
+  if (futuresPosition && futuresPosition.margin.gt(BigInt.fromI32(1000).pow(18))) {
+    feeForSynthetix = event.params.fee.minus(BigInt.fromI32(1002).pow(18));
+  } else {
+    const ninetyPercent = event.params.fee
+      .times(BigInt.fromI32(90).pow(18))
+      .div(BigInt.fromI32(100).pow(18));
+    feeForSynthetix = event.params.fee.minus(ninetyPercent);
+  }
+
+  if (futuresPosition) {
+    futuresPosition.isLiquidated = true;
+    futuresPosition.isOpen = false;
+    futuresPosition.closeTimestamp = event.block.timestamp;
+    futuresPosition.feesPaidToSynthetix = futuresPosition.feesPaidToSynthetix.plus(feeForSynthetix);
+    futuresPosition.exitPrice = event.params.price;
+    futuresPosition.save();
+  }
+
+  const tradeEntity = FuturesTrade.load(
+    event.transaction.hash.toHex() + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString()
+  );
+  if (tradeEntity) {
+    tradeEntity.size = event.params.size.times(BigInt.fromI32(-1));
+    tradeEntity.positionClosed = true;
+    tradeEntity.timestamp = event.block.timestamp;
+    tradeEntity.trader = event.params.account.toHex();
+    tradeEntity.futuresPosition = futuresPositionId;
+    tradeEntity.price = event.params.price;
+    tradeEntity.txHash = event.transaction.hash.toHex();
+    tradeEntity.positionSize = BigInt.fromI32(0);
+    tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(feeForSynthetix);
+
+    // TODO make sure this is correct. I think we need to subtract something else.
+    tradeEntity.realizedPnl = tradeEntity.realizedPnl
+      .minus(event.params.fee)
+      .minus(tradeEntity.netFunding); // you loose funding when liquidated
+    tradeEntity.netFunding = BigInt.fromI32(0);
+    tradeEntity.type = 'Liquidated';
+    tradeEntity.save();
+  }
+  updateFeeStats(feeForSynthetix, event.address, event.block.timestamp);
+
+  const synthetix = Synthetix.load('synthetix');
+  if (synthetix) {
+    synthetix.feesByLiquidations = synthetix.feesByLiquidations.plus(feeForSynthetix);
+    synthetix.totalLiquidations = synthetix.totalLiquidations.plus(BigInt.fromI32(1));
+    synthetix.save();
+  }
+
+  let trader = Trader.load(event.params.account.toHex());
+  if (trader) {
+    trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(feeForSynthetix);
+    trader.totalLiquidations = trader.totalLiquidations.plus(BigInt.fromI32(1));
+    trader.totalMarginLiquidated = trader.totalMarginLiquidated.plus(event.params.size);
+    trader.margin = trader.margin.minus(event.params.size);
+    trader.save();
+  }
+}
+
+export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
+  log.info('handlePositionLiquidated', []);
+  const futuresPositionId = event.address.toHex() + '-' + event.params.id.toHex();
+  const positionLiquidatedEntity = new PositionLiquidated(event.params.id.toString());
+  positionLiquidatedEntity.trader = event.params.account.toHex();
+  positionLiquidatedEntity.market = event.address.toHex();
+  positionLiquidatedEntity.liquidator = event.params.liquidator;
+  positionLiquidatedEntity.size = event.params.size;
+  positionLiquidatedEntity.price = event.params.price;
+  positionLiquidatedEntity.fee = event.params.stakersFee.plus(
+    event.params.flaggerFee.plus(event.params.liquidatorFee)
+  );
+  positionLiquidatedEntity.futuresPosition = futuresPositionId;
+  positionLiquidatedEntity.timestamp = event.block.timestamp;
+  positionLiquidatedEntity.txHash = event.transaction.hash.toHex();
+  positionLiquidatedEntity.save();
+
+  const tradeEntity = FuturesTrade.load(
+    event.transaction.hash.toHex() + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString()
+  );
+  log.info('tradeEntity: {}', [tradeEntity ? tradeEntity.id.toString() : 'null']);
+  if (tradeEntity) {
+    tradeEntity.size = event.params.size.times(BigInt.fromI32(-1));
+    tradeEntity.positionClosed = true;
+    tradeEntity.timestamp = event.block.timestamp;
+    tradeEntity.trader = event.params.account.toHex();
+    tradeEntity.futuresPosition = futuresPositionId;
+    tradeEntity.price = event.params.price;
+    tradeEntity.txHash = event.transaction.hash.toHex();
+    tradeEntity.positionSize = BigInt.fromI32(0);
+    tradeEntity.feesPaidToSynthetix = tradeEntity.feesPaidToSynthetix.plus(event.params.stakersFee);
+
+    // TODO make sure this is correct. I think we need to subtract something else.
+    tradeEntity.realizedPnl = tradeEntity.realizedPnl
+      .minus(event.params.stakersFee.plus(event.params.liquidatorFee).plus(event.params.flaggerFee))
+      .minus(tradeEntity.netFunding); // you loose funding when liquidated
+    tradeEntity.netFunding = BigInt.fromI32(0);
+    tradeEntity.type = 'Liquidated';
+    tradeEntity.save();
+  }
+
+  updateFeeStats(event.params.stakersFee, event.address, event.block.timestamp);
+
+  const synthetix = Synthetix.load('synthetix');
+  if (synthetix) {
+    synthetix.feesByLiquidations = synthetix.feesByLiquidations.plus(event.params.stakersFee);
+    synthetix.totalLiquidations = synthetix.totalLiquidations.plus(BigInt.fromI32(1));
+    synthetix.save();
+  }
+
+  const futuresPosition = FuturesPosition.load(futuresPositionId);
+  if (futuresPosition) {
+    futuresPosition.isLiquidated = true;
+    futuresPosition.isOpen = false;
+    futuresPosition.closeTimestamp = event.block.timestamp;
+    futuresPosition.feesPaidToSynthetix = futuresPosition.feesPaidToSynthetix.plus(
+      event.params.stakersFee
+    );
+    futuresPosition.exitPrice = event.params.price;
+    futuresPosition.save();
+  }
+
+  let trader = Trader.load(event.params.account.toHex());
+  if (trader) {
+    trader.feesPaidToSynthetix = trader.feesPaidToSynthetix.plus(event.params.stakersFee);
+    trader.totalLiquidations = trader.totalLiquidations.plus(BigInt.fromI32(1));
+    trader.totalMarginLiquidated = trader.totalMarginLiquidated.plus(event.params.size);
+    trader.margin = trader.margin.minus(event.params.size);
+    trader.save();
+  }
+}

--- a/v2/perps-v2/perps-subgraph/src/liquidation.ts
+++ b/v2/perps-v2/perps-subgraph/src/liquidation.ts
@@ -14,7 +14,6 @@ import { updateFeeStats } from './historical-trade-stats';
 export { handlePositionModified } from './position-modified';
 
 export function handlePositionLiquidatedLegacy(event: PositionLiquidatedEventLegacy): void {
-  log.info('handlePositionLiquidatedLegacy', []);
   const futuresPositionId = event.address.toHex() + '-' + event.params.id.toHex();
   const positionLiquidatedEntity = new PositionLiquidated(event.params.id.toString());
   positionLiquidatedEntity.trader = event.params.account.toHex();

--- a/v2/perps-v2/perps-subgraph/src/trade-entities.ts
+++ b/v2/perps-v2/perps-subgraph/src/trade-entities.ts
@@ -16,6 +16,9 @@ function createBaseTradeEntity(event: PositionModifiedNewEvent, positionId: stri
   tradeEntity.price = event.params.lastPrice;
   tradeEntity.feesPaidToSynthetix = event.params.fee;
   tradeEntity.txHash = event.transaction.hash.toHex();
+  // Most of the time it wont be a market order. But at this point we cant tell if it is a market order, delayed or delayed offchain.
+  // So we just set it to true now, and expect this field to be updated when the handleDelayedOrderRemoved is triggered
+  tradeEntity.marketOrder = true;
 
   return tradeEntity;
 }

--- a/v2/perps-v2/perps-subgraph/subgraph.base.yaml
+++ b/v2/perps-v2/perps-subgraph/subgraph.base.yaml
@@ -3,46 +3,6 @@ schema:
   file: ./schema.graphql
 
 templates:
-  # - name: AggregatorProxy
-  #   kind: ethereum/contract
-  #   source:
-  #     abi: AggregatorProxy
-  #   mapping:
-  #     kind: ethereum/events
-  #     apiVersion: 0.0.7
-  #     language: wasm/assemblyscript
-  #     file: ./src/latest-rates.ts
-  #     entities:
-  #       - Candle
-  #       - LatestRate
-  #       - RateUpdate
-  #     abis:
-  #       - name: AggregatorProxy
-  #         file: ./abis/AggregatorProxy.json
-  #     eventHandlers:
-  #       - event: 'AggregatorConfirmed(indexed address,indexed address)'
-  #         handler: 'handleAggregatorProxyAddressUpdated'
-
-  # - name: Aggregator
-  #   kind: ethereum/contract
-  #   source:
-  #     abi: Aggregator
-  #   mapping:
-  #     kind: ethereum/events
-  #     apiVersion: 0.0.7
-  #     language: wasm/assemblyscript
-  #     file: ./src/latest-rates.ts
-  #     entities:
-  #       - Candle
-  #       - LatestRate
-  #       - RateUpdate
-  #     abis:
-  #       - name: Aggregator
-  #         file: ./abis/Aggregator.json
-  #     eventHandlers:
-  #       - event: 'AnswerUpdated(indexed int256,indexed uint256,uint256)'
-  #         handler: 'handleAggregatorAnswerUpdated'
-
   - name: PerpetualFuturesMarket
     kind: ethereum/contract
     source:
@@ -76,9 +36,9 @@ templates:
         - event: DelayedOrderSubmitted(indexed
             address,bool,int256,uint256,uint256,uint256,uint256,uint256,bytes32)
           handler: handleDelayedOrderSubmitted
-        - event: DelayedOrderRemoved(indexed
-            address,bool,uint256,int256,uint256,uint256,uint256,bytes32)
+        - event: DelayedOrderRemoved(indexed address,bool,uint256,int256,uint256,uint256,uint256,bytes32)
           handler: handleDelayedOrderRemoved
+          receipt: true
         - event: MarginTransferred(indexed address,int256)
           handler: handleMarginTransferred
         - event: 'FundingRecomputed(int256,int256,uint256,uint256)'

--- a/v2/perps-v2/perps-subgraph/subgraph.base.yaml
+++ b/v2/perps-v2/perps-subgraph/subgraph.base.yaml
@@ -38,7 +38,6 @@ templates:
           handler: handleDelayedOrderSubmitted
         - event: DelayedOrderRemoved(indexed address,bool,uint256,int256,uint256,uint256,uint256,bytes32)
           handler: handleDelayedOrderRemoved
-          receipt: true
         - event: MarginTransferred(indexed address,int256)
           handler: handleMarginTransferred
         - event: 'FundingRecomputed(int256,int256,uint256,uint256)'

--- a/v2/perps-v2/perps-subgraph/tests/liquidation.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/liquidation.test.ts
@@ -1,0 +1,79 @@
+import { Address, BigInt, log } from '@graphprotocol/graph-ts';
+import {
+  afterEach,
+  assert,
+  clearStore,
+  describe,
+  logStore,
+  test,
+} from 'matchstick-as/assembly/index';
+import { handlePositionLiquidatedLegacy, handlePositionModified } from '../src/futures';
+import {
+  createPositionLiquidatedEvent,
+  createPositionModifiedEvent,
+  toEth,
+  toGwei,
+} from './perpsV2-utils';
+
+const trader = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+describe('Perps V2', () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test('position got liquidated, with old liquidation event', () => {
+    const positionOpenedEvent = createPositionModifiedEvent(
+      BigInt.fromI32(1), // id
+      Address.fromString(trader), // account
+      toEth(10), // margin
+      toEth(1), // size
+      toEth(1), // tradeSize
+      toEth(1000), // lastPrice
+      BigInt.fromI32(1), // fundingIndex
+      toGwei(2), // fee
+      10, // timestamp
+      BigInt.fromI32(12), // skew
+      1 // logIndex
+    );
+    handlePositionModified(positionOpenedEvent);
+    const positionModifiedByLiquidationEvent = createPositionModifiedEvent(
+      BigInt.fromI32(1),
+      Address.fromString(trader),
+      toEth(0),
+      toEth(0),
+      toEth(0),
+      toEth(1000),
+      BigInt.fromI32(1),
+      toGwei(0),
+      10,
+      BigInt.fromI32(12),
+      2
+    );
+    handlePositionModified(positionModifiedByLiquidationEvent);
+    const positionLiquidatedEvent = createPositionLiquidatedEvent(
+      BigInt.fromI32(1),
+      Address.fromString(trader),
+      Address.fromString('0x98018d1eB5F2AE291D1537548ABBAA773382eEd4'),
+      toEth(10),
+      toEth(800),
+      toEth(1),
+      20,
+      3
+    );
+    handlePositionLiquidatedLegacy(positionLiquidatedEvent);
+    log.warning('STARTING ASSERTION', []);
+    // SYNTHETIX
+    log.info('Synthetix', []);
+    // 90% of the total fee
+    assert.fieldEquals('Synthetix', 'synthetix', 'feesByLiquidations', '849905364703000879');
+    // FUTURES TRADE
+    log.info('Futures Trade', []);
+    logStore();
+    assert.fieldEquals(
+      'FuturesTrade',
+      `${positionLiquidatedEvent.transaction.hash.toHex()}-${2}`,
+      'type',
+      'Liquidated'
+    );
+  });
+});

--- a/v2/perps-v2/perps-subgraph/tests/margin-transfer.test.ts
+++ b/v2/perps-v2/perps-subgraph/tests/margin-transfer.test.ts
@@ -1,0 +1,113 @@
+import { Address, BigInt, log } from '@graphprotocol/graph-ts';
+import { afterEach, assert, clearStore, describe, test } from 'matchstick-as/assembly/index';
+import {
+  handleFundingRecomputed,
+  handleMarginTransferred,
+  handlePositionModified,
+} from '../src/futures';
+import {
+  createFunctionRecomputedEvent,
+  createMarginTransferredEvent,
+  createPositionModifiedEvent,
+  toEth,
+  toGwei,
+} from './perpsV2-utils';
+const trader = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+describe('Perps V2', () => {
+  afterEach(() => {
+    clearStore();
+  });
+  test('Margin Transferred works and updates position funding', () => {
+    const initialFunding = 1000;
+    const initialFundingRecomputedEvent = createFunctionRecomputedEvent(
+      toEth(initialFunding), // funding
+      toEth(10), // fundingRate
+      BigInt.fromI32(1), // funding index
+      BigInt.fromI32(15), // block timestamp
+      10 // log index
+    );
+    handleFundingRecomputed(initialFundingRecomputedEvent);
+    const positionOpenedEvent = createPositionModifiedEvent(
+      BigInt.fromI32(1), //id
+      Address.fromString(trader), //account
+      toEth(500), // margin
+      toEth(-2), // size
+      toEth(-2), //tradeSize
+      toEth(1000), // lastPrice
+      BigInt.fromI32(1), // funding Index
+      toGwei(1000000000), // fee
+      10, // timestamp
+      BigInt.fromI32(12), // skew
+      1 // log index
+    );
+    handlePositionModified(positionOpenedEvent);
+    const positionId = `${positionOpenedEvent.address.toHex() + '-' + '0x1'}`;
+    assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', toEth(-1).toString());
+    assert.fieldEquals('FuturesPosition', positionId, 'margin', toEth(500).toString());
+    assert.fieldEquals('FuturesPosition', positionId, 'leverage', toEth(4).toString());
+    assert.fieldEquals('FuturesPosition', positionId, 'netFunding', toEth(0).toString());
+
+    const FundingRecomputedEvent1 = createFunctionRecomputedEvent(
+      toEth(initialFunding - 10), // funding going down
+      toEth(10), // fundingRate
+      BigInt.fromI32(2), //funding index
+      BigInt.fromI32(16), // block timestamp
+      10 // log index
+    );
+    handleFundingRecomputed(FundingRecomputedEvent1);
+    const marginTransferredEvent = createMarginTransferredEvent(
+      Address.fromString(trader), //sender
+      toEth(100), // marginDelta
+      10, // timestamp
+      1 // log index
+    );
+    handleMarginTransferred(marginTransferredEvent);
+    const positionUpdatedByTransferredMargin = createPositionModifiedEvent(
+      BigInt.fromI32(1), //id
+      Address.fromString(trader), //account
+      toEth(400), // margin
+      toEth(-2), // size
+      toEth(0), // tradeSize
+      toEth(1000), // lastPrice
+      BigInt.fromI32(2), // funding index
+      toGwei(0), // fee
+      10, // timestamp
+      BigInt.fromI32(12), // skew
+      2 // log index
+    );
+    handlePositionModified(positionUpdatedByTransferredMargin);
+    log.warning('STARTING ASSERTION', []);
+    log.info('Futures Position', []);
+
+    assert.fieldEquals('FuturesPosition', positionId, 'netFunding', toEth(20).toString()); // (10 * 2)
+    assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', toEth(19).toString()); // -1 + (10 * 2)
+    assert.fieldEquals('FuturesPosition', positionId, 'margin', toEth(400).toString());
+    assert.fieldEquals('FuturesPosition', positionId, 'leverage', toEth(5).toString());
+
+    const FundingRecomputedEvent2 = createFunctionRecomputedEvent(
+      toEth(initialFunding + 10), // funding going down
+      toEth(10), // fundingRate
+      BigInt.fromI32(3), //funding index
+      BigInt.fromI32(16), // block timestamp
+      10 // log index
+    );
+    handleFundingRecomputed(FundingRecomputedEvent2);
+    const increasePos = createPositionModifiedEvent(
+      BigInt.fromI32(1), //id
+      Address.fromString(trader), //account
+      toEth(400), // margin
+      toEth(-3), // size
+      toEth(-1), // tradeSize
+      toEth(1000), // lastPrice
+      BigInt.fromI32(3), // funding index
+      toGwei(1000000000), // fee
+      10, // timestamp
+      BigInt.fromI32(12), // skew
+      2 // log index
+    );
+    handlePositionModified(increasePos);
+    assert.fieldEquals('FuturesPosition', positionId, 'netFunding', toEth(-20).toString()); // (10 * 2) + (-20* 2)
+    assert.fieldEquals('FuturesPosition', positionId, 'realizedPnl', toEth(-22).toString()); // -1 + (10 * 2) +  (-20 * 2) -1
+  });
+});

--- a/v2/perps-v2/ui/src/components/Actions/AllActionsTable.tsx
+++ b/v2/perps-v2/ui/src/components/Actions/AllActionsTable.tsx
@@ -7,7 +7,7 @@ import { Action } from '../Shared/Action';
 const isPosition = (l: string) => l !== 'Deposit Margin' && l !== 'Withdraw Margin';
 
 export const AllActionsTable = () => {
-  const { loading, data, error } = useActions(undefined, 1000);
+  const { loading, data, error } = useActions();
 
   return (
     <>

--- a/v2/perps-v2/ui/src/components/Actions/AllActionsTable.tsx
+++ b/v2/perps-v2/ui/src/components/Actions/AllActionsTable.tsx
@@ -7,7 +7,7 @@ import { Action } from '../Shared/Action';
 const isPosition = (l: string) => l !== 'Deposit Margin' && l !== 'Withdraw Margin';
 
 export const AllActionsTable = () => {
-  const { loading, data, error } = useActions();
+  const { loading, data, error } = useActions(undefined, 1000);
 
   return (
     <>


### PR DESCRIPTION
- Before this change all trade entities was missing the relation to the orders.
We know have a new field on the OrderEntity called market order. If this is set to true, we expect the orderType to be null. Otherwise there should always be a relation from FuturesTrade to OrderEntity.
 
- Moved out liquidation and margin transfer tests. Matchstick doesn't have `only` feature for running tests, so it make sense to have things more split out

- When updating fee aggregation for keeper fees we only want that to happen if we have a trade entity. 

