### PR TITLE
Refactor accountId URL sync

### DIFF
--- a/v3/cypress/cypress/e2e/Manage Position - Borrow.e2e.js
+++ b/v3/cypress/cypress/e2e/Manage Position - Borrow.e2e.js
@@ -34,7 +34,7 @@ it('should borrow against already deposited SNX collateral', () => {
   });
 
   cy.location().should((loc) => {
-    expect(loc.search).to.eq('?manageAction=borrow');
+    expect(loc.search).to.include('manageAction=borrow');
   });
   cy.get('[data-testid="manage action"][data-action="borrow"]')
     .should('exist')

--- a/v3/cypress/cypress/e2e/Manage Position - Deposit.e2e.js
+++ b/v3/cypress/cypress/e2e/Manage Position - Deposit.e2e.js
@@ -38,7 +38,7 @@ it('should deposit additional SNX collateral', () => {
     .click()
     .should('have.attr', 'data-active', 'true');
   cy.location().should((loc) => {
-    expect(loc.search).to.eq('?manageAction=deposit');
+    expect(loc.search).to.include('manageAction=deposit');
   });
 
   cy.get('[data-testid="manage stats collateral"]').should('include.text', '10 SNX');

--- a/v3/cypress/cypress/e2e/Manage Position - Repay.e2e.js
+++ b/v3/cypress/cypress/e2e/Manage Position - Repay.e2e.js
@@ -45,7 +45,7 @@ it('should repay borrowed snxUSD and get back SNX collateral', () => {
     .click()
     .should('have.attr', 'data-active', 'true');
   cy.location().should((loc) => {
-    expect(loc.search).to.eq('?manageAction=repay');
+    expect(loc.search).to.include('manageAction=repay');
   });
 
   cy.get('[data-testid="current debt"]').should('not.have.text', '-');

--- a/v3/cypress/cypress/e2e/Manage Position - Withdraw.e2e.js
+++ b/v3/cypress/cypress/e2e/Manage Position - Withdraw.e2e.js
@@ -41,7 +41,7 @@ it('should withdraw borrowed snxUSD and get back SNX collateral', () => {
     .click()
     .should('have.attr', 'data-active', 'true');
   cy.location().should((loc) => {
-    expect(loc.search).to.eq('?manageAction=withdraw');
+    expect(loc.search).to.include('manageAction=withdraw');
   });
 
   cy.get('[data-testid="available to withdraw"]').should('not.have.text', '-');

--- a/v3/lib/useAccounts/package.json
+++ b/v3/lib/useAccounts/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "@snx-v3/useAccountProxy": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
+    "@snx-v3/useParams": "workspace:*",
     "@tanstack/react-query": "^4.24.6",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "react-router-dom": "^6.8.1"
   }
 }

--- a/v3/lib/useParams/useParams.ts
+++ b/v3/lib/useParams/useParams.ts
@@ -1,12 +1,27 @@
 import { useParams as useParamsRouter, useSearchParams } from 'react-router-dom';
 import { useMemo } from 'react';
 
+export function searchParamsToObject(searchParams: URLSearchParams) {
+  return Object.fromEntries(Array.from(searchParams));
+}
+
+export function sortObject(params: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(params).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+export function cleanObject(params: Record<string, string | undefined>): Record<string, string> {
+  const cleaned = Object.entries(params).filter(([, value]) => value !== undefined) as [
+    [string, string]
+  ];
+  return Object.fromEntries(cleaned);
+}
+
 export const useParams = (): Record<string, string | undefined> => {
   const pathParams = useParamsRouter();
   const [queryParams] = useSearchParams();
 
   return useMemo(
-    () => ({ ...pathParams, ...Object.fromEntries(queryParams) }),
+    () => sortObject({ ...cleanObject(pathParams), ...searchParamsToObject(queryParams) }),
     [pathParams, queryParams]
   );
 };

--- a/v3/ui/src/App.tsx
+++ b/v3/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { GasSpeedProvider } from '@snx-v3/useGasSpeed';
 import { BlockchainProvider } from '@snx-v3/useBlockchain';
 import { TermsModal } from '@snx-v3/TermsModal';
 import { SESSION_STORAGE_KEYS } from '@snx-v3/constants';
+import { useAccountUrlSync } from '@snx-v3/useAccounts';
 import { Router } from './Router';
 import './i18n';
 
@@ -21,6 +22,11 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+function Sync() {
+  useAccountUrlSync();
+  return null;
+}
 
 export const App = () => {
   const { colorMode, toggleColorMode } = useColorMode();
@@ -43,6 +49,7 @@ export const App = () => {
             <BrowserRouter>
               <TermsModal defaultOpen={!TERMS_CONDITIONS_ACCEPTED} />
               <Router />
+              <Sync />
             </BrowserRouter>
           </GasSpeedProvider>
           <ReactQueryDevtools />

--- a/v3/ui/src/pages/Home/Home.tsx
+++ b/v3/ui/src/pages/Home/Home.tsx
@@ -14,8 +14,8 @@ import {
   Thead,
   Tr,
 } from '@chakra-ui/react';
-import { FC, useEffect } from 'react';
-import { createSearchParams, generatePath, NavigateFunction, useNavigate } from 'react-router-dom';
+import { FC } from 'react';
+import { generatePath, NavigateFunction, useNavigate } from 'react-router-dom';
 import { useAccounts } from '@snx-v3/useAccounts';
 import { CollateralType, useCollateralTypes } from '@snx-v3/useCollateralTypes';
 import { VaultRow } from './VaultRow';
@@ -178,14 +178,12 @@ export function HomeUi({
 }
 
 export function Home() {
-  const { data: accounts = [], isLoading: accountsLoading } = useAccounts();
+  const { isLoading: accountsLoading } = useAccounts();
   const { data: collateralTypes = [], isLoading: collateralTypesLoading } = useCollateralTypes();
   const { data: preferredPool, isLoading: preferredPoolLoading } = usePreferredPool();
 
   const params = useParams();
   const navigate = useNavigate();
-
-  const [accountId] = accounts;
 
   const {
     data: liquidityPositionsById,
@@ -194,15 +192,6 @@ export function Home() {
   } = useLiquidityPositions({
     accountId: params.accountId,
   });
-
-  useEffect(() => {
-    if (!params.accountId && accountId) {
-      navigate({
-        pathname: generatePath('/'),
-        search: createSearchParams({ accountId }).toString(),
-      });
-    }
-  }, [navigate, accountId, params.accountId]);
 
   const title = 'Synthetix V3';
   const isLoading =

--- a/yarn.lock
+++ b/yarn.lock
@@ -8209,8 +8209,10 @@ __metadata:
   dependencies:
     "@snx-v3/useAccountProxy": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
+    "@snx-v3/useParams": "workspace:*"
     "@tanstack/react-query": ^4.24.6
     react: ^18.2.0
+    react-router-dom: ^6.8.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
When we disconnect wallet account id keeps hanging. This update makes sure we add and clean up account id in URL search in sync with current app state.

Also it used to be on Home page only for some reason. This Sync abstraction allows us not to bother with URL updates anywhere in the app as app state will be automatically synchronised to URL.