### PR TITLE
Fix migrate react-query v4

### DIFF
--- a/v2/perps-v2/ui/src/index.tsx
+++ b/v2/perps-v2/ui/src/index.tsx
@@ -27,7 +27,7 @@ const client = new ApolloClient({
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      notifyOnChangeProps: 'tracked',
+      notifyOnChangeProps: 'all',
       refetchInterval: DEFAULT_REQUEST_REFRESH_INTERVAL,
       refetchOnWindowFocus: false,
     },


### PR DESCRIPTION
@jmzwar @bachstatter Hotfix migrate react-query v3 to @tanstack/react-query v4

![Screen Shot 2023-10-24 at 18 12 58](https://github.com/Synthetixio/js-monorepo/assets/109568199/33720839-3fd9-41f7-8beb-a4e6eca36b15)
