### PR TITLE
Add position side at Liquidations page

### DIFF
--- a/v2/perps-v2/ui/src/components/Liquidations/LiquidationsTable.tsx
+++ b/v2/perps-v2/ui/src/components/Liquidations/LiquidationsTable.tsx
@@ -10,7 +10,6 @@ import {
 } from '../Shared';
 import { useLiquidations } from '../../hooks';
 import { LiquidationsLoading } from './LiquidationsLoading';
-import { Action } from '../Shared/Action';
 
 export const LiquidationsTable = () => {
   const { loading, data, error } = useLiquidations();
@@ -31,7 +30,6 @@ export const LiquidationsTable = () => {
         <Table bg="navy.700">
           <Thead>
             <Tr>
-              <TableHeaderCell>Action</TableHeaderCell>
               <TableHeaderCell>Market</TableHeaderCell>
               <TableHeaderCell>Age</TableHeaderCell>
               <TableHeaderCell>Price</TableHeaderCell>
@@ -67,15 +65,11 @@ export const LiquidationsTable = () => {
               }) => {
                 return (
                   <Tr key={liquidationId} borderTopWidth="1px">
-                    <Action
-                      label={long ? 'LONG' : 'SHORT'}
-                      txHash={txHash}
-                      sx={{ color: long ? 'green.500' : 'red.500' }}
-                    />
                     <Market
                       asset={asset}
                       leverage={leverage?.toNumber() || null}
-                      isPosition={false}
+                      direction={long ? 'LONG' : 'SHORT'}
+                      txHash={txHash}
                     />
                     <Age timestamp={timestamp} />
                     <Currency amount={price?.toNumber() || null} />

--- a/v2/perps-v2/ui/src/components/Liquidations/LiquidationsTable.tsx
+++ b/v2/perps-v2/ui/src/components/Liquidations/LiquidationsTable.tsx
@@ -10,6 +10,7 @@ import {
 } from '../Shared';
 import { useLiquidations } from '../../hooks';
 import { LiquidationsLoading } from './LiquidationsLoading';
+import { Action } from '../Shared/Action';
 
 export const LiquidationsTable = () => {
   const { loading, data, error } = useLiquidations();
@@ -30,6 +31,7 @@ export const LiquidationsTable = () => {
         <Table bg="navy.700">
           <Thead>
             <Tr>
+              <TableHeaderCell>Action</TableHeaderCell>
               <TableHeaderCell>Market</TableHeaderCell>
               <TableHeaderCell>Age</TableHeaderCell>
               <TableHeaderCell>Price</TableHeaderCell>
@@ -42,7 +44,6 @@ export const LiquidationsTable = () => {
           <Tbody>
             {loading && (
               <>
-                <LiquidationsLoading />
                 <LiquidationsLoading />
                 <LiquidationsLoading />
                 <LiquidationsLoading />
@@ -61,9 +62,16 @@ export const LiquidationsTable = () => {
                 trader: { id },
                 fee,
                 futuresPosition: { leverage },
+                txHash,
+                long,
               }) => {
                 return (
                   <Tr key={liquidationId} borderTopWidth="1px">
+                    <Action
+                      label={long ? 'LONG' : 'SHORT'}
+                      txHash={txHash}
+                      sx={{ color: long ? 'green.500' : 'red.500' }}
+                    />
                     <Market
                       asset={asset}
                       leverage={leverage?.toNumber() || null}

--- a/v2/perps-v2/ui/src/components/Shared/Action/Action.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/Action/Action.tsx
@@ -1,4 +1,4 @@
-import { Button, Fade, Link, Td, Text, Tooltip } from '@chakra-ui/react';
+import {Button, Fade, Link, SystemStyleObject, Td, Text, Tooltip} from '@chakra-ui/react';
 import { formatDistance } from 'date-fns';
 import { optimisticEthercanTx } from '../../../utils';
 import { RightUpIcon } from '../../Icons';
@@ -6,11 +6,12 @@ import { RightUpIcon } from '../../Icons';
 interface ActionProps {
   label: string;
   txHash: string;
-  timestamp: number;
+  timestamp?: number;
+  sx?: SystemStyleObject
 }
 
-export const Action = ({ label, txHash, timestamp }: ActionProps) => {
-  const date = new Date(timestamp * 1000);
+export const Action = ({ label, txHash, timestamp, sx }: ActionProps) => {
+  const date = timestamp? new Date(timestamp * 1000) : undefined;
   return (
     <Td border="none" fontSize="14px" lineHeight="20px" fontFamily="heading" fontWeight={500}>
       <Fade in>
@@ -24,24 +25,25 @@ export const Action = ({ label, txHash, timestamp }: ActionProps) => {
           fontFamily="inter"
           fontWeight="500"
           fontSize="14px"
+          sx={{...sx}}
         >
           {label}
           <RightUpIcon ml={1} mb={0.5} />
         </Button>
-        <Text color="gray.500" fontSize="12px" lineHeight="16px">
+        {date && <Text color="gray.500" fontSize="12px" lineHeight="16px">
           <Tooltip
-            py={2}
-            px={4}
-            bg="gray.900"
-            color="gray.500"
-            fontSize="12px"
-            fontFamily="heading"
-            borderRadius="4px"
-            label={date.toISOString()}
+              py={2}
+              px={4}
+              bg="gray.900"
+              color="gray.500"
+              fontSize="12px"
+              fontFamily="heading"
+              borderRadius="4px"
+              label={date.toISOString()}
           >
             {formatDate(date)}
           </Tooltip>
-        </Text>
+        </Text>}
       </Fade>
     </Td>
   );

--- a/v2/perps-v2/ui/src/components/Shared/Action/Action.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/Action/Action.tsx
@@ -1,4 +1,4 @@
-import {Button, Fade, Link, SystemStyleObject, Td, Text, Tooltip} from '@chakra-ui/react';
+import { Button, Fade, Link, SystemStyleObject, Td, Text, Tooltip } from '@chakra-ui/react';
 import { formatDistance } from 'date-fns';
 import { optimisticEthercanTx } from '../../../utils';
 import { RightUpIcon } from '../../Icons';
@@ -7,11 +7,11 @@ interface ActionProps {
   label: string;
   txHash: string;
   timestamp?: number;
-  sx?: SystemStyleObject
+  sx?: SystemStyleObject;
 }
 
 export const Action = ({ label, txHash, timestamp, sx }: ActionProps) => {
-  const date = timestamp? new Date(timestamp * 1000) : undefined;
+  const date = timestamp ? new Date(timestamp * 1000) : undefined;
   return (
     <Td border="none" fontSize="14px" lineHeight="20px" fontFamily="heading" fontWeight={500}>
       <Fade in>
@@ -25,13 +25,14 @@ export const Action = ({ label, txHash, timestamp, sx }: ActionProps) => {
           fontFamily="inter"
           fontWeight="500"
           fontSize="14px"
-          sx={{...sx}}
+          sx={{ ...sx }}
         >
           {label}
           <RightUpIcon ml={1} mb={0.5} />
         </Button>
-        {date && <Text color="gray.500" fontSize="12px" lineHeight="16px">
-          <Tooltip
+        {date && (
+          <Text color="gray.500" fontSize="12px" lineHeight="16px">
+            <Tooltip
               py={2}
               px={4}
               bg="gray.900"
@@ -40,10 +41,11 @@ export const Action = ({ label, txHash, timestamp, sx }: ActionProps) => {
               fontFamily="heading"
               borderRadius="4px"
               label={date.toISOString()}
-          >
-            {formatDate(date)}
-          </Tooltip>
-        </Text>}
+            >
+              {formatDate(date)}
+            </Tooltip>
+          </Text>
+        )}
       </Fade>
     </Td>
   );

--- a/v2/perps-v2/ui/src/components/Shared/Market/Market.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/Market/Market.tsx
@@ -1,8 +1,9 @@
-import { Box, Fade, Flex, Td, Text } from '@chakra-ui/react';
+import { Box, Button, Fade, Flex, Link, Td, Text } from '@chakra-ui/react';
 import { formatNumber } from '@synthetixio/formatters';
 import { utils } from 'ethers';
 import { CurrencyIcon } from '../../CurrencyIcon';
-import { KwentaIcon, PolynomialIcon } from '../../Icons';
+import { KwentaIcon, PolynomialIcon, RightUpIcon } from '../../Icons';
+import { optimisticEthercanTx } from '../../../utils';
 
 interface MarketProps {
   asset: string;
@@ -10,6 +11,7 @@ interface MarketProps {
   direction?: 'LONG' | 'SHORT';
   isPosition?: boolean;
   protocol?: string;
+  txHash?: string;
 }
 
 const replace = ['sETH', 'sBTC'];
@@ -20,6 +22,7 @@ export const Market = ({
   direction,
   isPosition = true,
   protocol,
+  txHash,
 }: MarketProps) => {
   const marketName = utils.parseBytes32String(asset);
   const assetDisplayName = replace.includes(marketName) ? marketName.substring(1) : marketName;
@@ -49,12 +52,27 @@ export const Market = ({
                 color="gray.50"
               >{`${assetDisplayName.toUpperCase()}-PERP`}</Text>
               {Boolean(isPosition && direction) && (
-                <Text fontSize="12px" lineHeight="16px" fontFamily="heading" color="gray.500">
-                  {leverageString}
-                  <Text ml={1} as="span" color={isLong ? 'green.500' : 'red.500'}>
+                <Flex alignItems="center" gap={1}>
+                  {leverageString && (
+                    <Text fontSize="12px" lineHeight="16px" fontFamily="heading" color="gray.500">
+                      {leverageString}
+                    </Text>
+                  )}
+                  <Text
+                    as="span"
+                    fontSize="12px"
+                    lineHeight="16px"
+                    fontFamily="heading"
+                    color={isLong ? 'green.500' : 'red.500'}
+                  >
                     {direction}
                   </Text>
-                </Text>
+                  {txHash && (
+                    <Link href={optimisticEthercanTx(txHash)} target="_blank" rel="noopener">
+                      <RightUpIcon mb={0.5} />
+                    </Link>
+                  )}
+                </Flex>
               )}
             </Box>
           </Flex>

--- a/v2/perps-v2/ui/src/components/Shared/Market/Market.tsx
+++ b/v2/perps-v2/ui/src/components/Shared/Market/Market.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Fade, Flex, Link, Td, Text } from '@chakra-ui/react';
+import { Box, Fade, Flex, Link, Td, Text } from '@chakra-ui/react';
 import { formatNumber } from '@synthetixio/formatters';
 import { utils } from 'ethers';
 import { CurrencyIcon } from '../../CurrencyIcon';

--- a/v2/perps-v2/ui/src/hooks/useLiquidations.ts
+++ b/v2/perps-v2/ui/src/hooks/useLiquidations.ts
@@ -52,6 +52,7 @@ interface Liquidation {
     id: string;
     totalLiquidations: string;
   };
+  long: boolean;
 }
 
 function parsedLiquidationData(
@@ -78,6 +79,7 @@ function parsedLiquidationData(
       id: liquidation.trader.id,
       totalLiquidations: liquidation.trader.totalLiquidations,
     },
+    long: wei(liquidation.size, 18, true).gt(0),
   }));
 }
 


### PR DESCRIPTION
@jmzwar Can you help me review this PR?
Specs: Add which side the position was that was liquidated (long / short) + Tx Hash
https://watcher.synthetix.io/liquidations

Note:
- Size is positive for longs, negative for shorts
- Color code: longs green, shorts red

![liquidated-synthetix](https://github.com/Synthetixio/js-monorepo/assets/109568199/28b253fd-3157-4bce-a4aa-2c1002253a19)
