### PR TITLE
Smarter priority fees

### DIFF
--- a/v2/components/EthGasPriceEstimator/EthGasPriceEstimator.tsx
+++ b/v2/components/EthGasPriceEstimator/EthGasPriceEstimator.tsx
@@ -17,7 +17,6 @@ import { formatNumberToUsd } from '@snx-v2/formatters';
 
 import { GasSpeedContext, GasSpeed } from '@snx-v2/GasSpeedContext';
 import { ChevronDown, InfoIcon } from '@snx-v2/icons';
-import { ContractContext } from '@snx-v2/ContractContext';
 
 interface EthGasPriceEstimatorUiProps extends FlexProps {
   transactionFee?: Wei | null;

--- a/v2/components/EthGasPriceEstimator/EthGasPriceEstimator.tsx
+++ b/v2/components/EthGasPriceEstimator/EthGasPriceEstimator.tsx
@@ -92,14 +92,6 @@ export const EthGasPriceEstimator: FC<EthGasPriceEstimatorProps> = ({
   ...props
 }) => {
   const { setGasSpeed, gasSpeed } = useContext(GasSpeedContext);
-  const { networkId } = useContext(ContractContext);
-
-  const isMainnet = networkId === 1;
-  const isGoerli = networkId === 5;
-
-  const showGas = isMainnet || isGoerli;
-
-  if (!showGas) return null;
 
   return (
     <EthGasPriceEstimatorUi

--- a/v2/components/EthGasPriceEstimator/package.json
+++ b/v2/components/EthGasPriceEstimator/package.json
@@ -5,7 +5,6 @@
   "version": "0.0.1",
   "dependencies": {
     "@chakra-ui/react": "^2.5.0",
-    "@snx-v2/ContractContext": "workspace:*",
     "@snx-v2/GasSpeedContext": "workspace:*",
     "@snx-v2/formatters": "workspace:*",
     "@snx-v2/icons": "workspace:*",

--- a/v2/lib/feeSuggestion/feeSuggestion.ts
+++ b/v2/lib/feeSuggestion/feeSuggestion.ts
@@ -1,0 +1,85 @@
+/**
+ * This module is heavily inspired by https://github.com/rainbow-me/fee-suggestions
+ * That library have some hardcoded min and max that doesn't make sense for optimism. See: https://github.com/rainbow-me/fee-suggestions/blob/main/src/index.ts#L165
+ * It also a bit overkill in how it calculates maxFeePerGas per gas. It's using linear regression and sampling curves.
+ * Instead of doing that, this module calculates max by taking previous (baseFeePerGat * 2) + maxPriorityFeePerGas.
+ *
+ * The calculation for maxPriorityFeePerGas I kept quite complex since that will affect what the user actually pay..
+ * It's calculated based on the Exponential Moving Average (EMA) of the block rewards at the 15th, 30th, and 45th percentiles, after removing the outliers.
+ *
+ * The other differences is that I rely on our Wei library.
+ *
+ *
+ */
+import { utils, providers } from 'ethers';
+import { ema } from './math';
+import { getOutlierBlocksToRemove, rewardsFilterOutliers } from './utils';
+import { wei, Wei } from '@synthetixio/wei';
+import { GWEI_DECIMALS } from '@snx-v2/Constants';
+
+type Reward = string[];
+type GasUsedRatio = number[];
+interface FeeHistoryResponse {
+  baseFeePerGas: string[];
+  gasUsedRatio: GasUsedRatio;
+  oldestBlock: number;
+  reward: Reward[];
+}
+export const feeSuggestion = async (provider: providers.JsonRpcProvider, fromBlock = 'latest') => {
+  const feeHistory = await provider
+    .send('eth_feeHistory', [utils.hexStripZeros(utils.hexlify(10)), fromBlock, [15, 30, 45]])
+    .then((feeHistoryResponse: FeeHistoryResponse) => {
+      return {
+        baseFeePerGas: feeHistoryResponse.baseFeePerGas.map((x) => wei(x, GWEI_DECIMALS, true)),
+        reward: feeHistoryResponse.reward.map((x) => x.map((num) => wei(num, GWEI_DECIMALS, true))),
+      };
+    });
+  const blocksRewards = feeHistory.reward;
+  const baseFeePerGas = feeHistory.baseFeePerGas.at(-1);
+
+  if (!blocksRewards.length) throw new Error('Error: block reward was empty');
+  if (!baseFeePerGas) throw new Error('Error: currentBaseFee was empty');
+
+  const outlierBlocks = getOutlierBlocksToRemove(blocksRewards, 0);
+
+  const blocksRewardsPerc15 = rewardsFilterOutliers(blocksRewards, outlierBlocks, 0);
+  const blocksRewardsPerc30 = rewardsFilterOutliers(blocksRewards, outlierBlocks, 1);
+  const blocksRewardsPerc45 = rewardsFilterOutliers(blocksRewards, outlierBlocks, 2);
+
+  const emaPerc15 = ema(blocksRewardsPerc15, blocksRewardsPerc15.length)[
+    blocksRewardsPerc15.length - 1
+  ];
+  const emaPerc30 = ema(blocksRewardsPerc30, blocksRewardsPerc30.length)[
+    blocksRewardsPerc30.length - 1
+  ];
+  const emaPerc45 = ema(blocksRewardsPerc45, blocksRewardsPerc45.length)[
+    blocksRewardsPerc45.length - 1
+  ];
+
+  if (emaPerc15 === undefined || emaPerc30 === undefined || emaPerc45 === undefined) {
+    throw new Error('Error: ema was undefined');
+  }
+
+  const averageMaxPriorityFee = wei(Math.min(emaPerc15, 1), GWEI_DECIMALS);
+  const fastMaxPriorityFee = wei(Math.min(emaPerc30, 2), GWEI_DECIMALS);
+  const fastestMaxPriorityFee = wei(Math.min(emaPerc45, 4), GWEI_DECIMALS);
+
+  const baseFeeToMax = (base: Wei, prio: Wei) => base.mul(wei(2, GWEI_DECIMALS)).add(prio);
+  return {
+    average: {
+      maxPriorityFeePerGas: averageMaxPriorityFee,
+      maxFeePerGas: baseFeeToMax(baseFeePerGas, averageMaxPriorityFee),
+      baseFeePerGas,
+    },
+    fast: {
+      maxPriorityFeePerGas: fastMaxPriorityFee,
+      maxFeePerGas: baseFeeToMax(baseFeePerGas, fastMaxPriorityFee),
+      baseFeePerGas,
+    },
+    fastest: {
+      maxPriorityFeePerGas: fastestMaxPriorityFee,
+      maxFeePerGas: baseFeeToMax(baseFeePerGas, fastestMaxPriorityFee),
+      baseFeePerGas,
+    },
+  };
+};

--- a/v2/lib/feeSuggestion/feeSuggestion.ts
+++ b/v2/lib/feeSuggestion/feeSuggestion.ts
@@ -1,14 +1,16 @@
 /**
  * This module is heavily inspired by https://github.com/rainbow-me/fee-suggestions
  * That library have some hardcoded min and max that doesn't make sense for optimism. See: https://github.com/rainbow-me/fee-suggestions/blob/main/src/index.ts#L165
- * It also a bit overkill in how it calculates maxFeePerGas per gas. It's using linear regression and sampling curves.
- * Instead of doing that, this module calculates max by taking previous (baseFeePerGat * 2) + maxPriorityFeePerGas.
+ *
+ * So I changed min max a bit
+ *
+ * That library is also a bit overkill in how it calculates maxFeePerGas per gas. It's using linear regression and sampling curves.
+ * Instead of doing that, this module calculates max by taking previous (baseFeePerGas * 2) + maxPriorityFeePerGas.
  *
  * The calculation for maxPriorityFeePerGas I kept quite complex since that will affect what the user actually pay..
  * It's calculated based on the Exponential Moving Average (EMA) of the block rewards at the 15th, 30th, and 45th percentiles, after removing the outliers.
  *
- * The other differences is that I rely on our Wei library.
- *
+ * The other differences is that I also rely on our Wei library.
  *
  */
 import { utils, providers } from 'ethers';

--- a/v2/lib/feeSuggestion/feeSuggestion.ts
+++ b/v2/lib/feeSuggestion/feeSuggestion.ts
@@ -5,7 +5,7 @@
  * So I changed min max a bit
  *
  * That library is also a bit overkill in how it calculates maxFeePerGas per gas. It's using linear regression and sampling curves.
- * Instead of doing that, this module calculates max by taking previous (baseFeePerGas * 2) + maxPriorityFeePerGas.
+ * Instead of doing that, this module calculates max by taking  (previous baseFeePerGas * 2) + maxPriorityFeePerGas.
  *
  * The calculation for maxPriorityFeePerGas I kept quite complex since that will affect what the user actually pay..
  * It's calculated based on the Exponential Moving Average (EMA) of the block rewards at the 15th, 30th, and 45th percentiles, after removing the outliers.

--- a/v2/lib/feeSuggestion/index.ts
+++ b/v2/lib/feeSuggestion/index.ts
@@ -1,0 +1,1 @@
+export * from './feeSuggestion';

--- a/v2/lib/feeSuggestion/math.ts
+++ b/v2/lib/feeSuggestion/math.ts
@@ -1,0 +1,72 @@
+// copied from npm package: moving-averages
+// Only grabbed what we needed and added types
+export const isNumber = (subject: unknown) =>
+  typeof subject === 'number' &&
+  // is not NaN: `NaN === NaN` => `false`
+  subject === subject;
+
+export const dma = (data: number[], alpha: number, noHead?: boolean): number[] => {
+  const length = data.length;
+
+  if (alpha > 1) {
+    return Array(length);
+  }
+
+  if (alpha === 1) {
+    return data.slice();
+  }
+
+  const noArrayWeight = !Array.isArray(alpha);
+  const ret = [];
+
+  let datum;
+
+  // period `i`
+  let i = 0;
+
+  // `s` is the value of the DWMA at any time period `i`
+  let s = 0;
+
+  // Handles head
+  for (; i < length; i++) {
+    datum = data[i];
+
+    if (isNumber(datum) && (noArrayWeight || isNumber(datum))) {
+      ret[i] = noHead ? 0 : datum;
+
+      s = datum;
+      i++;
+
+      break;
+    }
+  }
+
+  // Dynamic weights: an array of weights
+  // Ref:
+  // https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+  // with a dynamic alpha
+  if (!noArrayWeight) {
+    for (; i < length; i++) {
+      datum = data[i];
+
+      isNumber(datum) && isNumber(alpha[i])
+        ? (s = ret[i] = alpha[i] * datum + (1 - alpha[i]) * s)
+        : (ret[i] = ret[i - 1]);
+    }
+
+    return ret;
+  }
+
+  const o = 1 - alpha;
+
+  // Fixed alpha
+  for (; i < length; i++) {
+    datum = data[i];
+
+    isNumber(datum) ? (s = ret[i] = alpha * datum + o * s) : (ret[i] = ret[i - 1]);
+  }
+
+  return ret;
+};
+
+export const ema = (data: number[], size: number) => dma(data, 2 / (size + 1));

--- a/v2/lib/feeSuggestion/package.json
+++ b/v2/lib/feeSuggestion/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@snx-v2/feeSuggestion",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.0",
+  "dependencies": {
+    "@snx-v2/Constants": "workspace:*",
+    "@synthetixio/wei": "^2.74.4",
+    "ethers": "^5.7.2",
+    "react": "^18.2.0"
+  }
+}

--- a/v2/lib/feeSuggestion/utils.ts
+++ b/v2/lib/feeSuggestion/utils.ts
@@ -1,0 +1,22 @@
+import { Wei } from '@synthetixio/wei';
+
+export const rewardsFilterOutliers = (
+  blocksRewards: Wei[][],
+  outlierBlocks: number[],
+  rewardIndex: number
+) =>
+  blocksRewards
+    .filter((_, index) => !outlierBlocks.includes(index))
+    .map((reward) => reward[rewardIndex].toNumber());
+
+export const getOutlierBlocksToRemove = (blocksRewards: Wei[][], index: number) => {
+  const blocks: number[] = [];
+  blocksRewards
+    .map((reward) => reward[index])
+    .forEach((gweiReward, i) => {
+      if (gweiReward.gt(5)) {
+        blocks.push(i);
+      }
+    });
+  return blocks;
+};

--- a/v2/lib/useGasOptions/useGasOptions.ts
+++ b/v2/lib/useGasOptions/useGasOptions.ts
@@ -22,8 +22,7 @@ type GasPrice = {
 
 const getTotalGasPrice = (gasPrice?: GasPrice | null) => {
   const { baseFeePerGas, maxPriorityFeePerGas } = gasPrice || {};
-  if (!baseFeePerGas || maxPriorityFeePerGas) return wei(0);
-
+  if (!baseFeePerGas || !maxPriorityFeePerGas) return wei(0);
   return baseFeePerGas.add(maxPriorityFeePerGas || 0);
 };
 

--- a/v2/lib/useGasOptions/useGasOptions.ts
+++ b/v2/lib/useGasOptions/useGasOptions.ts
@@ -15,19 +15,16 @@ import { useExchangeRatesData } from '@snx-v2/useExchangeRatesData';
 const GAS_LIMIT_BUFFER = wei(1.2, GWEI_DECIMALS);
 
 type GasPrice = {
-  baseFeePerGas?: BigNumber; // Note that this is used for estimating price and should not be included in the transaction
-  maxPriorityFeePerGas?: BigNumber;
-  maxFeePerGas?: BigNumber;
-  gasPrice?: BigNumber;
+  baseFeePerGas?: Wei; // Note that this is used for estimating price and should not be included in the transaction
+  maxPriorityFeePerGas?: Wei;
+  maxFeePerGas?: Wei;
 };
 
 const getTotalGasPrice = (gasPrice?: GasPrice | null) => {
-  if (!gasPrice) return wei(0);
-  const { gasPrice: nonEIP1559Gas, baseFeePerGas, maxPriorityFeePerGas } = gasPrice;
-  if (nonEIP1559Gas) {
-    return wei(nonEIP1559Gas, GWEI_DECIMALS);
-  }
-  return wei(baseFeePerGas || 0, GWEI_DECIMALS).add(wei(maxPriorityFeePerGas || 0, GWEI_DECIMALS));
+  const { baseFeePerGas, maxPriorityFeePerGas } = gasPrice || {};
+  if (!baseFeePerGas || maxPriorityFeePerGas) return wei(0);
+
+  return baseFeePerGas.add(maxPriorityFeePerGas || 0);
 };
 
 const getTransactionPrice = (
@@ -76,11 +73,12 @@ export const useGasOptions = ({
       const formatGasPriceForTransaction = () => {
         if (!gasPrices) return undefined;
         const gasPrice = gasPrices[gasSpeed];
-        if ('baseFeePerGas' in gasPrice) {
-          const { baseFeePerGas: _baseFeePerGas, ...gasPriceToReturn } = gasPrice;
-          return { ...gasPriceToReturn, gasLimit };
-        }
-        return { ...gasPrice, gasLimit };
+        const { baseFeePerGas: _baseFeePerGas, maxFeePerGas, maxPriorityFeePerGas } = gasPrice;
+        return {
+          maxFeePerGas: maxFeePerGas.toBN(),
+          maxPriorityFeePerGas: maxPriorityFeePerGas.toBN(),
+          gasLimit,
+        };
       };
       return {
         populatedTransaction,

--- a/v2/lib/useGasPrice/package.json
+++ b/v2/lib/useGasPrice/package.json
@@ -4,11 +4,9 @@
   "main": "index.ts",
   "version": "0.0.10",
   "dependencies": {
-    "@ethersproject/bignumber": "^5.7.0",
-    "@ethersproject/providers": "^5.7.2",
     "@snx-v2/Constants": "workspace:*",
     "@snx-v2/ContractContext": "workspace:*",
-    "@snx-v2/SignerContext": "workspace:*",
+    "@snx-v2/feeSuggestion": "workspace:*",
     "@snx-v2/useGlobalProvidersWithFallback": "workspace:*",
     "@snx-v2/useSynthetixContracts": "workspace:*",
     "@synthetixio/wei": "^2.74.4",

--- a/v2/lib/useGasPrice/useGasPrice.ts
+++ b/v2/lib/useGasPrice/useGasPrice.ts
@@ -23,5 +23,6 @@ export const useGasPrice = () => {
       }
     },
     enabled: Boolean(networkId),
+    staleTime: 3000,
   });
 };

--- a/v2/lib/useGasPrice/useGasPrice.ts
+++ b/v2/lib/useGasPrice/useGasPrice.ts
@@ -1,43 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { useContext } from 'react';
-import { wei } from '@synthetixio/wei';
-import { Provider } from '@ethersproject/providers';
-import { BigNumber } from '@ethersproject/bignumber';
 import { ContractContext } from '@snx-v2/ContractContext';
 import { NetworkIdByName } from '@snx-v2/useSynthetixContracts';
-import { GWEI_DECIMALS } from '@snx-v2/Constants';
+
 import { useGlobalProvidersWithFallback } from '@snx-v2/useGlobalProvidersWithFallback';
-import { SignerContext } from '@snx-v2/SignerContext';
-
-const MULTIPLIER = wei(2, GWEI_DECIMALS);
-
-export const computeGasFee = (baseFeePerGas: BigNumber, maxPriorityFeePerGas: number) => {
-  return {
-    maxPriorityFeePerGas: wei(maxPriorityFeePerGas, GWEI_DECIMALS).toBN(),
-    maxFeePerGas: wei(baseFeePerGas, GWEI_DECIMALS)
-      .mul(MULTIPLIER)
-      .add(wei(maxPriorityFeePerGas, GWEI_DECIMALS))
-      .toBN(),
-    baseFeePerGas: baseFeePerGas,
-  };
-};
-
-const getGasPriceFromProvider = async (provider: Provider) => {
-  try {
-    const gasPrice = await provider.getGasPrice();
-    return {
-      fastest: { gasPrice },
-      fast: { gasPrice },
-      average: { gasPrice },
-    };
-  } catch (e) {
-    throw new Error('Could not retrieve gas price from provider');
-  }
-};
+import { feeSuggestion } from '@snx-v2/feeSuggestion';
 
 export const useGasPrice = () => {
   const { networkId, walletAddress } = useContext(ContractContext);
-  const signer = useContext(SignerContext);
   const { globalProviders } = useGlobalProvidersWithFallback();
 
   return useQuery({
@@ -46,19 +16,8 @@ export const useGasPrice = () => {
       if (!networkId) throw Error('Network id required');
       const globalProvider =
         networkId === NetworkIdByName.mainnet ? globalProviders.mainnet : globalProviders.optimism;
-      const provider = signer?.provider || globalProvider;
       try {
-        const block = await provider.getBlock('latest');
-        if (block.baseFeePerGas) {
-          return {
-            fastest: computeGasFee(block.baseFeePerGas, 6),
-            fast: computeGasFee(block.baseFeePerGas, 4),
-            average: computeGasFee(block.baseFeePerGas, 2),
-          };
-        }
-
-        // When Testnet, Optimism network or missing baseFeePerGas we get the Gas Price through the provider
-        return getGasPriceFromProvider(provider);
+        return await feeSuggestion(globalProvider);
       } catch (e) {
         throw new Error(`Could not fetch and compute network fee. ${e}`);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6331,6 +6331,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@snx-v2/feeSuggestion@workspace:*, @snx-v2/feeSuggestion@workspace:v2/lib/feeSuggestion":
+  version: 0.0.0-use.local
+  resolution: "@snx-v2/feeSuggestion@workspace:v2/lib/feeSuggestion"
+  dependencies:
+    "@snx-v2/Constants": "workspace:*"
+    "@synthetixio/wei": ^2.74.4
+    ethers: ^5.7.2
+    react: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@snx-v2/formatters@workspace:*, @snx-v2/formatters@workspace:v2/lib/formatters":
   version: 0.0.0-use.local
   resolution: "@snx-v2/formatters@workspace:v2/lib/formatters"
@@ -6658,11 +6669,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@snx-v2/useGasPrice@workspace:v2/lib/useGasPrice"
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/providers": ^5.7.2
     "@snx-v2/Constants": "workspace:*"
     "@snx-v2/ContractContext": "workspace:*"
-    "@snx-v2/SignerContext": "workspace:*"
+    "@snx-v2/feeSuggestion": "workspace:*"
     "@snx-v2/useGlobalProvidersWithFallback": "workspace:*"
     "@snx-v2/useSynthetixContracts": "workspace:*"
     "@synthetixio/wei": ^2.74.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,7 +5894,6 @@ __metadata:
   resolution: "@snx-v2/EthGasPriceEstimator@workspace:v2/components/EthGasPriceEstimator"
   dependencies:
     "@chakra-ui/react": ^2.5.0
-    "@snx-v2/ContractContext": "workspace:*"
     "@snx-v2/GasSpeedContext": "workspace:*"
     "@snx-v2/formatters": "workspace:*"
     "@snx-v2/icons": "workspace:*"


### PR DESCRIPTION
The feeSuggestion module is heavily inspired by https://github.com/rainbow-me/fee-suggestions
That library have some hardcoded min and max that doesn't make sense for optimism. See: https://github.com/rainbow-me/fee-suggestions/blob/main/src/index.ts#L165

 So I changed min/max a bit

That library is also a bit overkill in how it calculates `maxFeePerGas` per gas. It's using linear regression and sampling curves. Instead of doing that, this module calculates max by taking (previous baseFeePerGas * 2) + maxPriorityFeePerGas.

 The calculation for `maxPriorityFeePerGas` I kept quite complex since that will affect what the user actually pay..
 It's calculated based on the Exponential Moving Average (EMA) of the block rewards at the 15th, 30th, and 45th percentiles, after removing the outliers.

 The other differences is that I also rely on our Wei library.