### PR TITLE
Switch to dynamic accountTimeoutWithdraw config value

### DIFF
--- a/v3/lib/useAccountCollateralUnlockDate/package.json
+++ b/v3/lib/useAccountCollateralUnlockDate/package.json
@@ -8,6 +8,7 @@
     "@snx-v3/useCoreProxy": "workspace:*",
     "@snx-v3/useMulticall3": "workspace:*",
     "@tanstack/react-query": "^4.24.6",
+    "ethers": "^5.7.2",
     "react": "^18.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8202,6 +8202,7 @@ __metadata:
     "@snx-v3/useCoreProxy": "workspace:*"
     "@snx-v3/useMulticall3": "workspace:*"
     "@tanstack/react-query": ^4.24.6
+    ethers: ^5.7.2
     react: ^18.2.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
As this is now avail on both supported networks (op, op goe)

Still had to ts-ignore because mainnet and eth goe do not have that released (and will not for some time perhaps)

<img width="1013" alt="image" src="https://github.com/Synthetixio/js-monorepo/assets/28145325/419ee237-8469-4e9f-b92e-3a762cab0403">
