### PR TITLE
Open positions Table w/ Filtering

### DIFF
--- a/v2/perps-v2/ui/src/components/Header.tsx
+++ b/v2/perps-v2/ui/src/components/Header.tsx
@@ -96,13 +96,20 @@ export const Header: FC = () => {
                     </Text>
                   </RouterLink>
                 </MenuItem>
+                <MenuItem>
+                  <RouterLink to="/positions">
+                    <Text fontSize="14px" fontWeight={700} fontFamily="heading" color="gray.400">
+                      Positions
+                    </Text>
+                  </RouterLink>
+                </MenuItem>
               </MenuList>
             </Menu>
           </Flex>
         </Flex>
         <AddressInput />
       </Flex>
-      {['/', '/trades', '/actions', '/markets'].includes(location.pathname) && (
+      {['/', '/trades', '/actions', '/markets', '/positions'].includes(location.pathname) && (
         <Box px={{ base: '16px', md: '40px' }} display={{ base: 'none', md: 'flex', lg: 'flex' }}>
           <Flex as="nav" mt={16}>
             <Box style={isActive('/') ? activeStyle : inactiveStyle} pr={7} mr={16} width={120}>
@@ -123,6 +130,14 @@ export const Header: FC = () => {
               width={120}
             >
               <RouterLink to="/markets">Markets</RouterLink>
+            </Box>
+            <Box
+              style={isActive('/positions') ? activeStyle : inactiveStyle}
+              pr={7}
+              mr={16}
+              width={120}
+            >
+              <RouterLink to="/positions">Positions</RouterLink>
             </Box>
           </Flex>
         </Box>

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsFilter/OpenPositionsFilter.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsFilter/OpenPositionsFilter.tsx
@@ -1,0 +1,57 @@
+import { Stack } from '@chakra-ui/react';
+import { MarketSelect, DropdownFilter } from '../../Shared';
+import { PageFilter } from './PageFilter';
+import { useMarketSummaries } from '../../../hooks/useMarketSummaries';
+
+interface DropdownInterface {
+    value: string;
+    display: string;
+}
+
+const ORDER_BY_CATEGORIES: DropdownInterface[] = [
+    { value: 'size', display: 'Size' },
+    { value: 'unrealizedPnl', display: 'Unrealized PNL' },
+    { value: 'realizedPnl', display: 'Realized PNL' },
+];
+
+const ORDER_DIRECTIONS: DropdownInterface[] = [
+    { value: 'desc', display: 'Desc' },
+    { value: 'asc', display: 'Asc' },
+];
+
+interface OpenPositionsFilterProps {
+    route: string;
+}
+
+export const OpenPositionsFilter = ({ route }: OpenPositionsFilterProps) => {
+    const markets = useMarketSummaries();
+    return (
+
+        <Stack
+            direction={{ base: 'column', md: 'row' }}
+            spacing={{ base: 5, md: 10 }}
+            width={'100%'}
+        >
+
+            <MarketSelect markets={markets.data?.map((x) => x.asset)} route={'positions'} />
+
+            <DropdownFilter
+                route={route}
+                options={ORDER_BY_CATEGORIES}
+                queryParam="orderby"
+                label="Order By"
+            />
+
+            <DropdownFilter
+                route={route}
+                options={ORDER_DIRECTIONS}
+                queryParam="direction"
+                label="Sort Order"
+            />
+
+            <PageFilter route={route} />
+
+        </Stack>
+
+    );
+};

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsFilter/PageFilter.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsFilter/PageFilter.tsx
@@ -1,0 +1,46 @@
+import { AddIcon, MinusIcon } from '@chakra-ui/icons';
+import { Text, IconButton, Center, Stack } from '@chakra-ui/react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+interface PageFilterProps {
+    route: string;
+}
+
+export const PageFilter = ({ route }: PageFilterProps) => {
+    const [searchParams] = useSearchParams();
+    const page = Number(searchParams.get('page')) || 1;
+    const navigate = useNavigate();
+
+    const updatePage = (newPage: number) => {
+        const newParams = new URLSearchParams(searchParams.toString());
+        newParams.set('page', newPage.toString());
+        navigate({
+            pathname: `/${route}`,
+            search: `?${newParams.toString()}`,
+        });
+    };
+
+    return (
+        <>
+            <Stack direction='row' spacing='4' p='1'>
+                <IconButton
+                    variant='outline'
+                    aria-label='minus page'
+                    size='sm'
+                    icon={<MinusIcon />}
+                    onClick={() => updatePage(page - 1)}
+                />
+                <Center>
+                    <Text fontSize='lg'>{page}</Text>
+                </Center>
+                <IconButton
+                    variant='outline'
+                    aria-label='add page'
+                    size='sm'
+                    onClick={() => updatePage(page + 1)}
+                    icon={<AddIcon />}
+                />
+            </Stack>
+        </>
+    );
+};

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsFilter/index.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsFilter/index.tsx
@@ -1,0 +1,1 @@
+export * from './OpenPositionsFilter'

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsLoading.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsLoading.tsx
@@ -1,0 +1,60 @@
+import { SkeletonCircle, Skeleton, Td, Tr, Box, Flex } from '@chakra-ui/react';
+
+// A loading skeleton with dummy values
+export const OpenPositionsLoading = () => {
+  return (
+    <Tr borderTopWidth="1px">
+      <Flex as={Td} border="none" alignItems="center">
+        <SkeletonCircle mr={4} startColor="gray.700" endColor="gray.900" />
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Flex>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+      <Box as={Td} border="none">
+        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
+          Lorem Ipsum
+        </Skeleton>
+      </Box>
+    </Tr>
+  );
+};

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsLoading.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsLoading.tsx
@@ -40,21 +40,6 @@ export const OpenPositionsLoading = () => {
           Lorem Ipsum
         </Skeleton>
       </Box>
-      <Box as={Td} border="none">
-        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
-          Lorem Ipsum
-        </Skeleton>
-      </Box>
-      <Box as={Td} border="none">
-        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
-          Lorem Ipsum
-        </Skeleton>
-      </Box>
-      <Box as={Td} border="none">
-        <Skeleton startColor="gray.700" endColor="gray.900" my={2}>
-          Lorem Ipsum
-        </Skeleton>
-      </Box>
     </Tr>
   );
 };

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsTable.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsTable.tsx
@@ -2,44 +2,14 @@ import { TableContainer, Table, Thead, Tr, Tbody, Flex, Text } from '@chakra-ui/
 import { useSearchParams } from 'react-router-dom';
 import { TableHeaderCell, PnL, Market, Size, MarkPrice, PercentageChange, WalletTooltip } from '../Shared';
 import { OpenPositionsLoading } from './OpenPositionsLoading';
-import { usePositions } from '../../hooks';
-import { useMarketSummaries } from '../../hooks/useMarketSummaries';
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { PositionsLoading } from '../Positions/PositionsLoading';
+import { usePositions, PositionType } from '../../hooks';
+import { useState, useEffect, useMemo } from 'react';
 
 export const OpenPositionsTable = () => {
 
-  /*
-  const [previousParams, setPreviousParams] = useState(null);
-  const [showLoading, setShowLoading] = useState(true);
-
-  const isInitialRender = useRef(true);
-  const [searchParams] = useSearchParams();
-  const currentParams = useMemo(() => searchParams.toString(), [searchParams]);
-
-  const { data, error, loading } = usePositions();
-  const noData = !data?.length;
-
-
-  useEffect(() => {
-    if (isInitialRender.current) {
-      isInitialRender.current = false;
-    } else if (previousParams !== currentParams) {
-      setShowLoading(true);
-    }
-    // Update previousParams for the next render
-    setPreviousParams(currentParams);
-  }, [currentParams, previousParams]);
-
-  useEffect(() => {
-    if (data) {
-      // Data has loaded, hide loading
-      setShowLoading(false);
-    }
-  }, [data]);
-  */
-
-  const [storedParams, setStoredParams] = useState(null);
-  const [showLoading, setShowLoading] = useState(true);
+  const [storedParams, setStoredParams] = useState<string>('');
+  const [showLoading, setShowLoading] = useState<boolean>(true);
 
   const [searchParams] = useSearchParams();
   const currentParams = useMemo(() => searchParams.toString(), [searchParams]);
@@ -47,16 +17,16 @@ export const OpenPositionsTable = () => {
   const { data, error, loading } = usePositions();
   const noData = !data?.length;
 
+  // we are loading lots of data, only show loading component on inital render or when params have changed
   useEffect(() => {
     if (storedParams !== currentParams) {
       setShowLoading(true);
-      setStoredParams(currentParams);  // Update storedParams if they have changed
+      setStoredParams(currentParams);
     }
   }, [currentParams, storedParams]);
 
   useEffect(() => {
     if (data) {
-      // Data has loaded, hide loading
       setShowLoading(false);
     }
   }, [data]);
@@ -82,8 +52,8 @@ export const OpenPositionsTable = () => {
                 <TableHeaderCell>Mark Price</TableHeaderCell>
                 <TableHeaderCell>Size</TableHeaderCell>
                 <TableHeaderCell>Unrealized PNL</TableHeaderCell>
-                <TableHeaderCell>Realized PNL</TableHeaderCell>
                 <TableHeaderCell>ROI</TableHeaderCell>
+                <TableHeaderCell>Realized PNL</TableHeaderCell>
                 <TableHeaderCell>Address</TableHeaderCell>
 
               </Tr>
@@ -100,22 +70,17 @@ export const OpenPositionsTable = () => {
                 (
                   {
                     asset,
-                    avgEntryPrice,
                     indexPrice,
                     leverage,
                     unrealizedPnl,
                     realizedPnl,
-                    remainingMargin,
                     size,
                     long,
                     address,
-                    funding,
-                    liquidationPrice,
                     marketPrice,
-                    fees,
                     unrealizedPnlPercentage,
-                  },
-                  index
+                  }: PositionType,
+                  index: number
                 ) => {
                   return (
                     <Tr key={address?.concat(index.toString())} borderTopWidth="1px">
@@ -131,17 +96,17 @@ export const OpenPositionsTable = () => {
                         markPrice={marketPrice.toNumber()}
                       />
                       <Size size={size.toNumber()} marketPrice={marketPrice.toNumber()} />
-
+                        {/* PNL */}
                       <PnL
                         pnl={unrealizedPnl.toNumber()}
                         pnlPercentage={unrealizedPnlPercentage.toNumber()} //
                       />
-                      <PnL pnl={realizedPnl.toNumber()} />
-
+                      {/* Unrealized ROI */}
                       <PercentageChange amount={unrealizedPnlPercentage.toNumber()} />
-
+                      {/* Realized PNL */}
+                      <PnL pnl={realizedPnl.toNumber()} />
+                      {/* Address */}
                       <WalletTooltip address={address} />
-
                     </Tr>
                   );
                 }

--- a/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsTable.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/OpenPositionsTable.tsx
@@ -1,0 +1,172 @@
+import { TableContainer, Table, Thead, Tr, Tbody, Flex, Text } from '@chakra-ui/react';
+import { useSearchParams } from 'react-router-dom';
+import { TableHeaderCell, PnL, Market, Size, MarkPrice, PercentageChange, WalletTooltip } from '../Shared';
+import { OpenPositionsLoading } from './OpenPositionsLoading';
+import { usePositions } from '../../hooks';
+import { useMarketSummaries } from '../../hooks/useMarketSummaries';
+import { useState, useEffect, useMemo, useRef } from 'react';
+
+export const OpenPositionsTable = () => {
+
+  /*
+  const [previousParams, setPreviousParams] = useState(null);
+  const [showLoading, setShowLoading] = useState(true);
+
+  const isInitialRender = useRef(true);
+  const [searchParams] = useSearchParams();
+  const currentParams = useMemo(() => searchParams.toString(), [searchParams]);
+
+  const { data, error, loading } = usePositions();
+  const noData = !data?.length;
+
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+    } else if (previousParams !== currentParams) {
+      setShowLoading(true);
+    }
+    // Update previousParams for the next render
+    setPreviousParams(currentParams);
+  }, [currentParams, previousParams]);
+
+  useEffect(() => {
+    if (data) {
+      // Data has loaded, hide loading
+      setShowLoading(false);
+    }
+  }, [data]);
+  */
+
+  const [storedParams, setStoredParams] = useState(null);
+  const [showLoading, setShowLoading] = useState(true);
+
+  const [searchParams] = useSearchParams();
+  const currentParams = useMemo(() => searchParams.toString(), [searchParams]);
+
+  const { data, error, loading } = usePositions();
+  const noData = !data?.length;
+
+  useEffect(() => {
+    if (storedParams !== currentParams) {
+      setShowLoading(true);
+      setStoredParams(currentParams);  // Update storedParams if they have changed
+    }
+  }, [currentParams, storedParams]);
+
+  useEffect(() => {
+    if (data) {
+      // Data has loaded, hide loading
+      setShowLoading(false);
+    }
+  }, [data]);
+
+  return (
+    <>
+      <TableContainer
+        maxW="100%"
+        my={5}
+        borderColor="gray.900"
+        borderWidth="1px"
+        borderRadius="5px"
+        sx={{
+          borderCollapse: 'separate !important',
+          borderSpacing: 0,
+        }}
+      >
+        <>
+          <Table bg="navy.700">
+            <Thead>
+              <Tr>
+                <TableHeaderCell>Market</TableHeaderCell>
+                <TableHeaderCell>Mark Price</TableHeaderCell>
+                <TableHeaderCell>Size</TableHeaderCell>
+                <TableHeaderCell>Unrealized PNL</TableHeaderCell>
+                <TableHeaderCell>Realized PNL</TableHeaderCell>
+                <TableHeaderCell>ROI</TableHeaderCell>
+                <TableHeaderCell>Address</TableHeaderCell>
+
+              </Tr>
+            </Thead>
+            <Tbody>
+              {showLoading && (
+                <>
+                  <OpenPositionsLoading />
+                  <OpenPositionsLoading />
+                  <OpenPositionsLoading />
+                </>
+              )}
+              {data?.map(
+                (
+                  {
+                    asset,
+                    avgEntryPrice,
+                    indexPrice,
+                    leverage,
+                    unrealizedPnl,
+                    realizedPnl,
+                    remainingMargin,
+                    size,
+                    long,
+                    address,
+                    funding,
+                    liquidationPrice,
+                    marketPrice,
+                    fees,
+                    unrealizedPnlPercentage,
+                  },
+                  index
+                ) => {
+                  return (
+                    <Tr key={address?.concat(index.toString())} borderTopWidth="1px">
+                      {/* Market and Direction */}
+                      <Market
+                        asset={asset}
+                        leverage={leverage.toNumber()}
+                        direction={long ? 'LONG' : 'SHORT'}
+                      />
+                      {/* Mark Price */}
+                      <MarkPrice
+                        indexPrice={indexPrice.toNumber()}
+                        markPrice={marketPrice.toNumber()}
+                      />
+                      <Size size={size.toNumber()} marketPrice={marketPrice.toNumber()} />
+
+                      <PnL
+                        pnl={unrealizedPnl.toNumber()}
+                        pnlPercentage={unrealizedPnlPercentage.toNumber()} //
+                      />
+                      <PnL pnl={realizedPnl.toNumber()} />
+
+                      <PercentageChange amount={unrealizedPnlPercentage.toNumber()} />
+
+                      <WalletTooltip address={address} />
+
+                    </Tr>
+                  );
+                }
+              )}
+            </Tbody>
+          </Table>
+
+          {!loading && !error && noData && (
+            <Flex width="100%" justifyContent="center" bg="navy.700" borderTopWidth="1px">
+              <Text fontFamily="inter" fontWeight="500" fontSize="14px" color="gray.500" m={6}>
+                No open positions
+              </Text>
+            </Flex>
+          )}
+
+          {error && noData && !loading && (
+            <Flex width="100%" justifyContent="center" bg="navy.700" borderTopWidth="1px">
+              <Text fontFamily="inter" fontWeight="500" fontSize="14px" color="gray.500" m={6}>
+                We&apos;re having problem loading the position data
+              </Text>
+            </Flex>
+          )}
+
+        </>
+      </TableContainer>
+    </>
+  );
+};

--- a/v2/perps-v2/ui/src/components/OpenPositions/index.tsx
+++ b/v2/perps-v2/ui/src/components/OpenPositions/index.tsx
@@ -1,0 +1,1 @@
+export * from './OpenPositionsTable';

--- a/v2/perps-v2/ui/src/components/Shared/DropdownFilter/DropdownCheckbox.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/DropdownFilter/DropdownCheckbox.tsx
@@ -1,0 +1,72 @@
+import { Text, Flex, useCheckbox, UseCheckboxProps, chakra } from '@chakra-ui/react';
+import { Tick } from '../../Icons';
+
+interface CheckboxProps extends UseCheckboxProps {
+  label: string;
+  icon?: JSX.Element;
+}
+
+export const DropdownCheckbox = ({ label, icon, ...props }: CheckboxProps) => {
+  const { 
+    state, 
+    getCheckboxProps, 
+    getInputProps, 
+    getLabelProps, 
+    htmlProps,
+  } = useCheckbox(props);
+
+  return (
+    <chakra.label
+      display="flex"
+      flexDirection="row"
+      alignItems="center"
+      gridColumnGap={2}
+      px={3}
+      py={1}
+      my={1}
+      cursor="pointer"
+      {...htmlProps}
+    >
+      <input {...getInputProps()} hidden />
+      <Flex justifyContent="space-between" width="100%" alignItems="center">
+        <Flex alignItems="center">
+          {icon}
+          <Text
+            ml={icon ? 2 : 0}
+            color="whiteAlpha.900"
+            fontFamily="heading"
+            fontSize="16px"
+            lineHeight="24px"
+            {...getLabelProps()}
+          >
+            {label}
+          </Text>
+        </Flex>
+        <Flex alignItems="center" justifyContent="center" w={4} h={4} {...getCheckboxProps()}>
+          {state.isChecked ? (
+            <Flex
+              borderRadius="sm"
+              w="100%"
+              height="100%"
+              justifyContent="center"
+              alignItems="center"
+              bg="cyan.500"
+            >
+              <Tick color="black" />
+            </Flex>
+          ) : (
+            <Flex
+              border="1px"
+              borderColor="gray.900"
+              w="100%"
+              height="100%"
+              justifyContent="center"
+              alignItems="center"
+              borderRadius="sm"
+            />
+          )}
+        </Flex>
+      </Flex>
+    </chakra.label>
+  );
+};

--- a/v2/perps-v2/ui/src/components/Shared/DropdownFilter/DropdownFilter.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/DropdownFilter/DropdownFilter.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { ChevronDownIcon } from '@chakra-ui/icons';
+import { Button, Menu, MenuButton, MenuList, Flex } from '@chakra-ui/react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { DropdownCheckbox } from './DropdownCheckbox';
+
+interface DropdownOption {
+    value: string;
+    display: string;
+}
+
+interface DropdownProps {
+    route: string;
+    options: DropdownOption[];
+    queryParam: string;
+    label: string;
+}
+
+export const DropdownFilter = ({ route, options, queryParam, label }: DropdownProps) => {
+    const [searchParams] = useSearchParams();
+    const initialOptionValue = searchParams.get(queryParam) || options[0].value;
+
+    const [activeOptionValue, setActiveOptionValue] = useState<string>(initialOptionValue);
+
+    const navigate = useNavigate();
+
+    const onClick = (optionValue: string) => {
+        const newParams = new URLSearchParams(searchParams.toString());
+        newParams.set(queryParam, optionValue);
+        newParams.set('page', '1');
+        navigate({
+            pathname: `/${route}`,
+            search: `?${newParams.toString()}`,
+        });
+        setActiveOptionValue(optionValue);
+    };
+
+    return (
+        <Menu>
+            <MenuButton
+                color="gray.500"
+                fontSize="16px"
+                lineHeight="24px"
+                fontWeight={400}
+                width="225px"
+                _hover={{ background: 'none' }}
+                _active={{ background: 'none' }}
+                textAlign="start"
+                bg="none"
+                borderWidth="1px"
+                borderColor="gray.900"
+                as={Button}
+                rightIcon={<ChevronDownIcon />}
+            >
+                {label}: {
+                    options.find((option) => option.value === activeOptionValue)?.display
+                }
+            </MenuButton>
+            <MenuList>
+                <Flex
+                    bg="navy.900"
+                    p={1}
+                    borderColor="gray.900"
+                    borderWidth="1px"
+                    borderRadius="md"
+                    flexDirection="column"
+                >
+                    {
+                        options.map((option) => (
+                            <DropdownCheckbox
+                                key={option.value}
+                                label={option.display}
+                                onChange={() => onClick(option.value)}
+                                isChecked={activeOptionValue === option.value}
+                            />
+                        ))
+                    }
+                </Flex>
+            </MenuList>
+        </Menu>
+    );
+};

--- a/v2/perps-v2/ui/src/components/Shared/DropdownFilter/index.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/DropdownFilter/index.tsx
@@ -1,0 +1,1 @@
+export * from './DropdownFilter';

--- a/v2/perps-v2/ui/src/components/Shared/MarketSelect/MarketSelect.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/MarketSelect/MarketSelect.tsx
@@ -7,9 +7,10 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 interface MarketSelectProps {
   markets?: string[];
+  route: string;
 }
 
-export const MarketSelect = ({ markets }: MarketSelectProps) => {
+export const MarketSelect = ({ markets, route }: MarketSelectProps) => {
   const [searchParams] = useSearchParams();
   const initialState = searchParams.get('markets')?.split(',') || [];
 
@@ -18,33 +19,22 @@ export const MarketSelect = ({ markets }: MarketSelectProps) => {
   const navigate = useNavigate();
 
   const onClick = (markets: string) => {
+
+    const newParams = new URLSearchParams(searchParams.toString());
+
     if (markets.length !== 0) {
-      const params: string[][] = [];
-      const min = searchParams.get('min') || '';
-      const max = searchParams.get('max') || '';
-
-      if (min !== '') {
-        params.push(['min', min]);
-      }
-
-      if (max !== '') {
-        params.push(['max', max]);
-      }
-
-      if (markets !== '') {
-        params.push(['markets', markets]);
-      }
-
-      const newParams = new URLSearchParams(params);
-
-      navigate({
-        pathname: `/actions`,
-        search: `?${newParams.toString()}`,
-      });
+        newParams.set('markets', markets);
     } else {
-      navigate(`/actions`);
+        newParams.delete('markets');
     }
-  };
+
+    newParams.delete('page');
+
+    navigate({
+        pathname: `/${route}`,
+        search: `?${newParams.toString()}`,
+    });
+};
 
   return (
     <Menu>
@@ -53,7 +43,8 @@ export const MarketSelect = ({ markets }: MarketSelectProps) => {
         fontSize="16px"
         lineHeight="24px"
         fontWeight={400}
-        width="25%"
+        width={{ base: '225px', md: '25%' }}
+        minWidth="225px"
         _hover={{
           background: 'none',
         }}

--- a/v2/perps-v2/ui/src/components/Shared/index.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/index.tsx
@@ -19,3 +19,4 @@ export * from './SmartWallet';
 export * from './MarketSelect';
 export * from './SizeSelect';
 export * from './DailyVolumeChange';
+export * from './DropdownFilter';

--- a/v2/perps-v2/ui/src/components/index.tsx
+++ b/v2/perps-v2/ui/src/components/index.tsx
@@ -5,3 +5,4 @@ export * from './PerpsStats';
 export * from './Positions';
 export * from './Shared';
 export * from './ExternalLink';
+export * from './OpenPositions';

--- a/v2/perps-v2/ui/src/hooks/useActions.ts
+++ b/v2/perps-v2/ui/src/hooks/useActions.ts
@@ -122,7 +122,7 @@ const mergeData = (
   return data.sort((a, b) => b.timestamp.toNumber() - a.timestamp.toNumber());
 };
 
-function generateMarketIds(
+export function generateMarketIds(
   marketSummaries: { asset: string; address: string }[],
   markets: string | null
 ): string[] | undefined {

--- a/v2/perps-v2/ui/src/hooks/usePositions.ts
+++ b/v2/perps-v2/ui/src/hooks/usePositions.ts
@@ -48,7 +48,7 @@ const Multicall3Contract = new Contract(
   provider
 ) as Multicall3;
 
-interface PositionType {
+export interface PositionType {
   accountType: string;
   address: string;
   asset: string;

--- a/v2/perps-v2/ui/src/index.tsx
+++ b/v2/perps-v2/ui/src/index.tsx
@@ -11,7 +11,7 @@ import {
   PERPS_V2_DASHBOARD_GRAPH_GOERLI_URL,
 } from './utils/constants';
 import { resolvers, typeDefs } from './queries/resolved';
-import { Dashboard, Actions, Markets } from './pages';
+import { Dashboard, Actions, Markets, Positions } from './pages';
 import { isStaging } from './utils/isStaging';
 
 const client = new ApolloClient({
@@ -55,6 +55,15 @@ const router = createBrowserRouter([
       <>
         <Header />
         <Markets />
+      </>
+    ),
+  },
+  {
+    path: '/positions',
+    element: (
+      <>
+        <Header />
+        <Positions />
       </>
     ),
   },

--- a/v2/perps-v2/ui/src/pages/Actions.tsx
+++ b/v2/perps-v2/ui/src/pages/Actions.tsx
@@ -13,7 +13,7 @@ export function Actions() {
           Actions
         </Heading>
         <Flex>
-          <MarketSelect markets={markets.data?.map((x) => x.asset)} />
+          <MarketSelect markets={markets.data?.map((x) => x.asset)} route='actions' />
           <SizeSelect />
         </Flex>
         <AllActionsTable />

--- a/v2/perps-v2/ui/src/pages/Positions.tsx
+++ b/v2/perps-v2/ui/src/pages/Positions.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Flex, Heading } from '@chakra-ui/react';
+import { OpenPositionsTable } from '../components/OpenPositions';
+import { OpenPositionsFilter } from '../components/OpenPositions/OpenPositionsFilter';
+
+export function Positions() {
+  return (
+    <>
+      <Flex flexDir="column" px={{ base: '16px', md: '40px' }} py={2}>
+        <Heading fontSize="24px" my={2} mt={12}>
+          Open Positions
+        </Heading>
+        <Flex>
+          <OpenPositionsFilter route='positions' />
+        </Flex>
+        <OpenPositionsTable />
+      </Flex>
+    </>
+  );
+}
+
+export default Positions;

--- a/v2/perps-v2/ui/src/pages/index.tsx
+++ b/v2/perps-v2/ui/src/pages/index.tsx
@@ -2,3 +2,4 @@ export * from './Account';
 export * from './Dashboard';
 export * from './Actions';
 export * from './Markets';
+export * from './Positions';

--- a/v2/perps-v2/ui/src/queries/resolved.ts
+++ b/v2/perps-v2/ui/src/queries/resolved.ts
@@ -34,7 +34,7 @@ interface PositionData {
 // TODO: Figure out return type
 export const typeDefs = gql(`
   extend type Query {
-    positionsFromContract(penPositions: PositionsMarketQuery): String!
+    positionsFromContract(openPositions: PositionsMarketQuery): String!
   }
 `);
 
@@ -48,7 +48,7 @@ export const resolvers: Resolvers | Resolvers[] = {
       _contextValue,
       _info
     ): Promise<PositionData[]> => {
-      const positionsData = await fetchPositions(openPositions || '');
+      const positionsData = await fetchPositions(openPositions);
       const offchainPrices: { asset: string; price: Wei }[] = [];
       const pythConfigByMarketKey = await getMarketsPythConfig();
       await Promise.all(

--- a/v2/perps-v2/ui/src/queries/resolved.ts
+++ b/v2/perps-v2/ui/src/queries/resolved.ts
@@ -7,15 +7,34 @@ import { notNill } from '../utils/notNil';
 import { scale, calculatePositionData, getMarketsPythConfig } from '../utils';
 
 export const POSITIONS_CONTRACT_QUERY = gql(`
-  query ($walletAddress: String!, $openPositions: PositionsMarketQuery) {
-    positionsFromContract(walletAddress: $walletAddress, openPositions: $openPositions) @client
+  query ($openPositions: PositionsMarketQuery) {
+    positionsFromContract(openPositions: $openPositions) @client
   }
 `);
+
+interface PositionData {
+  asset: string;
+  indexPrice: Wei;
+  liquidationPrice: Wei;
+  unrealizedPnl: Wei;
+  realizedPnl: Wei;
+  unrealizedPnlPercentage: Wei;
+  remainingMargin: Wei;
+  size: Wei;
+  long: boolean;
+  avgEntryPrice: Wei;
+  leverage: Wei;
+  funding: Wei;
+  marketPrice: Wei;
+  notionalValue: Wei;
+  fees: Wei;
+  address: string;
+}
 
 // TODO: Figure out return type
 export const typeDefs = gql(`
   extend type Query {
-    positionsFromContract(walletAddress: String!, openPositions: PositionsMarketQuery): String!
+    positionsFromContract(penPositions: PositionsMarketQuery): String!
   }
 `);
 
@@ -25,11 +44,11 @@ export const resolvers: Resolvers | Resolvers[] = {
   Query: {
     positionsFromContract: async (
       _parent,
-      { walletAddress, openPositions },
+      { openPositions },
       _contextValue,
       _info
-    ) => {
-      const positionsData = await fetchPositions(openPositions, walletAddress || '');
+    ): Promise<PositionData[]> => {
+      const positionsData = await fetchPositions(openPositions || '');
       const offchainPrices: { asset: string; price: Wei }[] = [];
       const pythConfigByMarketKey = await getMarketsPythConfig();
       await Promise.all(
@@ -56,8 +75,7 @@ export const resolvers: Resolvers | Resolvers[] = {
           const calculatedPositionData = calculatePositionData(
             subgraphData,
             pythPrice?.price,
-            contractData,
-            walletAddress
+            contractData
           );
 
           return calculatedPositionData;

--- a/v2/perps-v2/ui/src/types/index.ts
+++ b/v2/perps-v2/ui/src/types/index.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export interface SubgraphPositionData {
   market: string;
   asset: string;
+  walletAddress: string;
   avgEntryPrice: Wei;
   leverage: Wei;
   fees: Wei;

--- a/v2/perps-v2/ui/src/utils/calculations.ts
+++ b/v2/perps-v2/ui/src/utils/calculations.ts
@@ -54,8 +54,7 @@ export const calculatePnlPercentage = (
 export const calculatePositionData = (
   subgraphPositionData: SubgraphPositionData,
   pythPrice: Wei | undefined,
-  contractData: ContractData,
-  address?: string
+  contractData: ContractData
 ) => {
   if (contractData.size.eq(0)) return null;
   const marketPrice = calculateMarkPrice(pythPrice, contractData);
@@ -91,7 +90,7 @@ export const calculatePositionData = (
     marketPrice,
     notionalValue: notionalValue,
     fees: subgraphPositionData.fees,
-    address,
+    address: subgraphPositionData.walletAddress,
   };
 };
 


### PR DESCRIPTION
grants council task: "open position leaderboard (real time updates) for largest/smallest: pnl/size, asset filter"


Adds a `Positions` route and page, that renders a table of the top open positions, with options for sorting and filtering the Open Positions by 'Size', 'Unrealized PNL', and 'Realized PNL'. Also handles pagination.

![image](https://github.com/Synthetixio/js-monorepo/assets/100385397/11ae4688-a6e1-474a-9e7d-bc18b1b0b274)

Updated the `usePositions` hook to be able to fetch all open positions, and filter/sort/paginate those positions based on url parameters. The hook now can handle fetching all open positions in addition to fetching the open positions for a single address.

Created a Shared Component for Dropdowns, that is being used for the `OrderBy` and `OrderDirection` components. 

Updated the `MarketSelect` component to accept a `route` prop, so that it can be used on different pages and accurately update the URL params. Also updated the handling on URL params to make them dynamic. 

Created OpenPositions components, based off existing Positions components, to allow users to filter open positions.

