### PR TITLE
Only block burning from min stake time if custom burning is used

### DIFF
--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -128,11 +128,12 @@ export const BurnUi = ({
   };
   const notEnoughBalance = burnAmountForCalculations > susdBalance;
 
-  const burningBlockedByMinStakeTime =
+  const burningBlockedByMinStakeTime = Boolean(
     activePreset !== 'toTarget' &&
-    burnAmountForCalculations &&
-    dateAllowedToBurn &&
-    dateAllowedToBurn > new Date();
+      burnAmountForCalculations > 0 &&
+      dateAllowedToBurn &&
+      dateAllowedToBurn > new Date()
+  );
 
   return (
     <>
@@ -414,7 +415,7 @@ export const BurnUi = ({
                 t('staking-v2.delegate.missing-permission')
               ) : notEnoughBalance ? (
                 t('staking-v2.burn.balance-error')
-              ) : burningBlockedByMinStakeTime ? (
+              ) : burningBlockedByMinStakeTime && dateAllowedToBurn ? (
                 <Tooltip
                   label={`Min stake time not reached, custom burning enabled ${formatShortDateWithTime(
                     dateAllowedToBurn

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -705,7 +705,7 @@ export const Burn: FC = () => {
             }}
             onPresetClick={handlePresetClick}
             gasError={gasError}
-            dateAllowedToBurn={new Date('2023-07-08T04:24:25.846Z')}
+            dateAllowedToBurn={stakeTimeDate?.dateAllowedToBurn}
             isGasEnabledAndNotFetched={isGasEnabledAndNotFetched}
             transactionFee={transactionFee}
             onSubmit={handleSubmit}

--- a/v2/components/Burn/Burn.tsx
+++ b/v2/components/Burn/Burn.tsx
@@ -127,7 +127,12 @@ export const BurnUi = ({
     onPresetClick(badgeType);
   };
   const notEnoughBalance = burnAmountForCalculations > susdBalance;
-  const burningBlockedByMinStakeTime = dateAllowedToBurn && dateAllowedToBurn > new Date();
+
+  const burningBlockedByMinStakeTime =
+    activePreset !== 'toTarget' &&
+    burnAmountForCalculations &&
+    dateAllowedToBurn &&
+    dateAllowedToBurn > new Date();
 
   return (
     <>
@@ -410,8 +415,12 @@ export const BurnUi = ({
               ) : notEnoughBalance ? (
                 t('staking-v2.burn.balance-error')
               ) : burningBlockedByMinStakeTime ? (
-                <Tooltip label="Min stake time not reached">
-                  <span>Burning enabled {formatShortDateWithTime(dateAllowedToBurn)}</span>
+                <Tooltip
+                  label={`Min stake time not reached, custom burning enabled ${formatShortDateWithTime(
+                    dateAllowedToBurn
+                  )}`}
+                >
+                  <span>Only burn to target enabled</span>
                 </Tooltip>
               ) : (
                 `${t('staking-v2.mint.gas-estimation-error')}: ${parseTxnError(gasError)}`
@@ -696,7 +705,7 @@ export const Burn: FC = () => {
             }}
             onPresetClick={handlePresetClick}
             gasError={gasError}
-            dateAllowedToBurn={stakeTimeDate?.dateAllowedToBurn}
+            dateAllowedToBurn={new Date('2023-07-08T04:24:25.846Z')}
             isGasEnabledAndNotFetched={isGasEnabledAndNotFetched}
             transactionFee={transactionFee}
             onSubmit={handleSubmit}


### PR DESCRIPTION
We need to have burn to target enabled even when min stake time hasn't been reached.

Iniital state no error:
<img width="567" alt="image" src="https://github.com/Synthetixio/js-monorepo/assets/5688912/680ad8d6-2013-4fc5-a953-14971d9b1e59">

Error when using custom amount:
<img width="525" alt="Screenshot 2023-07-07 at 2 27 07 pm" src="https://github.com/Synthetixio/js-monorepo/assets/5688912/94a67d42-d5f2-47cf-ba07-1962ac70b7b7">

No error when burn to target is selected
<img width="541" alt="Screenshot 2023-07-07 at 2 26 51 pm" src="https://github.com/Synthetixio/js-monorepo/assets/5688912/29900b31-dccc-4ecc-a7c6-48837cf45dce">
