### PR TITLE
More pool page updates

### DIFF
--- a/v3/lib/usePoolData/usePoolData.tsx
+++ b/v3/lib/usePoolData/usePoolData.tsx
@@ -83,7 +83,7 @@ const PoolsDataDocument = gql`
           net_issuance
           reported_debt
           updated_at
-          market_snapshots_by_week(first: 2) {
+          market_snapshots_by_week(first: 2, orderBy: updated_at, orderDirection: desc) {
             id
             usd_deposited
             usd_withdrawn

--- a/v3/lib/usePoolData/usePoolData.tsx
+++ b/v3/lib/usePoolData/usePoolData.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useQuery } from '@tanstack/react-query';
 import { getSubgraphUrl } from '@snx-v3/constants';
 import { z } from 'zod';
@@ -97,6 +98,30 @@ const PoolsDataDocument = gql`
     }
   }
 `;
+export const logMarket = (market: z.infer<typeof MarketSchema>) => {
+  console.log('Market:');
+  console.table({
+    market: market.id,
+    usd_deposited: market.usd_deposited.toNumber(),
+    usd_withdrawn: market.usd_withdrawn.toNumber(),
+    net_issuance: market.net_issuance.toNumber(),
+    reported_debt: market.reported_debt.toNumber(),
+    pnl: market.pnl.toNumber(),
+    updated_at: new Date(Number(market.updated_at) * 1000),
+  });
+  console.log('Snapshots:');
+  console.table(
+    market.market_snapshots_by_week.map((s) => ({
+      ...s,
+      pnl: s.pnl.toNumber(),
+      usd_deposited: s.usd_deposited.toNumber(),
+      usd_withdrawn: s.usd_withdrawn.toNumber(),
+      net_issuance: s.net_issuance.toNumber(),
+      reported_debt: s.reported_debt.toNumber(),
+      updated_at: new Date(Number(s.updated_at) * 1000),
+    }))
+  );
+};
 
 const getPoolData = async (chainName: string, id: string) => {
   const res = await fetch(getSubgraphUrl(chainName), {

--- a/v3/ui/src/App.tsx
+++ b/v3/ui/src/App.tsx
@@ -28,7 +28,7 @@ function Sync() {
   return null;
 }
 
-export const App = () => {
+function ColorMode() {
   const { colorMode, toggleColorMode } = useColorMode();
 
   useEffect(() => {
@@ -36,13 +36,17 @@ export const App = () => {
       toggleColorMode();
     }
   }, [colorMode, toggleColorMode]);
+  return null;
+}
 
+export const App = () => {
   const TERMS_CONDITIONS_ACCEPTED =
     sessionStorage.getItem(SESSION_STORAGE_KEYS.TERMS_CONDITIONS_ACCEPTED) === 'true';
 
   return (
     <QueryClientProvider client={queryClient}>
       <ChakraProvider theme={theme}>
+        <ColorMode />
         <Fonts />
         <BlockchainProvider>
           <GasSpeedProvider>

--- a/v3/ui/src/pages/Pool/MarketSection.tsx
+++ b/v3/ui/src/pages/Pool/MarketSection.tsx
@@ -75,9 +75,15 @@ const LoadingRow = () => (
 interface TotalValueProps extends TextProps {
   value?: Wei;
   isLoading: boolean;
+  formatter?: (val: string | number) => string;
 }
 
-const TotalValue: FC<TotalValueProps> = ({ value, isLoading, ...props }) => {
+const TotalValue: FC<TotalValueProps> = ({
+  value,
+  isLoading,
+  formatter = formatNumberToUsd,
+  ...props
+}) => {
   if (isLoading) return <Skeleton w={16} h={8} mt={1} />;
   if (!value) return <>-</>;
   return (
@@ -89,7 +95,7 @@ const TotalValue: FC<TotalValueProps> = ({ value, isLoading, ...props }) => {
       fontWeight="800"
       {...props}
     >
-      {formatNumberToUsd(value.toNumber())}{' '}
+      {formatter(value.toNumber())}{' '}
     </TrendText>
   );
 };
@@ -143,6 +149,7 @@ export function MarketSectionUi({
             value={sevenDaysPerformance?.growthPercentage}
             isLoading={!poolDataFetched}
             fontSize="md"
+            formatter={formatPercent}
           />
         </BorderBox>
         <BorderBox paddingY={2} paddingX={4} flexGrow="1" flexDirection="column">

--- a/v3/ui/src/pages/Pool/MarketSection.tsx
+++ b/v3/ui/src/pages/Pool/MarketSection.tsx
@@ -15,7 +15,7 @@ import {
   Skeleton,
   TextProps,
 } from '@chakra-ui/react';
-import { PoolType, usePoolData } from '@snx-v3/usePoolData';
+import { logMarket, PoolType, usePoolData } from '@snx-v3/usePoolData';
 import {
   calculateSevenDaysPnlGrowth,
   calculatePoolPerformanceSevenDays,
@@ -195,7 +195,13 @@ export function MarketSectionUi({
                   const isLastItem = i + 1 === poolData.configurations.length;
                   const growth = calculateSevenDaysPnlGrowth(market.market_snapshots_by_week);
                   return (
-                    <Tr key={id} color="gray.500" data-testid="pool market" data-market={id}>
+                    <Tr
+                      onClick={() => logMarket(market)}
+                      key={id}
+                      color="gray.500"
+                      data-testid="pool market"
+                      data-market={id}
+                    >
                       <StyledTd isLastItem={isLastItem}>
                         <Text
                           fontSize="sm"


### PR DESCRIPTION
- Make sure market snapshots are sorted on time. 
- Chakra darkmode fixed (hopefully, cant reproduce locally)
- Percent formatted:
![Screenshot 2023-05-30 at 1 59 45 pm](https://github.com/Synthetixio/js-monorepo/assets/5688912/86161103-3019-4670-81b6-5b788090eaef)
Before:
![image](https://github.com/Synthetixio/js-monorepo/assets/5688912/29e66d3f-4806-42db-86b7-c116211518f8)
- Log out market data on row click
![Screenshot 2023-05-30 at 2 37 10 pm](https://github.com/Synthetixio/js-monorepo/assets/5688912/acfc4059-b991-4484-85c3-83e25215bc8f)
